### PR TITLE
Support auto-post of combined datasets from registry to portal

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,8 +21,8 @@ Installation:
 
 From a clean database you must run::
 
-   paster canada create-vocabularies
-   ckanapi load organizations -I transitional_orgs.jsonl
+    paster canada create-vocabularies
+    ckanapi load organizations -I transitional_orgs.jsonl
 
 Once to create the tag vocabularies and organizations this extension requires
 before loading any data.
@@ -334,7 +334,7 @@ Compiling the updated French localization strings
 Each time you install or update this extension you need to install the
 updated translations by running::
 
-   bin/build-combined-ckan-mo.sh
+    bin/build-combined-ckan-mo.sh
 
 This script overwrites the ckan French translations by combining it with
 ours.
@@ -346,7 +346,7 @@ Data.gc.ca uses the Drupal web content management system to provide much of its 
 for users to comment on and rate the data-sets found in the CKAN catalog. If using with Drupal, provide the database
 connection string for the Drupal database in the CKAN configuration file::
 
-   ckan.drupal.url =  postgresql://db_user:user_password/drupal_database
+    ckan.drupal.url =  postgresql://db_user:user_password/drupal_database
 
 If this value is not defined, then the extension will not attempt to read from the Drupal database.
 
@@ -372,3 +372,103 @@ Drupal. Run the following SQL commands to create the necessary views in the Drup
     alter view public.opendata_package_count_v owner to <db_user>;
 
 Substitute <db_user> with the appropriate SQL user account.
+
+Automating ATI and PD Dataset Promotion from Registry to Portal (Optional)
+--------------------------------------------------------------------------
+
+This section outlines the process of automating the promotion of ATI
+and PD datasets from the Registry to the Portal through the invocation
+of the ``bin/reg2portal.sh`` and ``bin/csv2solr.sh`` scripts.
+
+*The Registry*
+
+On the registry, the ``bin/reg2portal.sh`` script pushes specified
+datasets to the registry's CKAN installation. It takes the following
+parameters:
+
+  ``CKAN-INI-FILE``
+    The path to the configuration file of the CKAN registry installation
+
+  ``PORTAL-URL``
+    The URL of the CKAN public portal
+
+  ``API-KEY``
+    The API key to use in invoking the CKAN API to propagate ATI and PD
+    datasets to the portal
+
+  ``TARGET-DATASET:PACKAGE-ID ...``
+    One or more space-separated and colon-delimited mappings
+    (e.g. ``ati:00000000-0000-0000-0000-000000000000``) between target
+    datasets and their respective names or identifiers on the portal
+
+  ``VIRTUAL-ENV-HOME`` (optional)
+    If present, the root directory of the python virtual environment to
+    activate, under which the script will operate
+
+First, the execution of the script activates the virtual environment
+if specified.
+
+Then, it uses ckanext-recombinant to parse all target datasets from
+its (JSON) recombinant tables file. For each such target dataset
+mapped on the command line, the execution queries ckanext-recombinant
+for its respective dataset types (e.g.; ati-none, ati-summaries).
+The script calls ckanext-recombinant to combine CKAN content for
+each of these dataset types into a temporary .csv file for promotion.
+
+The script then calls, for each target dataset mapped on the command
+line, the ``bin\reg2portal.py`` script, specifying:
+* the CKAN configuration file
+* the URL for the portal
+* the API key
+* the mapped identifier for the target dataset
+* all paths to temporary combined .csv files germane to the target dataset
+
+The ``bin\reg2portal.py`` script invokes the CKAN API to patch the
+package by its specified identifier, clearing out existing resources
+and uploading the combined .csv files to the portal in their stead.
+
+Finally, the ``bin\reg2portal.sh`` script cleans up the temporary
+files it created in its operations.
+
+For the registry host, a sample crontab entry automating daily
+ATI and PD propagation (specifying names for the datasets on the
+registry, to a portal on host devubu3) follows:
+
+    ``0 2 * * * /opt/open-data/ckanext-canada/bin/reg2portal.sh /opt/open-data/ckanext-canada/development.ini http://devubu3:5000 141d4974-7d48-47b9-a003-b09d5f8e7c3a ati:ati pd:pd /opt/venvs/env-ckan-2.1 >> /var/log/reg2portal.log 2>&1``
+
+*The Portal*
+
+On the portal, the ``bin/csv2solr.sh`` script rebuilds the configured
+local solr core with the content of specified datasets from the local
+CKAN installation. It takes the following parameters:
+
+  ``CKAN-INI-FILE``
+    The path to the configuration file of the CKAN portal installation
+
+  ``TARGET-DATASET:PACKAGE-ID ...``
+    One or more space-separated and colon-delimited mappings
+    (e.g. ``pd:11111111-1111-1111-1111-111111111111``) between target
+    datasets and their respective names or identifiers on the portal
+
+  ``VIRTUAL-ENV-HOME`` (optional)
+    If present, the root directory of the python virtual environment to
+    activate, under which the script will operate
+
+First, the execution of the script activates the virtual environment
+if specified.
+
+Then, uses ckanext-recombinant to parse all target datasets from
+its (JSON) recombinant tables file. For each such target dataset
+mapped on the command line, the script calls ckanext-canada to
+locate its associated resources on the portal. The operation
+downloads these resources and uses them to rebuild the target
+dataset from them via ckanext-canada.
+
+Finally, the script cleans up the temporary files it created
+in its operations.
+
+For the portal host, a sample crontab entry automating daily
+ATI and PD solr core rebuild (specifying identifiers for the
+datasets on the portal) follows:
+
+    ``0 2 * * * /opt/open-data/ckanext-canada/bin/csv2solr.sh /opt/open-data/ckanext-canada/development.ini ati:636893c9-e4b4-451c-b652-571f2f1349dd pd:ca8f5f4b-b5d8-4884-a8d5-4a87dca4f6f6 /opt/venvs/env-ckan-2.3 >> /var/log/csv2solr.log 2>&1``

--- a/bin/csv2solr.sh
+++ b/bin/csv2solr.sh
@@ -1,59 +1,100 @@
 #!/bin/bash
 
 function usage() {
-    echo "Usage: ${0} CKAN-INI-FILE [VIRTUAL-ENV-HOME]"
-    echo "The script:"
+    echo "Usage: ${0} CKAN-INI-FILE \\"
+    echo "    TARGET-DATASET:PACKAGE-ID ... [VIRTUAL-ENV-HOME]"
+    echo
+    echo "This script:"
     echo "- activates virtual environment if specified"
     echo "- pushes datasets from .csv files to the solr core"
+    echo
+    echo "e.g., ${0} ../development.ini ati:ati_id pd:pd_id /opt/my-venv"
+
     exit -1
 }
 
-#
-#
-# THIS SCRIPT AS IT IS WRITTEN IS HOPELESS: NEEDS TO USE CKANAPI FILE STORAGE
-#
-#
+function log() {
+    DT=$(date +'%F %T')
+    LEVEL=${1}
+    MSG=${2}
+    echo ${DT} ${LEVEL} [$(basename "${0}")] ${MSG}
+}
 
-if [ "$#" -eq 0 ]
+LAST_TARG_ARG_IDX=$#
+if [ "$#" -lt 2 ]
 then
     usage
-elif [ "$#" -gt 1 ]
+elif [[ ! "${!#}" =~ ":" ]]
 then
-   VENV_HOME=$(echo ${2} | sed -e 's./$..')
-   source ${VENV_HOME}/bin/activate
+    LAST_TARG_ARG_IDX=$(( $# - 1 ))
+    VENV_HOME=$(echo ${!#} | sed -e 's:/$::')
+    source ${VENV_HOME}/bin/activate
 fi
 
+# Establish bin directory
 cd "$(dirname ${0})"
 BIN_HOME=$(pwd)
 
-# Set ini file
+# Set .ini file, get port of operation from [server:main] section
 cd "$(dirname ${1})"
 INI_FILE=$(basename ${1})
 INI_PATH="$(pwd)/${INI_FILE}"
+INI_PORT=$(sed -n -e '/^\[server:main\]/,/^\[.*\]/p' ${INI_PATH} | sed -n 's/^ *port *= *\([^ ]*.*\)/\1/p')
+INI_PORT=${INI_PORT%% *}
+
+# Associate target datasets with ids
+declare -A TARG_DS_MAP
+for TARG_ARG in $(seq 2 ${LAST_TARG_ARG_IDX})
+do
+    TARG_DS_MAP["${!TARG_ARG%:*}"]="${!TARG_ARG#*:}"
+done
+
+TMPDIR=$(mktemp -t -d)
 
 # Record ckanext-canada home
 cd "${BIN_HOME}/.."
 CXC_HOME=$(pwd)
 
-# Go to ckanext-recombinant
+# Go to ckanext-recombinant, identify bona fide target datasets
 cd "${BIN_HOME}/../../ckanext-recombinant"
-CXR_HOME=$(pwd)
-
-# Get target dataset names
+CXR_HOME="$(pwd)"
 TARGET_DATASETS=$(paster recombinant target-datasets -c "${INI_PATH}")
+
+# Go to ckanext-canada and fetch resources per target dataset
+cd "${CXC_HOME}"
 for TARG_DS in $(echo ${TARGET_DATASETS} | tr ' ' '\n')
 do
-    # Identify .csv files to push to solr
+    # Get resource URLs for those datasets specified on command line
+    if [ -z "${TARG_DS_MAP[${TARG_DS}]}" ]
+    then
+        continue
+    fi
+
+    CSV_URLS=$(paster canada locate-dataset-resources "${TARG_DS_MAP[${TARG_DS}]}" -c "${INI_PATH}")
+
     CSV_FILES=""
-    cd "${CXR_HOME}"
-    DATASET_TYPES=$(echo $(paster recombinant dataset-types ${TARG_DS} -c "${INI_PATH}") | sed -e 's/.*: //')
-    for F in ${DATASET_TYPES}
+    for CSV_URL in $(echo ${CSV_URLS} | tr ' ' '\n')
     do
-      CSV_FILES="${CSV_FILES} ${TARG_DS}.${F}.csv"
+        # Sometimes http://host:port/ is there and sometimes not
+        if [[ "${CSV_URL}" =~ :///.* ]]
+        then
+            CSV_URL=${CSV_URL#*///}
+            CSV_URL="http://localhost:${INI_PORT}/${CSV_URL}"
+        fi
+
+        # Strip off everything but file name and extension
+        FPATH="${TMPDIR}/${CSV_URL#*.*.}"
+        CSV_FILES="${CSV_FILES} ${FPATH}"
+        wget -q ${CSV_URL} -O "${FPATH}"
+        log 'INFO' "Downloaded $(wc -c ${FPATH} | cut -d ' ' -f1) bytes: [${CSV_URL}]"
     done
     CSV_FILES=${CSV_FILES/ /}
 
-    # rebuild solr core from identified .csv files
-    cd "${CXC_HOME}"
-    paster "${TARG_DS}" rebuild -f ${CSV_FILES} -c "${INI_PATH}" ${TARG_DS}.${DS_TYPE}.csv
+    # Rebuild solr core from downloaded .csv files
+    paster "${TARG_DS}" clear
+    paster "${TARG_DS}" rebuild -f ${CSV_FILES} -c "${INI_PATH}"
+    log 'INFO' "Cleared and rebuilt [${TARG_DS}] solr core"
 done
+
+# Clean up
+/bin/rm -rf "${TMPDIR}"

--- a/bin/csv2solr.sh
+++ b/bin/csv2solr.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+function usage() {
+    echo "Usage: ${0} CKAN-INI-FILE [VIRTUAL-ENV-HOME]"
+    echo "The script:"
+    echo "- activates virtual environment if specified"
+    echo "- pushes datasets from .csv files to the solr core"
+    exit -1
+}
+
+#
+#
+# THIS SCRIPT AS IT IS WRITTEN IS HOPELESS: NEEDS TO USE CKANAPI FILE STORAGE
+#
+#
+
+if [ "$#" -eq 0 ]
+then
+    usage
+elif [ "$#" -gt 1 ]
+then
+   VENV_HOME=$(echo ${2} | sed -e 's./$..')
+   source ${VENV_HOME}/bin/activate
+fi
+
+cd "$(dirname ${0})"
+BIN_HOME=$(pwd)
+
+# Set ini file
+cd "$(dirname ${1})"
+INI_FILE=$(basename ${1})
+INI_PATH="$(pwd)/${INI_FILE}"
+
+# Record ckanext-canada home
+cd "${BIN_HOME}/.."
+CXC_HOME=$(pwd)
+
+# Go to ckanext-recombinant
+cd "${BIN_HOME}/../../ckanext-recombinant"
+CXR_HOME=$(pwd)
+
+# Get target dataset names
+TARGET_DATASETS=$(paster recombinant target-datasets -c "${INI_PATH}")
+for TARG_DS in $(echo ${TARGET_DATASETS} | tr ' ' '\n')
+do
+    # Identify .csv files to push to solr
+    CSV_FILES=""
+    cd "${CXR_HOME}"
+    DATASET_TYPES=$(echo $(paster recombinant dataset-types ${TARG_DS} -c "${INI_PATH}") | sed -e 's/.*: //')
+    for F in ${DATASET_TYPES}
+    do
+      CSV_FILES="${CSV_FILES} ${TARG_DS}.${F}.csv"
+    done
+    CSV_FILES=${CSV_FILES/ /}
+
+    # rebuild solr core from identified .csv files
+    cd "${CXC_HOME}"
+    paster "${TARG_DS}" rebuild -f ${CSV_FILES} -c "${INI_PATH}" ${TARG_DS}.${DS_TYPE}.csv
+done

--- a/bin/reg2portal.py
+++ b/bin/reg2portal.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+"""
+Script uploading input files from registry to portal via CKAN API.
+
+Usage:
+    reg2portal.py CKAN_INI_FILE PORTAL_URL API_KEY PACKAGE_ID FILE ...
+"""
+
+import ckanapi
+from ckanapi.errors import CKANAPIError
+import ConfigParser
+from docopt import docopt
+import os
+import sys
+import logging
+
+usage = __doc__
+opts = docopt(__doc__)
+
+if len(opts) < 5:
+    sys.stderr.write(opts + '\n')
+    sys.exit()
+
+ini_file = opts['CKAN_INI_FILE']
+portal_url = opts['PORTAL_URL']
+api_key = opts['API_KEY']
+package_id = opts['PACKAGE_ID']
+files = opts['FILE']
+
+cfg = ConfigParser.ConfigParser()
+cfg.read(opts['CKAN_INI_FILE'])
+
+logging.config.fileConfig(opts['CKAN_INI_FILE'])
+log = logging.getLogger()
+
+user_agent = None
+
+# Set user-agent
+try:
+    reg_url = cfg.get('app:main', 'ckan.site_url')
+    if reg_url:
+        user_agent = 'ckanapi-uploader/1.0 (+{0:s})'.format(reg_url)
+except ConfigParser.Error:
+    log.warning('ckan.site_url not configured: specifying default user-agent')
+    pass
+
+# Instantiate remote ckanapi
+portal_site = ckanapi.RemoteCKAN(
+    portal_url,
+    apikey=api_key,
+    user_agent=user_agent)
+
+# Update package: add resources
+try:
+    portal_site.call_action(
+        'package_update',
+        {'id': package_id, 'url': '', 'resources': []})
+    print 'Cleared resources from package_id [{0:s}]'.format(package_id)
+
+    for file in files:
+        resource_name = os.path.basename(file)
+        with open(file) as f:
+            rc = portal_site.call_action(
+                'resource_create',
+                {'package_id': package_id, 'url': '', 'name': resource_name},
+                files={'upload': f})
+        print 'Uploaded resource [{0:s}] to package_id [{1:s}]'.format(
+            resource_name,
+            package_id)
+
+except (AttributeError, ValueError, CKANAPIError, Exception) as e:
+    log.error('Encountered {0:s}'.format(str(e)))

--- a/bin/reg2portal.py
+++ b/bin/reg2portal.py
@@ -31,7 +31,7 @@ cfg = ConfigParser.ConfigParser()
 cfg.read(opts['CKAN_INI_FILE'])
 
 logging.config.fileConfig(opts['CKAN_INI_FILE'])
-log = logging.getLogger()
+log = logging.getLogger('ckanext')
 
 user_agent = None
 
@@ -50,12 +50,12 @@ portal_site = ckanapi.RemoteCKAN(
     apikey=api_key,
     user_agent=user_agent)
 
-# Update package: add resources
+# Patch package: add resources
 try:
     portal_site.call_action(
-        'package_update',
+        'package_patch',
         {'id': package_id, 'url': '', 'resources': []})
-    print 'Cleared resources from package_id [{0:s}]'.format(package_id)
+    log.info('Cleared resources from package_id [{0:s}]'.format(package_id))
 
     for file in files:
         resource_name = os.path.basename(file)
@@ -64,9 +64,9 @@ try:
                 'resource_create',
                 {'package_id': package_id, 'url': '', 'name': resource_name},
                 files={'upload': f})
-        print 'Uploaded resource [{0:s}] to package_id [{1:s}]'.format(
+        log.info('Uploaded resource [{0:s}] to package_id [{1:s}]'.format(
             resource_name,
-            package_id)
+            package_id))
 
 except (AttributeError, ValueError, CKANAPIError, Exception) as e:
     log.error('Encountered {0:s}'.format(str(e)))

--- a/bin/reg2portal.sh
+++ b/bin/reg2portal.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+function usage() {
+    echo "Usage: ${0} CKAN-INI-FILE PORTAL-URL API-KEY \\"
+    echo "    TARGET-DATASET:PACKAGE-ID ... [VIRTUAL-ENV-HOME]"
+    echo
+    echo "This script:"
+    echo "- activates the virtual environment if specified"
+    echo "- dumps datasets to .csv files"
+    echo "- pushes these files to the portal as CKAN resources."
+    echo
+    echo "e.g., ${0} ../development.ini http://portal.gc.ca \\"
+    echo "    00000000-0000-0000-0000-000000000000 ati:ati_id pd:pd_id"
+    exit -1
+}
+
+LAST_TARG_ARG_IDX=$#
+if [ "$#" -lt 4 ]
+then
+    usage
+elif [[ ! "${!#}" =~ ":" ]]
+then
+    LAST_TARG_ARG_IDX=$(( $# - 1 ))
+    VENV_HOME=$(echo ${!#} | sed -e 's:/$::')
+    source ${VENV_HOME}/bin/activate
+fi
+
+# Establish bin directory
+cd "$(dirname ${0})"
+BIN_HOME=$(pwd)
+
+# Record portal URL, API key
+PORTAL_URL=${2}
+API_KEY=${3}
+
+# Set ini file
+cd "$(dirname ${1})"
+INI_FILE=$(basename ${1})
+INI_PATH="$(pwd)/${INI_FILE}"
+
+# Associate target datasets with ids
+declare -A TARG_DS_MAP
+for TARG_ARG in $(seq 4 ${LAST_TARG_ARG_IDX})
+do
+    TARG_DS_MAP["${!TARG_ARG%:*}"]="${!TARG_ARG#*:}"
+done
+
+TMPDIR=$(mktemp -t -d)
+
+# Go to ckanext-recombinant, get target datasets
+cd "${BIN_HOME}/../../ckanext-recombinant"
+CXR_HOME="$(pwd)"
+TARGET_DATASETS=$(paster recombinant target-datasets -c "${INI_PATH}")
+
+for TARG_DS in $(echo ${TARGET_DATASETS} | tr ' ' '\n')
+do
+    # Go to recombinant, get dataset types for current target
+    cd "${CXR_HOME}"
+    DATASET_TYPES=$(echo $(paster recombinant dataset-types ${TARG_DS} -c "${INI_PATH}") | sed -e 's/.*: //')
+    CSV_FILES=""
+    for DS_TYPE in $(echo ${DATASET_TYPES} | tr ' ' '\n')
+    do
+        F="${TMPDIR}/${TARG_DS}.${DS_TYPE}.csv"
+        paster recombinant combine ${DS_TYPE} -c "${INI_PATH}" > "${F}"
+        CSV_FILES="${CSV_FILES} ${F}"
+    done
+    CSV_FILES=${CSV_FILES/ /}
+
+    # Go to bin directory and upload files
+    cd "${BIN_HOME}"
+    python reg2portal.py "${INI_PATH}" "${PORTAL_URL}" "${API_KEY}" "${TARG_DS_MAP[${TARG_DS}]}" ${CSV_FILES}
+done
+
+# Clean up
+/bin/rm -rf "${TMPDIR}"

--- a/bin/reg2portal.sh
+++ b/bin/reg2portal.sh
@@ -47,14 +47,20 @@ done
 
 TMPDIR=$(mktemp -t -d)
 
-# Go to ckanext-recombinant, get target datasets
+# Go to ckanext-recombinant, identify bona fide target datasets
 cd "${BIN_HOME}/../../ckanext-recombinant"
 CXR_HOME="$(pwd)"
 TARGET_DATASETS=$(paster recombinant target-datasets -c "${INI_PATH}")
 
 for TARG_DS in $(echo ${TARGET_DATASETS} | tr ' ' '\n')
 do
-    # Go to recombinant, get dataset types for current target
+    # Promote only those datasets specified on command line
+    if [ -z "${TARG_DS_MAP[${TARG_DS}]}" ]
+    then
+        continue
+    fi
+
+    # Go to ckanext-recombinant, get dataset types for current target
     cd "${CXR_HOME}"
     DATASET_TYPES=$(echo $(paster recombinant dataset-types ${TARG_DS} -c "${INI_PATH}") | sed -e 's/.*: //')
     CSV_FILES=""

--- a/ckanext/canada/ati.py
+++ b/ckanext/canada/ati.py
@@ -89,31 +89,18 @@ class ATICommand(CkanCommand):
         if csv_files:
             count = {}
             for csv_file in csv_files:
-                try:
-                    print csv_file + ':'
-                    count[csv_file] = {}
-                    for org_recs in csv_data_batch(csv_file, TARGET_DATASET):
-                        org_id = org_recs.keys()[0]
-                        if org_id not in count[csv_file]:
-                            count[csv_file][org_id] = 0
-                        org_detail = lc.action.organization_show(id=org_id)
-                        records = org_recs[org_id]
-                        _update_records(records, org_detail, conn)
-                        count[csv_file][org_id] += len(records)
-                    for k, v in count[csv_file].iteritems():
-                        print "    {0:s} {1}".format(k, v)
-                except _csvError as e:
-                    logging.error('On {0:s}, encountered: {1:s}'.format(
-                        csv_file,
-                        e.message))
-                except AssertionError as e:
-                    logging.warning('On {0:s}, encountered: {1:s}'.format(
-                        csv_file,
-                        e.message))
-                except IOError as e:
-                    logging.error('On {0:s}, encountered: {1:s}'.format(
-                        csv_file,
-                        e.strerror))
+                print csv_file + ':'
+                count[csv_file] = {}
+                for org_recs in csv_data_batch(csv_file, TARGET_DATASET):
+                    org_id = org_recs.keys()[0]
+                    if org_id not in count[csv_file]:
+                        count[csv_file][org_id] = 0
+                    org_detail = lc.action.organization_show(id=org_id)
+                    records = org_recs[org_id]
+                    _update_records(records, org_detail, conn)
+                    count[csv_file][org_id] += len(records)
+                for k, v in count[csv_file].iteritems():
+                    print "    {0:s} {1}".format(k, v)
             for org_id in lc.action.organization_list():
                 print org_id, sum((count[f].get(org_id, 0) for f in count))
         else:

--- a/ckanext/canada/ati.py
+++ b/ckanext/canada/ati.py
@@ -2,31 +2,27 @@
 import hashlib
 import calendar
 import datetime
+import logging
+from unicodecsv import DictReader
+from _csv import Error as _csvError
 
 import paste.script
 from pylons import config
 from ckan.lib.cli import CkanCommand
 
-from ckanapi import LocalCKAN
+from ckanapi import LocalCKAN, NotFound
+
+from ckanext.recombinant.plugins import get_table
+
+from ckanext.canada.dataset import (
+    MONTHS_FR,
+    solr_connection,
+    data_batch,
+    csv_data_batch)
 
 DATASET_TYPES = ['ati-summaries', 'ati-none']
-BATCH_SIZE = 1000
 WINDOW_YEARS = 2
-MONTHS_FRA = [
-    u'', # "month 0"
-    u'janvier',
-    u'février',
-    u'mars',
-    u'avril',
-    u'mai',
-    u'juin',
-    u'juillet',
-    u'août',
-    u'septembre',
-    u'octobre',
-    u'novembre',
-    u'décembre',
-    ]
+
 
 class ATICommand(CkanCommand):
     """
@@ -35,14 +31,30 @@ class ATICommand(CkanCommand):
     Usage::
 
         paster ati clear
-                   rebuild
+                   rebuild [-f <file> <file>]
+
+    Options::
+
+        -f/--csv-file <file> <file>    use specified CSV files as ati-summaries
+                                       and ati-none input, instead of the
+                                       (default) CKAN database
     """
     summary = __doc__.split('\n')[0]
     usage = __doc__
 
     parser = paste.script.command.Command.standard_parser(verbose=True)
-    parser.add_option('-c', '--config', dest='config',
-        default='development.ini', help='Config file to use.')
+    parser.add_option(
+        '-c',
+        '--config',
+        dest='config',
+        default='development.ini',
+        help='Config file to use.')
+    parser.add_option(
+        '-f',
+        '--csv',
+        nargs=2,
+        dest='csv_files',
+        help='CSV files to use as input (or default CKAN DB)')
 
     def command(self):
         if not self.args or self.args[0] in ['--help', '-h', 'help']:
@@ -55,56 +67,72 @@ class ATICommand(CkanCommand):
         if cmd == 'clear':
             return self._clear_index()
         elif cmd == 'rebuild':
-            return self._rebuild()
+            return self._rebuild(self.options.csv_files)
 
     def _clear_index(self):
-        conn = _solr_connection()
+        conn = solr_connection('ati_summaries', True)
         conn.delete_query("*:*")
         conn.commit()
 
-    def _rebuild(self):
-        conn = _solr_connection()
+    def _rebuild(self, csv_files=None):
+        """
+        Implement rebuild command
+
+        :param csv_files: sequence of paths to .csv files for input
+        :type csv_files: sequence of str
+
+        :return: Nothing
+        :rtype: None
+        """
+        conn = solr_connection('ati_summaries', True)
         lc = LocalCKAN()
-        for org in lc.action.organization_list():
-            count = 0
-            org_detail = lc.action.organization_show(id=org)
-            for records in _ati_summaries(org_detail, lc):
-                _update_records(records, org_detail, conn)
-                count += len(records)
+        if csv_files:
+            for csv_file in csv_files:
+                try:
+                    print csv_file
+                    count = {}
+                    for org_recs in csv_data_batch(csv_file, DATASET_TYPES):
+                        org_id = org_recs.keys()[0]
+                        if org_id not in count:
+                            count[org_id] = 0
+                        org_detail = lc.action.organization_show(id=org_id)
+                        records = org_recs[org_id]
+                        _update_records(records, org_detail, conn)
+                        count[org_id] += len(records)
+                    for k, v in count.iteritems():
+                        print "    {0:s} {1}".format(k, v)
+                except (_csvError, AssertionError) as e:
+                    logging.error('On {0:s}, encountered: {1:s}'.format(
+                        csv_file, e.message))
+                except IOError as e:
+                    logging.error('On {0:s}, encountered: {1:s}'.format(
+                        csv_file, e.strerror))
+        else:
+            for org_id in lc.action.organization_list():
+                count = 0
+                org_detail = lc.action.organization_show(id=org_id)
+                for records in data_batch(org_detail['id'], lc, DATASET_TYPES):
+                    _update_records(records, org_detail, conn)
+                    count += len(records)
+                print org_id, count
+            #rval = conn.query("*:*" , rows=2)
 
-            print org, count
-        #rval = conn.query("*:*" , rows=2)
-
-def _solr_connection():
-    from solr import SolrConnection
-    url = config['ati_summaries.solr_url']
-    user = config.get('ati_summaries.solr_user')
-    password = config.get('ati_summaries.solr_password')
-    if user is not None and password is not None:
-        return SolrConnection(url, http_user=user, http_pass=password)
-    return SolrConnection(url)
-
-def _ati_summaries(org, lc):
-    """
-    generator of ati summary dicts for organization with name org
-    """
-    for dataset_type in DATASET_TYPES:
-        result = lc.action.package_search(
-            q="type:%s owner_org:%s" % (dataset_type, org['id']),
-            rows=1000)['results']
-        resource_id = result[0]['resources'][0]['id']
-        offset = 0
-        while True:
-            rval = lc.action.datastore_search(resource_id=resource_id,
-                limit=BATCH_SIZE, offset=offset)
-            records = rval['records']
-            if not records:
-                break
-            yield records
-            offset += len(records)
 
 def _update_records(records, org_detail, conn):
     """
+    Update records on solr core
+
+    :param records: record dicts
+    :ptype records: sequence of record dicts
+
+    :param org_detail: org structure as returned via local CKAN
+    :ptype org_detail: dict with local CKAN org structure
+
+    :param conn: solr connection
+    :ptype conn: obj
+
+    :returns: Nothing
+    :rtype: None
     """
     out = []
     org = org_detail['name']
@@ -139,8 +167,9 @@ def _update_records(records, org_detail, conn):
             'ss_ati_contact_information_en':
                 "http://data.gc.ca/data/en/organization/about/{0}"
                 .format(org),
-            'ss_ati_disposition_en': r.get('disposition', '').split(' / ', 1)[0],
-            'ss_ati_month_en': '{0:02d}'.format(r['month']),
+            'ss_ati_disposition_en':
+                r.get('disposition', '').split(' / ', 1)[0],
+            'ss_ati_month_en': '{0:02d}'.format(int(r['month'])),
             'ss_ati_monthname_en': calendar.month_name[month],
             'ss_ati_number_of_pages_en': r.get('pages', ''),
             'ss_ati_organization_en': org_detail['title'].split(' | ', 1)[0],
@@ -160,9 +189,10 @@ def _update_records(records, org_detail, conn):
             'ss_ati_contact_information_fr':
                 "http://donnees.gc.ca/data/fr/organization/about/{0}"
                 .format(org),
-            'ss_ati_disposition_fr': r.get('disposition', '').split(' / ', 1)[-1],
-            'ss_ati_month_fr': '{0:02d}'.format(r['month']),
-            'ss_ati_monthname_fr': MONTHS_FRA[month],
+            'ss_ati_disposition_fr':
+                r.get('disposition', '').split(' / ', 1)[-1],
+            'ss_ati_month_fr': '{0:02d}'.format(int(r['month'])),
+            'ss_ati_monthname_fr': MONTHS_FR[month],
             'ss_ati_number_of_pages_fr': r.get('pages', ''),
             'ss_ati_organization_fr': org_detail['title'].split(' | ', 1)[-1],
             'ss_ati_year_fr': r['year'],

--- a/ckanext/canada/commands.py
+++ b/ckanext/canada/commands.py
@@ -11,7 +11,6 @@ import json
 import time
 import sys
 import gzip
-import unicodecsv
 import urllib2
 from datetime import datetime, timedelta
 from contextlib import contextmanager
@@ -48,6 +47,7 @@ class CanadaCommand(CkanCommand):
                       copy-datasets <remote server> [<dataset-id> ...]
                                     [-f | -a <push-apikey>] [-m]
                       dump-datasets [-p <num>] [-z]
+                      locate-dataset-resources <dataset-id>
                       changed-datasets [<since date>] [-s <remote server>] [-b]
 
         <starting line number> of .jl source file, default: 1
@@ -140,6 +140,9 @@ class CanadaCommand(CkanCommand):
         elif cmd == 'dump-datasets-worker':
             with _quiet_int_pipe():
                 self.dump_datasets_worker()
+
+        elif cmd == 'locate-dataset-resources':
+            self.locate_dataset_resources(self.args[1])
 
         elif cmd == 'changed-datasets':
             self.changed_datasets(*self.args[1:])
@@ -553,6 +556,16 @@ class CanadaCommand(CkanCommand):
                 registry.action.package_show(id=name.strip()), sort_keys=True)
                 + '\n')
             sys.stdout.flush()
+
+
+    def locate_dataset_resources(self, package_id):
+        """
+        Return space-separated list of URLs, one per resource
+        in the identified package
+        """
+        registry = LocalCKAN()
+        pkg = registry.action.package_show(id=package_id)
+        print ' '.join([r['url'] for r in pkg.get('resources', [])])
 
 
     def changed_datasets(self, since_date):

--- a/ckanext/canada/commands.py
+++ b/ckanext/canada/commands.py
@@ -11,6 +11,7 @@ import json
 import time
 import sys
 import gzip
+import unicodecsv
 import urllib2
 from datetime import datetime, timedelta
 from contextlib import contextmanager

--- a/ckanext/canada/dataset.py
+++ b/ckanext/canada/dataset.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+import os
+from unicodecsv import DictReader
+from pylons import config
+from ckanext.recombinant.plugins import get_table
+
+BATCH_SIZE = 1000
+MONTHS_FR = [
+    u'', # "month 0"
+    u'janvier',
+    u'février',
+    u'mars',
+    u'avril',
+    u'mai',
+    u'juin',
+    u'juillet',
+    u'août',
+    u'septembre',
+    u'octobre',
+    u'novembre',
+    u'décembre',
+    ]
+
+def solr_connection(ini_prefix, solr_default=False):
+    """
+    Set up solr connection
+    :param ini_prefix: prefix to use in specifying .ini file keys (e.g.,
+        ati_summaries to use config setting ati_summaries.solr_url etc.)
+    :ptype ini_prefix: str
+    :param solr_default: whether to accept .ini file keys for solr if
+        ini_prefix-specified settings are absent
+    :ptype solr_default: true
+
+    :return a solr connection from configured URL, user, password settings
+    :rtype object
+    """
+    from solr import SolrConnection
+    url = config.get('{0:s}.solr_url'.format(ini_prefix))
+    user = config.get('{0:s}.solr_user'.format(ini_prefix))
+    password = config.get('{0:s}.solr_password'.format(ini_prefix))
+    if solr_default:
+        if not url:
+            url = config.get('solr_url')
+        if not user:
+            user = config.get('solr_user')
+        if not password:
+            password = config.get('solr_password')
+    if url is None:
+        raise KeyError('{0:s}.solr_url'.format(ini_prefix))
+    if user is not None and password is not None:
+        return SolrConnection(url, http_user=user, http_pass=password)
+    return SolrConnection(url)
+
+def data_batch(org_id, lc, dataset_types):
+    """
+    Generator of dataset dicts for organization with name org
+
+    :param org_id: the id for the organization of interest
+    :ptype org_id: str
+    :param lc: local CKAN
+    :ptype lc: obj
+    :param dataset_types: dataset types of interest
+    :ptype dataset_types: sequence of str
+
+    :return generates batches of dataset dict records
+    :rtype batch of dataset dict records
+    """
+    for dataset_type in dataset_types:
+        records = {}
+        result = lc.action.package_search(
+            q="type:{0:s} owner_org:{1:s}".format(dataset_type, org_id),
+            rows=1000)['results']
+        print ">>> " + org_id + ": " + str(len(result))
+        if len(result) == 0:
+            yield records
+        else:
+            resource_id = result[0]['resources'][0]['id']
+            offset = 0
+            while True:
+                rval = lc.action.datastore_search(
+                    resource_id=resource_id,
+                    limit=BATCH_SIZE,
+                    offset=offset)
+                records = rval['records']
+                if not records:
+                    break
+                yield records
+                offset += len(records)
+
+
+def csv_data_batch(csv_path, dataset_types):
+    """
+    Generator of dataset records from csv file
+
+    :param csv_path: file to parse
+    :ptype csv_file: str
+    :param dataset_types: dataset types of interest as per JSON schema
+    :ptype dataset_types: sequence of basestr
+
+    :return a batch of records for at most one organization
+    :rtype: dict mapping at most one org-id to
+            at most BATCH_SIZE (dict) records
+    """
+    # Use JSON schema to discover the dataset type to which the file corresponds
+    schema_tables = dict((
+            t,
+            dict((f['label'], f['datastore_id'])
+                for f in get_table(t)['fields']))
+        for t in dataset_types)
+    records = {}
+    schema_cols = None
+    cols = None
+    csv_path = os.path.abspath(os.path.expandvars(os.path.expanduser(csv_path)))
+    if os.path.islink(csv_path):
+        csv_path = os.readlink(csv_path)
+    with open(csv_path) as f:
+        csv_in = DictReader(f)
+        cols = csv_in.unicode_fieldnames
+
+        for k, v in schema_tables.iteritems():
+            if (len(set(v.keys()).intersection(set(cols))) == len(v.keys()) and
+                    len(cols) == len(v.keys()) + 2):
+                # columns represent all schema data fields + 'Org id', 'Org'
+                schema_cols = [v[col] if col in v else col for col in cols]
+                break
+
+    assert schema_cols > 0, '{0:s} does not match any dataset type {1}'.format(
+        csv_path, dataset_types)
+
+    with open(csv_path) as f:
+        # use new dict, each col named for its corresponding JSON datastore_id
+        csv_in = DictReader(f, fieldnames=schema_cols)
+        csv_in.next()   # skip header row: no new info
+        for row_dict in csv_in:
+            org_id = row_dict.pop('Org id')
+            org = row_dict.pop('Org')
+            if org_id not in records:
+                if len(records.keys()):
+                    org_id_done = records.keys()[0]
+                    yield {org_id_done: records.pop(org_id_done)}
+                records[org_id] = []
+            records[org_id].append(row_dict)
+            if len(records[org_id]) >= BATCH_SIZE:
+                yield {org_id: records.pop(org_id)}
+    yield records

--- a/ckanext/canada/recombinant_tables.json
+++ b/ckanext/canada/recombinant_tables.json
@@ -1,6 +1,7 @@
 [
   {
     "dataset_type": "ati-summaries",
+    "target_dataset": "ati",
     "title": "ATI Summaries",
     "xls_sheet_name": "ATI AI",
     "fields": [
@@ -64,6 +65,7 @@
   },
   {
     "dataset_type": "ati-none",
+    "target_dataset": "ati",
     "title": "ATI Nothing to Report",
     "xls_sheet_name": "ATI AI none",
     "fields": [
@@ -88,6 +90,7 @@
   },
   {
     "dataset_type": "contracts",
+    "target_dataset": "pd",
     "title": "Contracts",
     "xls_sheet_name": "contracts",
     "fields": [

--- a/ckanext/canada/recombinant_tables.json
+++ b/ckanext/canada/recombinant_tables.json
@@ -6,14 +6,14 @@
     "fields": [
       {
         "datastore_id": "year",
-        "label": "Year / Annee",
-        "datastore_type": "int",
+        "label": "Year / Année",
+        "datastore_type": "year",
         "xls_column_width": 13
       },
       {
         "datastore_id": "month",
         "label": "Month / Mois",
-        "datastore_type": "int",
+        "datastore_type": "month",
         "xls_column_width": 13
       },
       {
@@ -69,14 +69,14 @@
     "fields": [
       {
         "datastore_id": "year",
-        "label": "Year / Annee",
-        "datastore_type": "int",
+        "label": "Year / Année",
+        "datastore_type": "year",
         "xls_column_width": 5
       },
       {
         "datastore_id": "month",
         "label": "Month / Mois",
-        "datastore_type": "int",
+        "datastore_type": "month",
         "xls_column_width": 4
       }
     ],
@@ -142,43 +142,43 @@
       {
         "datastore_id": "contract_date",
         "label": "Contract Date / Date du contrat",
-        "datastore_type": "text",
+        "datastore_type": "date",
         "xls_column_width": 20
       },
       {
         "datastore_id": "contract_period_start",
         "label": "Contract Period Start / Date de début du contrat",
-        "datastore_type": "text",
+        "datastore_type": "date",
         "xls_column_width": 20
       },
       {
         "datastore_id": "contract_period_end",
         "label": "Contract Period End / Date de clôture du contrat",
-        "datastore_type": "text",
+        "datastore_type": "date",
         "xls_column_width": 20
       },
       {
         "datastore_id": "delivery_date",
         "label": "Delivery Date / Date de livraison",
-        "datastore_type": "text",
+        "datastore_type": "date",
         "xls_column_width": 20
       },
       {
         "datastore_id": "contract_value",
         "label": "Contract Value / Valeur du contrat",
-        "datastore_type": "text",
+        "datastore_type": "money",
         "xls_column_width": 20
       },
       {
         "datastore_id": "original_value",
         "label": "Original Value / Valeur d'origine",
-        "datastore_type": "text",
+        "datastore_type": "money",
         "xls_column_width": 20
       },
       {
         "datastore_id": "cumulative_value",
         "label": "Cumulative Value / Valeur cumulative",
-        "datastore_type": "text",
+        "datastore_type": "money",
         "xls_column_width": 20
       },
       {

--- a/solr_schema.ati_pd.xml
+++ b/solr_schema.ati_pd.xml
@@ -16,7 +16,7 @@
  limitations under the License.
 -->
 
-<schema name="ckan" version="2.0">
+<schema name="ckan" version="2.3">
 
 <types>
     <fieldType name="string" class="solr.StrField" sortMissingLast="true" omitNorms="true"/>
@@ -70,11 +70,8 @@
 
 
 <fields>
-    <field name="index_id" type="string" indexed="true" stored="true" required="true" />
+    <field name="index_id" type="string" indexed="true" stored="true" required="false" />
     <field name="id" type="string" indexed="true" stored="true" required="true" />
-    <!--
-    <field name="site_id" type="string" indexed="true" stored="true" required="true" />
-    -->
     <field name="site_id" type="string" indexed="true" stored="true" required="false" />
     <field name="title" type="text" indexed="true" stored="true" />
     <field name="entity_type" type="string" indexed="true" stored="true" omitNorms="true" />
@@ -100,9 +97,12 @@
 
     <field name="capacity" type="string" indexed="true" stored="true" multiValued="false"/>
 
+    <field name="res_name" type="textgen" indexed="true" stored="true" multiValued="true" />
     <field name="res_description" type="textgen" indexed="true" stored="true" multiValued="true"/>
     <field name="res_format" type="string" indexed="true" stored="true" multiValued="true"/>
     <field name="res_url" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="res_type" type="string" indexed="true" stored="true" multiValued="true"/>
+
 
     <!-- catchall field, containing all other searchable text fields (implemented
          via copyField further on in this schema  -->
@@ -139,6 +139,7 @@
     <dynamicField name="*_date" type="date" indexed="true" stored="true" multiValued="false"/>
 
     <dynamicField name="extras_*" type="text" indexed="true" stored="true" multiValued="false"/>
+    <dynamicField name="res_extras_*" type="text" indexed="true" stored="true" multiValued="true"/>
     <dynamicField name="vocab_*" type="string" indexed="true" stored="true" multiValued="true"/>
     <dynamicField name="*" type="string" indexed="true"  stored="false"/>
     
@@ -150,7 +151,7 @@
     <field name="ready_to_publish" type="boolean" indexed="true" stored="true"/>
 </fields>
 
-<uniqueKey>index_id</uniqueKey>
+<uniqueKey>id</uniqueKey>
 <defaultSearchField>text</defaultSearchField>
 <solrQueryParser defaultOperator="AND"/>
 
@@ -159,6 +160,7 @@
 <copyField source="download_url" dest="urls"/>
 <copyField source="res_url" dest="urls"/>
 <copyField source="extras_*" dest="text"/>
+<copyField source="res_extras_*" dest="text"/>
 <copyField source="vocab_*" dest="text"/>
 <copyField source="urls" dest="text"/>
 <copyField source="name" dest="text"/>

--- a/solr_schema.xml
+++ b/solr_schema.xml
@@ -72,7 +72,10 @@
 <fields>
     <field name="index_id" type="string" indexed="true" stored="true" required="true" />
     <field name="id" type="string" indexed="true" stored="true" required="true" />
+    <!--
     <field name="site_id" type="string" indexed="true" stored="true" required="true" />
+    -->
+    <field name="site_id" type="string" indexed="true" stored="true" required="false" />
     <field name="title" type="text" indexed="true" stored="true" />
     <field name="entity_type" type="string" indexed="true" stored="true" omitNorms="true" />
     <field name="dataset_type" type="string" indexed="true" stored="true" />
@@ -133,7 +136,7 @@
 
     <field name="_version_" type="string" indexed="true" stored="true"/>
 
-    <dynamicField name="*_date" type="date" indexed="true" stored="true" multiValued="false"/>
+    <!--<dynamicField name="*_date" type="date" indexed="true" stored="true" multiValued="false"/>-->
 
     <dynamicField name="extras_*" type="text" indexed="true" stored="true" multiValued="false"/>
     <dynamicField name="vocab_*" type="string" indexed="true" stored="true" multiValued="true"/>


### PR DESCRIPTION
ckanext-recombinant:
+ recombinant_tables.json supports "target_dataset" per dataset_type (e.g., "ati" for "ati-summaries" and "ati-none")
+ paster recombinant command target-datasets command to return all target datasets defined
+ paster recombinant command dataset-types lists all dataset types per input target

ckanext-canada:
+ ckanext/canada/common code between ati.py, pd.py refactored and generalized in dataset.py
+ ckanext/canada/ati.py, pd.py know their respective target datasets and pass them to dataset.py, which gets corresponding dataset types on the fly
+ bin/reg2portal.sh and reg2portal.py combine dataset resources and upload to corresponding portal datasets
+ bin/csv2solr.sh on portal will update solr core from uploaded csv files, but is still a work in progress