### PR TITLE
Revert "Added temporary styles for the log in/out section"

### DIFF
--- a/ckanext/canada/templates/internal/base.html
+++ b/ckanext/canada/templates/internal/base.html
@@ -5,16 +5,6 @@
     >{{ _('Open Data Registry') }}</a>
 {% endblock %}
 
-{# Remove when WET v4.0.21 is out #}
-{%- block custom_styles %}
-  {{ super() }}
-  <style>
-      #wb-so {text-align: right;}
-      #wb-so .row {background: #fff; padding: 1em 0 0;}
-      #wb-so .container {border-left: 1px solid #ccc; border-right: 1px solid #ccc;}
-  </style>
-{%- endblock -%}
-
 {% block footer %}
 {% include "footer_gwcu.html" %}
 {% endblock %}


### PR DESCRIPTION
This reverts commit 3e922c1a6f689ddae3e6be85fa78cba085a2a914. No longer needed with WET v4.0.21
