### PR TITLE
Fixed the display of the login message

### DIFF
--- a/ckanext/canada/controller.py
+++ b/ckanext/canada/controller.py
@@ -152,8 +152,8 @@ class CanadaController(BaseController):
                     if len(orgs_list) == 0:
                         is_new = True
 
-            h.flash_success(_("<p><strong>Note</strong></p>"
-                "<p>%s is now logged in</p>") %
+            h.flash_success(_("<strong>Note</strong><br>"
+                "%s is now logged in") %
                 user_dict['display_name'], allow_html=True)
 
             if is_new:

--- a/i18n/fr/LC_MESSAGES/canada.po
+++ b/i18n/fr/LC_MESSAGES/canada.po
@@ -363,8 +363,8 @@ msgstr "S'il vous plaît vérifier l’orthographe, ou réduire le nombre de fil
 msgid "The following fields are required to publish this dataset:"
 msgstr "Les champs suivants doivent être remplis afin de publier ce jeu de données:"
 
-msgid "<p><strong>Note</strong></p><p>%s is now logged in</p>"
-msgstr "<p><strong>Note</strong></p><p>Bienvenue %s</p>"
+msgid "<strong>Note</strong><br>%s is now logged in"
+msgstr "<strong>Note</strong><br>Bienvenue %s"
 
 msgid "A resource has been added"
 msgstr "Une ressource a été ajoutée"


### PR DESCRIPTION
CKAN doesn't use `<p>` for it's notification so WET adds them. This fixes the following

![notificationissue](https://cloud.githubusercontent.com/assets/1090826/10584056/3e2b5a8a-765e-11e5-862a-3e94c7c68ef8.PNG)
