### PR TITLE
Footer update - Government Log in

### DIFF
--- a/ckanext/canada/i18n/fr/LC_MESSAGES/canada.po
+++ b/ckanext/canada/i18n/fr/LC_MESSAGES/canada.po
@@ -1547,8 +1547,8 @@ msgstr "http://ouvert.canada.ca/fr/formulaire/faites-nous-part-de-vos-commentair
 msgid "Open Government Log In"
 msgstr "Ouverture de session Gouvernement ouvert"
 
-msgid "/en/user"
-msgstr "/fr/user"
+msgid "/en/user/login"
+msgstr "/fr/user/login"
 
 msgid "Receive Open Government Email"
 msgstr "Courriels sur le Gouvernement ouvert"

--- a/ckanext/canada/templates/internal/footer.html
+++ b/ckanext/canada/templates/internal/footer.html
@@ -10,7 +10,7 @@
       <li><a href="{{ _('http://news.gc.ca/') }}">{{ _('News') }}</a></li>
       <li><a href="{{ _('https://www.canada.ca/en/government/system/laws.html') }}">{{ _('Treaties, laws and regulations') }}</a></li>
       <li><a href="{{ _('https://www.canada.ca/en/transparency/reporting.html') }}">{{ _('Government-wide reporting') }}</a></li>
-      <li><a href="{{ _('/en/user') }}">{{ _('Open Government Log In') }}</a></li>
+      <li><a href="{{ _('/en/user/login') }}">{{ _('Open Government Log In') }}</a></li>
       <li><a href="{{ _('https://www.canada.ca/en/government/system.html') }}">{{ _('How government works') }}</a></li>
       {% endblock %}
     </ul>

--- a/ckanext/canada/templates/public/footer.html
+++ b/ckanext/canada/templates/public/footer.html
@@ -6,7 +6,7 @@
 <li><a href="{{ _('http://news.gc.ca/') }}">{{ _('News') }}</a></li>
 <li><a href="{{ _('https://www.canada.ca/en/government/system/laws.html') }}">{{ _('Treaties, laws and regulations') }}</a></li>
 <li><a href="{{ _('https://www.canada.ca/en/transparency/reporting.html') }}">{{ _('Government-wide reporting') }}</a></li>
-<li><a href="{{ _('/en/user') }}">{{ _('Open Government Log In') }}</a></li>
+<li><a href="{{ _('/en/user/login') }}">{{ _('Open Government Log In') }}</a></li>
 <li><a href="{{ _('https://www.canada.ca/en/government/system.html') }}">{{ _('How government works') }}</a></li>
 {% endblock %}
 

--- a/ckanext/canada/templates/public/footer.html
+++ b/ckanext/canada/templates/public/footer.html
@@ -6,7 +6,7 @@
 <li><a href="{{ _('http://news.gc.ca/') }}">{{ _('News') }}</a></li>
 <li><a href="{{ _('https://www.canada.ca/en/government/system/laws.html') }}">{{ _('Treaties, laws and regulations') }}</a></li>
 <li><a href="{{ _('https://www.canada.ca/en/transparency/reporting.html') }}">{{ _('Government-wide reporting') }}</a></li>
-<li><a href="{{ _('/en/user/') }}">{{ _('Open Government Log In') }}</a></li>
+<li><a href="{{ _('/en/user') }}">{{ _('Open Government Log In') }}</a></li>
 <li><a href="{{ _('https://www.canada.ca/en/government/system.html') }}">{{ _('How government works') }}</a></li>
 {% endblock %}
 

--- a/ckanext/canada/templates/public/footer.html
+++ b/ckanext/canada/templates/public/footer.html
@@ -6,7 +6,7 @@
 <li><a href="{{ _('http://news.gc.ca/') }}">{{ _('News') }}</a></li>
 <li><a href="{{ _('https://www.canada.ca/en/government/system/laws.html') }}">{{ _('Treaties, laws and regulations') }}</a></li>
 <li><a href="{{ _('https://www.canada.ca/en/transparency/reporting.html') }}">{{ _('Government-wide reporting') }}</a></li>
-<li><a href="{{ _('/en/user/login') }}">{{ _('Open Government Log In') }}</a></li>
+<li><a href="{{ _('/en/user/') }}">{{ _('Open Government Log In') }}</a></li>
 <li><a href="{{ _('https://www.canada.ca/en/government/system.html') }}">{{ _('How government works') }}</a></li>
 {% endblock %}
 

--- a/ckanext/canada/templates/public/ramp/ramp-en-ckan.html
+++ b/ckanext/canada/templates/public/ramp/ramp-en-ckan.html
@@ -895,7 +895,7 @@
         <h3>Contact information</h3>
         <ul class="list-unstyled">
           <li><a class="gl-footer" href="/en/forms/contact-us">Open Government Contact</a></li>
-          <li><a class="gl-footer" href="/en/user">Open Government Log In</a></li>
+          <li><a class="gl-footer" href="/en/user/login">Open Government Log In</a></li>
           <li><a class="gl-footer" href="/en/forms/receive-open-government-email-form">Receive Open Government Email</a></li>
           <li><a class="gl-footer" href="http://www.canada.ca/en/contact/index.html#aat">Most asked-about topics</a></li>
           <li><a class="gl-footer" href="http://www.canada.ca/en/contact/index.html#spe">Specialized enquiries</a></li>

--- a/ckanext/canada/templates/public/ramp/ramp-fr-ckan.html
+++ b/ckanext/canada/templates/public/ramp/ramp-fr-ckan.html
@@ -895,7 +895,7 @@
       <h3>Coordonnées</h3>
       <ul class="list-unstyled">
         <li><a class="gl-footer" href="/fr/formulaire/faites-nous-part-de-vos-commentaires">Contactez Gouvernement ouvert</a></li>
-        <li><a class="gl-footer" href="/fr/user">Ouverture de session Gouvernement ouvert</a></li>
+        <li><a class="gl-footer" href="/fr/user/login">Ouverture de session Gouvernement ouvert</a></li>
         <li><a class="gl-footer" href="/fr/formulaire/courriels-gouvernement-ouvert">Courriels sur le Gouvernement ouvert</a></li>
         <li><a class="gl-footer" href="http://www.canada.ca/fr/contact/index.html#slq">Sujets sur lesquels portent la plupart des
           questions</a></li>


### PR DESCRIPTION
Changing the footer link "Open Government Log In" 

from: 
http://registry.open.canada.ca/en/user/
to: 
http://registry.open.canada.ca/en/user/login

from:
http://registry.open.canada.ca/fr/user/
to: 
http://registry.open.canada.ca/fr/user/login