### PR TITLE
Opn 146 test pd upload

### DIFF
--- a/ckanext/canada/tests/houssam.py
+++ b/ckanext/canada/tests/houssam.py
@@ -1,0 +1,6 @@
+import tempfile
+
+# f = tempfile.NamedTemporaryFile(suffix='xlsx')
+# file_path = tempfile.TemporaryDirectory() + '/empty_file.xlsx'
+f = tempfile.NamedTemporaryFile(delete=False, suffix=".xlsx")
+print(f.name)

--- a/ckanext/canada/tests/houssam.py
+++ b/ckanext/canada/tests/houssam.py
@@ -1,6 +1,0 @@
-import tempfile
-
-# f = tempfile.NamedTemporaryFile(suffix='xlsx')
-# file_path = tempfile.TemporaryDirectory() + '/empty_file.xlsx'
-f = tempfile.NamedTemporaryFile(delete=False, suffix=".xlsx")
-print(f.name)

--- a/ckanext/canada/tests/test_xls_upload.py
+++ b/ckanext/canada/tests/test_xls_upload.py
@@ -1,5 +1,6 @@
 # -*- coding: UTF-8 -*-
 import os
+import tempfile
 from nose.tools import assert_equal, assert_raises
 from ckanapi import LocalCKAN
 
@@ -14,6 +15,7 @@ from openpyxl import load_workbook, Workbook
 
 
 CURRENT_PATH = os.path.dirname(os.path.abspath(__file__))
+
 
 # testing the upload of PD template files
 # 'wrongdoing' PD template is used as an example here
@@ -30,53 +32,50 @@ class TestXlsUpload(FunctionalTestBase):
     def test_upload_empty(self):
         lc = LocalCKAN()
         wb = excel_template('wrongdoing', self.org)
-        file_path = CURRENT_PATH + '/empty_file.xlsx'
-        wb.save(file_path)
+        f = tempfile.NamedTemporaryFile(suffix=".xlsx")
+        wb.save(f.name)
         with assert_raises(BadExcelData) as e:
             _process_upload_file(
                 lc,
                 lc.action.package_show(id=self.pkg_id),
-                file_path,
+                f.name,
                 get_geno('wrongdoing'),
                 True)
         assert_equal('The template uploaded is empty', e.exception.message)
-        os.remove(file_path)
 
 
     def test_upload_example(self):
         lc = LocalCKAN()
         wb = excel_template('wrongdoing', self.org)
+        f = tempfile.NamedTemporaryFile(suffix=".xlsx")
 
         # Enter the example record into the excel template
         record = get_chromo('wrongdoing')['examples']['record']
         wb = append_data(wb, [record], get_chromo('wrongdoing'))
-        file_path = CURRENT_PATH + '/wrongdoing_test.xlsx'
-        wb.save(file_path)
+        wb.save(f.name)
 
         _process_upload_file(
             lc,
             lc.action.package_show(id=self.pkg_id),
-            file_path,
+            f.name,
             get_geno('wrongdoing'),
             True)
-        os.remove(file_path)
 
 
     def test_upload_wrong_type(self):
         lc = LocalCKAN()
         wb = excel_template('travela', self.org)
-        file_path = CURRENT_PATH + '/wrong_template.xlsx'
-        wb.save(file_path)
+        f = tempfile.NamedTemporaryFile(suffix=".xlsx")
+        wb.save(f.name)
         with assert_raises(BadExcelData) as e:
             _process_upload_file(
                 lc,
                 lc.action.package_show(id=self.pkg_id),
-                file_path,
+                f.name,
                 get_geno('wrongdoing'),
                 True)
         assert_equal('Invalid file for this data type. Sheet must be labeled "wrongdoing", but you supplied a sheet labeled "travela"',
             e.exception.message)
-        os.remove(file_path)
 
         
         

--- a/ckanext/canada/tests/test_xls_upload.py
+++ b/ckanext/canada/tests/test_xls_upload.py
@@ -1,5 +1,4 @@
 # -*- coding: UTF-8 -*-
-import os
 import tempfile
 from nose.tools import assert_equal, assert_raises
 from ckanapi import LocalCKAN
@@ -12,9 +11,6 @@ from ckanext.recombinant.controller import _process_upload_file
 from ckanext.recombinant.write_excel import excel_template, append_data
 from ckanext.recombinant.errors import  BadExcelData
 from openpyxl import load_workbook, Workbook
-
-
-CURRENT_PATH = os.path.dirname(os.path.abspath(__file__))
 
 
 # testing the upload of PD template files

--- a/ckanext/canada/tests/test_xls_upload.py
+++ b/ckanext/canada/tests/test_xls_upload.py
@@ -1,0 +1,85 @@
+# -*- coding: UTF-8 -*-
+import os
+from nose.tools import assert_equal, assert_raises
+from ckanapi import LocalCKAN
+
+from ckan.tests.helpers import FunctionalTestBase
+from ckan.tests.factories import Organization
+
+from ckanext.recombinant.tables import get_chromo, get_geno
+from ckanext.recombinant.controller import _process_upload_file
+from ckanext.recombinant.write_excel import excel_template, append_data
+from ckanext.recombinant.errors import  BadExcelData
+from openpyxl import load_workbook, Workbook
+
+
+CURRENT_PATH = os.path.dirname(os.path.abspath(__file__))
+
+# testing the upload of PD template files
+# 'wrongdoing' PD template is used as an example here
+class TestXlsUpload(FunctionalTestBase):
+    def setup(self):
+        super(TestXlsUpload, self).setup()
+        self.org = Organization()
+        lc = LocalCKAN()
+        lc.action.recombinant_create(dataset_type='wrongdoing', owner_org=self.org['name'])
+        rval = lc.action.recombinant_show(dataset_type='wrongdoing', owner_org=self.org['name'])
+        self.pkg_id = rval['id']
+
+    
+    def test_upload_empty(self):
+        lc = LocalCKAN()
+        wb = excel_template('wrongdoing', self.org)
+        file_path = CURRENT_PATH + '/empty_file.xlsx'
+        wb.save(file_path)
+        with assert_raises(BadExcelData) as e:
+            _process_upload_file(
+                lc,
+                lc.action.package_show(id=self.pkg_id),
+                file_path,
+                get_geno('wrongdoing'),
+                True)
+        assert_equal('The template uploaded is empty', e.exception.message)
+        os.remove(file_path)
+
+
+    def test_upload_example(self):
+        lc = LocalCKAN()
+        wb = excel_template('wrongdoing', self.org)
+
+        # Enter the example record into the excel template
+        record = get_chromo('wrongdoing')['examples']['record']
+        wb = append_data(wb, [record], get_chromo('wrongdoing'))
+        file_path = CURRENT_PATH + '/wrongdoing_test.xlsx'
+        wb.save(file_path)
+
+        _process_upload_file(
+            lc,
+            lc.action.package_show(id=self.pkg_id),
+            file_path,
+            get_geno('wrongdoing'),
+            True)
+        os.remove(file_path)
+
+
+    def test_upload_wrong_type(self):
+        lc = LocalCKAN()
+        wb = excel_template('travela', self.org)
+        file_path = CURRENT_PATH + '/wrong_template.xlsx'
+        wb.save(file_path)
+        with assert_raises(BadExcelData) as e:
+            _process_upload_file(
+                lc,
+                lc.action.package_show(id=self.pkg_id),
+                file_path,
+                get_geno('wrongdoing'),
+                True)
+        assert_equal('Invalid file for this data type. Sheet must be labeled "wrongdoing", but you supplied a sheet labeled "travela"',
+            e.exception.message)
+        os.remove(file_path)
+
+        
+        
+
+    
+            

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ backports.ssl-match-hostname>=3.5.0.1
 azure-storage==0.33.0
 configparser>=3.5.0
 nltk==3.4.5
+openpyxl==2.6.4

--- a/test-core.ini
+++ b/test-core.ini
@@ -22,7 +22,7 @@ scheming.presets = ckanext.scheming:presets.json
 
 ckan.plugins =
     canada_forms canada_internal canada_public canada_package canada_activity
-    wet_boew_theme_gc_intranet datastore recombinant
+    datastore recombinant
     scheming_datasets fluent extendedactivity
 
 #ckan.tracking_enabled = true


### PR DESCRIPTION
In this branch, I have created 3 test cases related to the pd template upload:

1. Uploading an empty file
2. Uploading the wrong file (from a different pd type)
3. Uploading the correct file with no errors.
