### PR TITLE
Remove ckanext-dcat extension from and added backports.ssl-match-host…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ pyyaml
 ckantoolkit
 pytz
 babel
--e git+https://github.com/ckan/ckanext-dcat.git#egg=ckanext-dcat
 rdflib-jsonld
 geomet
+backports.ssl-match-hostname>=3.5.0.1


### PR DESCRIPTION
…name to requirements.txt

Since we now use the ckanext-dcat extension from https://github.com/open-data/ckanext-dcat, removed it from the requirements,txt file