### PR TITLE
build combined ati summaries records (step 1)

### DIFF
--- a/ckanext/canada/ati.py
+++ b/ckanext/canada/ati.py
@@ -83,6 +83,7 @@ class ATICommand(CkanCommand):
         :return: Nothing
         :rtype: None
         """
+        self._clear_index()
 
         conn = solr_connection('ati_summaries')
         lc = LocalCKAN()

--- a/ckanext/canada/ati.py
+++ b/ckanext/canada/ati.py
@@ -127,9 +127,6 @@ def _update_records(records, org_detail, conn):
 
     :param conn: solr connection
     :ptype conn: obj
-
-    :returns: Nothing
-    :rtype: None
     """
     out = []
     org = org_detail['name']
@@ -157,7 +154,7 @@ def _update_records(records, org_detail, conn):
                 ati_email = e['value']
 
         # don't ask why, just doing it the way it was done before
-        out.append({
+        en_record = {
             'bundle': 'ati_summaries',
             'hash': 'avexlb',
             'id': unique + 'en',
@@ -178,8 +175,8 @@ def _update_records(records, org_detail, conn):
             'ss_ati_nothing_to_report_en': ('' if 'request_number' in r else
                 'Nothing to report this month'),
             'ss_language': 'en',
-            })
-        out.append({
+            }
+        fr_record = {
             'bundle': 'ati_summaries',
             'hash': 'avexlb',
             'id': unique + 'fr',
@@ -200,5 +197,14 @@ def _update_records(records, org_detail, conn):
             'ss_ati_nothing_to_report_fr': ('' if 'request_number' in r else
                 u'Rien à signaler ce mois-ci'),
             'ss_language': 'fr',
-            })
+            }
+
+        out.append(en_record)
+        out.append(fr_record)
+
+        record = dict(en_record, **fr_record)
+        record['ss_language'] = 'combined'
+        record['id'] = unique
+        out.append(record)
+
     conn.add_many(out, _commit=True)

--- a/ckanext/canada/ati.py
+++ b/ckanext/canada/ati.py
@@ -10,7 +10,7 @@ import paste.script
 from pylons import config
 from ckan.lib.cli import CkanCommand
 
-from ckanapi import LocalCKAN
+from ckanapi import LocalCKAN, NotFound
 
 from ckanext.canada.dataset import (
     MONTHS_FR,
@@ -96,7 +96,10 @@ class ATICommand(CkanCommand):
                     org_id = org_recs.keys()[0]
                     if org_id not in count[csv_file]:
                         count[csv_file][org_id] = 0
-                    org_detail = lc.action.organization_show(id=org_id)
+                    try:
+                        org_detail = lc.action.organization_show(id=org_id)
+                    except NotFound:
+                        continue
                     records = org_recs[org_id]
                     _update_records(records, org_detail, conn)
                     count[csv_file][org_id] += len(records)

--- a/ckanext/canada/pd.py
+++ b/ckanext/canada/pd.py
@@ -82,6 +82,8 @@ class PDCommand(CkanCommand):
         :return: Nothing
         :rtype: None
         """
+        self._clear_index()
+
         conn = solr_connection(self.command_name)
         lc = LocalCKAN()
         if csv_file:


### PR DESCRIPTION
The ATI summaries are now generated with en, fr and combined records to allow the front-end to be updated to use the combined records. When that update is complete we will remove the en + fr records (step 2)