### PR TITLE
Enabling nightly build of the Grants Solr core for Django-based search

### DIFF
--- a/bin/pd/Makefile
+++ b/bin/pd/Makefile
@@ -202,6 +202,7 @@ rebuild-contracts: $(workdir)/filtered/contracts.csv $(workdir)/filtered/contrac
 	@echo Rebuilding Contracts Quarterly...
 	@$(paster)  --plugin=ckanext-canada contracts rebuild -c $(portal_ini) \
 	-f "$(workdir)/filtered/contracts.csv" "$(workdir)/filtered/contracts-nil.csv"
+	@$(ogc_search)/load_gc_to_solr.py "$(workdir)/filtered/contracts.csv" "$(workdir)/filtered/contracts-nil.csv"
 
 $(workdir)/contracts.csv:
 	$(paster) $(combine) contracts -d $(workdir) -c $(registry_ini)


### PR DESCRIPTION
I was thinking we'd build both Solr cores for now so we can compare