### PR TITLE
Overrode the repeating_subfields template from ckanext-scheming. Over…

### DIFF
--- a/ckanext/canada/internal/static/internal.css
+++ b/ckanext/canada/internal/static/internal.css
@@ -635,3 +635,12 @@ ul#brf-pkg { padding-left: 0; }
 .nav-item.active > a span, .nav-aside li.active a span {
     white-space: inherit;
 }
+
+.scheming-subfield-group-panel-heading {
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap; 
+    justify-content: space-between; 
+    align-items: center;
+}

--- a/ckanext/canada/templates/internal/scheming/form_snippets/repeating_subfields.html
+++ b/ckanext/canada/templates/internal/scheming/form_snippets/repeating_subfields.html
@@ -1,0 +1,93 @@
+{# A complex field with repeating sub-fields #}
+
+{% include 'scheming/snippets/subfields_asset.html' %}
+{% import 'macros/form.html' as form %}
+
+{% macro repeating_panel(index, index1) %}
+  <div class="scheming-subfield-group" data-field="{{ field.field_name }}" data-group-index="{{ index }}">
+    <div class="panel panel-default">
+      <header class="panel-heading scheming-subfield-group-panel-heading">
+        <span>{{ h.scheming_language_text(field.repeating_label or field.label) }} {{ index1 }}</span>
+        {% block field_removal_button %}
+            <a class="btn btn-danger" name="repeating-remove" href="javascript:;">
+                {% block delete_button_text %}{{ _('Remove') }}{% endblock %}
+            </a>
+        {% endblock %}
+      </header>
+      <div class="panel-body fields-content">
+        {% for subfield in field.repeating_subfields %}
+          {% set sf = dict(
+            subfield,
+            field_name=field.field_name ~ '-' ~ index ~ '-' ~ subfield.field_name)
+          %}
+          {%- snippet 'scheming/snippets/form_field.html',
+            field=sf,
+            data=flat,
+            errors=flaterr,
+            licenses=licenses,
+            entity_type=entity_type,
+            object_type=object_type
+          -%}
+        {% endfor %}
+      </div>
+      <div class="panel-body fields-removed-notice" style="display:none">
+        {% block removal_text %}
+          {% if 'id' in data %}
+            {{ _('These fields have been removed, click update below to save your changes.') }}
+          {% else %}
+            {{ _('These fields have been removed.') }}
+          {% endif %}
+        {% endblock %}
+      </div>
+    </div>
+  </div>
+{% endmacro %}
+
+{% set flat = h.scheming_flatten_subfield(field, data) %}
+{% set flaterr = h.scheming_flatten_subfield(field, errors) %}
+
+{% call form.input_block(
+  'field-' + field.field_name,
+  h.scheming_language_text(field.label) or field.field_name,
+  [],
+  field.classes if 'classes' in field else ['control-medium'],
+  is_required=h.scheming_field_required(field)) %}
+    <div {{ form.attributes(field.get('form_attrs', {})) }}>
+      <fieldset name="scheming-repeating-subfields" class="scheming-fieldset" data-module="scheming-repeating-subfields">
+	{% set alert_warning = h.scheming_language_text(field.form_alert_warning) %}
+	{% if alert_warning %}
+	  <section class="alert alert-warning">
+	    {{ alert_warning|safe }}
+	  </section>
+	{% endif %}
+
+	{%- set group_data = data[field.field_name] -%}
+	{%- set group_count = group_data|length -%}
+	{%- if not group_count and 'id' not in data -%}
+	  {%- set group_count = field.form_blanks|default(1) -%}
+	{%- endif -%}
+
+	<div class="scheming-repeating-subfields-group">
+	  {% for index in range(group_count) %}
+	    {{ repeating_panel(index, index + 1) }}
+	  {% endfor %}
+	</div>
+	<div class="control-medium">
+	    <a href="javascript:;" name="repeating-add" class="btn btn-success">
+            {% block add_button_text %}
+                <i class="fa fa-plus" aria-hidden="true"></i> {{ _('Add') }}
+            {% endblock %}
+        </a>
+
+	  {% set help_text = h.scheming_language_text(field.help_text) %}
+	  {% if help_text %}
+	    <div class="info-block mrgn-tp-md">
+	      {{ help_text }}
+	    </div>
+	  {% endif %}
+	</div>
+
+	<div name="repeating-template" style="display:none">{{ repeating_panel('REPEATING-INDEX0', 'REPEATING-INDEX1') }}</div>
+      </fieldset>
+    </div>
+{% endcall %}

--- a/ckanext/canada/templates/public/package/resources.html
+++ b/ckanext/canada/templates/public/package/resources.html
@@ -1,7 +1,26 @@
 {% ckan_extends %}
 
 {% block subtitle %}
-{{ _('Resources') }} - {{ h.get_translated(pkg, 'title') }}
+  {% if pkg.type != 'prop' %}
+    {{ _('Resources') }} - {{ h.get_translated(pkg, 'title') }}
+  {% endif %}
+{% endblock %}
+
+{% block primary_content_inner %}
+  {% if pkg.type != 'prop' %}
+    {% if pkg.resources %}
+      <ul class="resource-list"{% if has_reorder %} data-module="resource-reorder" data-module-id="{{ pkg.id }}"{% endif %}>
+        {% set can_edit = h.check_access('package_update', {'id':pkg.id }) %}
+        {% for resource in pkg.resources %}
+          {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=resource, url_is_edit=true, can_edit=can_edit %}
+        {% endfor %}
+      </ul>
+    {% else %}
+      {% trans url=h.url_for(controller='package', action='new_resource', id=pkg.name) %}
+        <p class="empty">This dataset has no data, <a href="{{ url }}">why not add some?</a></p>
+      {% endtrans %}
+    {% endif %}
+  {% endif %}
 {% endblock %}
 
 {% block secondary_content %}

--- a/ckanext/canada/templates/public/package/snippets/resources_list.html
+++ b/ckanext/canada/templates/public/package/snippets/resources_list.html
@@ -1,0 +1,36 @@
+{# 
+Renders a list of resources with icons and view links.
+
+resources - A list of resources to render
+pkg - A package object that the resources belong to.
+
+Example:
+
+  {% snippet "package/snippets/resources_list.html", pkg=pkg, resources=pkg.resources %}
+
+#}
+{% if pkg.type != 'prop' %}
+  <section id="dataset-resources" class="resources">
+      <h3>{{ _('Data and Resources') }}</h3>
+      {% block resource_list %}
+        {% if resources %}
+          <ul class="{% block resource_list_class %}resource-list{% endblock %}">
+            {% block resource_list_inner %}
+              {% set can_edit = h.check_access('package_update', {'id':pkg.id }) %}
+              {% for resource in resources %}
+                {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=resource, can_edit=can_edit %}
+              {% endfor %}
+            {% endblock %}
+          </ul>
+        {% else %}
+          {% if h.check_access('resource_create', {'package_id': pkg['id']}) %}
+              {% trans url=h.url_for(controller='package', action='new_resource', id=pkg.name) %}
+                <p class="empty">This dataset has no data, <a href="{{ url }}">why not add some?</a></p>
+              {% endtrans %}
+          {% else %}
+              <p class="empty">{{ _('This dataset has no data') }}</p>
+          {% endif %}
+        {% endif %}
+      {% endblock %}
+  </section>
+{% endif %}


### PR DESCRIPTION
…rode resources_list template from ckan. Added css class for scheming subfield heading.

I added the if type is prop in the jinja2 templates for the resources and resources_list (overrides from ckan templates). So this will not render the "Data and Resources" heading and sub text for Suggested Datasets.

As for the ckanext-scheming 2.1 UI issues with the Suggested Dataset form, that template has been overridden now, containing some minor changes to get the buttons and button positioning we want.