### PR TITLE
Remove H4 footer links to work with WET 3.1.1 mobile

### DIFF
--- a/ckanext/canada/templates/public/footer_gwcu.html
+++ b/ckanext/canada/templates/public/footer_gwcu.html
@@ -23,7 +23,7 @@
             <div class="menu-block-wrapper menu-block-wetkit_menu_blocks-2 menu-name-menu-wet-mid-footer parent-mlid-0 menu-level-1">
               <section>
                 <div class="span-2">
-                  <h4 class="gcwu-col-head"><a href="/eng/content/about-datagcca" title="About Open Government">About Open Government</a></h4>
+                  <h4 class="gcwu-col-head">About Open Government</h4>
                   <ul>
                     <li>
                       <a href="/eng/canadas-action-plan-open-government" title="Open Government Action Plan">Action Plan</a>
@@ -36,7 +36,7 @@
               </section>
               <section>
                 <div class="span-2">
-                  <h4 class="gcwu-col-head"><a href="/eng/media" title="Media">Media</a></h4>
+                  <h4 class="gcwu-col-head">Media</h4>
                   <ul>
                     <li>
                       <a href="/eng/media#toc1" title="News Releases">News Releases</a>
@@ -49,7 +49,7 @@
               </section>
               <section>
                 <div class="span-2">
-                  <h4 class="gcwu-col-head"><a href="/eng/forms/contact-us" title="Contact Us">Contact Us</a></h4>
+                  <h4 class="gcwu-col-head">Contact Us</h4>
                   <ul>
                     <li>
                       <a href="/eng/frequently-asked-questions" title="faq">Frequently Asked Questions</a>
@@ -62,7 +62,7 @@
               </section>
               <section>
                 <div class="span-2">
-                  <h4 class="gcwu-col-head"><a href="/eng/stay-connected" title="Stay connected">Stay Connected</a></h4>
+                  <h4 class="gcwu-col-head">Stay Connected</h4>
                   <ul>
                     <li>
                       <a href="https://twitter.com/TBS_Canada" title="Twitter">Twitter</a>
@@ -139,7 +139,7 @@
             <div class="menu-block-wrapper menu-block-wetkit_menu_blocks-2 menu-name-menu-wet-mid-footer parent-mlid-0 menu-level-1">
               <section>
                 <div class="span-2">
-                  <h4 class="gcwu-col-head"><a href="/fra" class="active">À propos de nous</a></h4>
+                  <h4 class="gcwu-col-head">À propos de nous</h4>
                   <ul>
                     <li>
                       <a href="/fra" class="active">Notre mandat</a>
@@ -152,7 +152,7 @@
               </section>
               <section>
                 <div class="span-2">
-                  <h4 class="gcwu-col-head"><a href="/fra" class="active">Média</a></h4>
+                  <h4 class="gcwu-col-head">Média</h4>
                   <ul>
                     <li>
                       <a href="/fra" class="active">Avis aux médias</a>
@@ -165,7 +165,7 @@
               </section>
               <section>
                 <div class="span-2">
-                  <h4 class="gcwu-col-head"><a href="/fra" class="active">Contactez-nous</a></h4>
+                  <h4 class="gcwu-col-head">Contactez-nous</h4>
                   <ul>
                     <li>
                       <a href="/fra" class="active">Numéros de téléphone</a>
@@ -178,7 +178,7 @@
               </section>
               <section>
                 <div class="span-2">
-                  <h4 class="gcwu-col-head"><a href="/fra" class="active">Restez branchés</a></h4>
+                  <h4 class="gcwu-col-head">Restez branchés</h4>
                   <ul>
                     <li>
                       <a href="https://twitter.com/SCT_Canada">Twitter</a>


### PR DESCRIPTION
This requires a patch to WET 3.1.1:

To fix the issue you need to make changes to the theme-min.js file located here:

wet-boew-dist-3.1.1-release-dist\dist\theme-gcwu-fegc\js\theme-min.js

search for:

```
 .wet-col-head
```

and replace with:

```
.gcwu-col-head
```

Also in the same file (theme-min.js) you will need to search for

```
.find("+ ul, + address ul")
```

and replace with:

```
.next("ul,address ul")
```

In addition WET3.1 changes how footer links work in mobile view so this will require that the top level h4 in the footer are not a link.
