### PR TITLE
OPN-442: replace status removal popup with simple text message

### DIFF
--- a/ckanext/canada/i18n/fr/LC_MESSAGES/canada.po
+++ b/ckanext/canada/i18n/fr/LC_MESSAGES/canada.po
@@ -3445,6 +3445,9 @@ msgstr "Êtes-vous certain de vouloir supprimer cet état?"
 msgid "The status has been added / updated for this suggested  dataset. This update will be reflected on open.canada.ca shortly."
 msgstr "L’état a été ajouté/mis à jour pour cet ensemble de données suggéré. Cette mise à jour sera bientôt effectuée dans ouvert.canada.ca."
 
+msgid "These fields have been removed, click save below to update the record with your changes."
+msgstr "Ces champs ont été supprimés. Cliquez sur « Enregistrer » ci-dessous pour mettre à jour le document."
+
 msgid "Your user sessions has timed out due to inactivity"
 msgstr "Vos sessions d’utilisateur ont été interrompues pour cause d’inactivité"
 

--- a/ckanext/canada/templates/internal/scheming/snippets/form_field.html
+++ b/ckanext/canada/templates/internal/scheming/snippets/form_field.html
@@ -1,23 +1,11 @@
 {% ckan_extends %}
 
-{% block removal_popup%}
-  {% set locale = h.dump_json({'content': _('Are you sure you want to delete this status?') }) %}
-  {% set template = [
-    '<div class="modal wb-overlay wb-popup-mid" id="mid-screen" tabindex="-1" role="dialog" aria-labelledby="mid-screenLabel" aria-hidden="true" style="max-height:185px;max-width:600px;">',
-      '<div class="modal-dialog" role="document" style="margin:auto;">',
-        '<div class="modal-content">',
-          '<div class="modal-header">',
-            '<h3 class="modal-title"></h3>',
-          '</div>',
-          '<div class="modal-body"></div>',
-          '<div class="modal-footer">',
-            '<button class="btn btn-cancel"></button>',
-            '<button class="btn btn-primary"></button>',
-          '</div>',
-        '</div>',
-      '</div>',
-    '</div>'
-    ]|join('\n') %}
-  <a class="btn btn-danger pull-left" name="repeating-remove" href="javascript:;" data-module="scheming-remove-subfields" data-module-i18n="{{ locale }}" data-module-template="{{ template }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
+{% block field_removal_button%}
+<a class="btn btn-danger pull-left" name="repeating-remove" href="javascript:;">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
 {% endblock %}
+
+{% block removal_text %}
+  {% set locale = h.dump_json({'content': _('These fields have been removed, click save below to update the record with your changes.') }) %}
+<fieldset name="scheming-repeating-subfields" class="scheming-fieldset" data-module="scheming-repeating-subfields" data-module-i18n="{{ locale }}">
+  {% endblock %}
 


### PR DESCRIPTION
Replaces the pop-up window when a status is removed with a simple removal text.
Dependent on https://github.com/ckan/ckanext-scheming/pull/260