### PR TITLE
Default 5 Start rating is 1

### DIFF
--- a/ckanext/canada/helpers.py
+++ b/ckanext/canada/helpers.py
@@ -32,7 +32,7 @@ def openness_score(pkg):
             'xls': 2,
             'xlsm': 2,
             'XML': 3,
-            }.get(r['format'], 0))
+            }.get(r['format'], 1))
     return score
 
 


### PR DESCRIPTION
TBS has indicated that the default 5 star rating is 1 for everything in the portal, regardless of the file extension.
