### PR TITLE
Change login page to point to registration message

### DIFF
--- a/ckanext/canada/templates/internal/user/login.html
+++ b/ckanext/canada/templates/internal/user/login.html
@@ -1,5 +1,26 @@
 {% ckan_extends %}
 
+{% block secondary_content %}
+  <section class="module module-info span-2">
+    <h2 class="module-heading">{{ _('Need an Account?') }}</h2>
+    <div class="module-content">
+      <p class="action">
+        <a class="button button-info" href="{{ h.url_for(controller='ckanext.canada.controller:CanadaController', action='view_new_user') }}">{{ _('Register') }}</a>
+      </p>
+    </div>
+  </section>
+
+  <section class="module module-attention span-2">
+    <h2 class="module-heading">{{ _('Forgotten your details?') }}</h2>
+    <div class="module-content">
+      <p>{% trans %}No problem, use our password recovery form to reset it.{% endtrans %}</p>
+      <p class="action">
+        <a class="button button-attention" href="{{ h.url_for(controller='user', action='request_reset') }}">{{ _('Forgot your password?') }}</a>
+      </p>
+    </div>
+  </section>
+{% endblock %}
+
 {% block primary_content %}
   <section class="module-poster">
     <div class="module-content">


### PR DESCRIPTION
The Need an Account block on the login page now points to the registration message page.
