### PR TITLE
Opn 333 new date field for 2.8

### DIFF
--- a/ckanext/canada/schemas/dataset.yaml
+++ b/ckanext/canada/schemas/dataset.yaml
@@ -197,7 +197,7 @@ dataset_fields:
 - preset: canada_date_published
 - preset: canada_date_modified
 - preset: canada_program_page_url
-- preset: canada_data_series_name
+- preset: canada_federated_date_modified
 - preset: canada_data_series_name
 - preset: canada_data_series_issue_identification
 - preset: canada_digital_object_identifier

--- a/ckanext/canada/schemas/dataset.yaml
+++ b/ckanext/canada/schemas/dataset.yaml
@@ -198,6 +198,7 @@ dataset_fields:
 - preset: canada_date_modified
 - preset: canada_program_page_url
 - preset: canada_data_series_name
+- preset: canada_data_series_name
 - preset: canada_data_series_issue_identification
 - preset: canada_digital_object_identifier
 

--- a/ckanext/canada/schemas/presets.yaml
+++ b/ckanext/canada/schemas/presets.yaml
@@ -2073,6 +2073,23 @@ presets:
     display_snippet: date.html
     validators: isodate
 
+# Field = Federated date modified.
+# Add a Calendar control to select a Date.
+# {The date on which the federated dataset was modified (YYYY-MM-DD)}
+- preset_name: canada_federated_date_modified
+  values:
+    field_name: federated_date_modified
+    label:
+      en: Federated Dateset Modified Date
+      fr: Date de modification de l'jeu de données fédérées
+    help_text:
+      en: The date on which the federated data partner's dataset was modified (YYYY-MM-DD)
+      fr: Date à laquelle le jeu de données du partenaire de données fédérées a été modifié (AAAA-MM-JJ)
+    # copied from date preset
+    form_snippet: null
+    display_snippet: date.html
+    validators: scheming_required isodate convert_to_json_if_date
+
 # Field = Usage Condition Type - Organization Section Name English.
 # {The English text for limitations or restrictions on how an information resource can be used (separate multiple names by commas).}
 # Field = Publisher - Organization Section Name French.


### PR DESCRIPTION
Hi @RabiaSajjad ,, @wardi FGP will need this new field in CKAN production this week I don't know what is actually deployed on production since the 2.6 branch is gone. This change was already deployed in staging but is quite stale now and wasn't transferred to 2.8. Could you please follow up on this week for FGP so they can load the QC data? Thanks