### PR TITLE
Open 1857 contracts template bug 2

### DIFF
--- a/ckanext/canada/tables/contracts.yaml
+++ b/ckanext/canada/tables/contracts.yaml
@@ -9,7 +9,7 @@ upload_info:
   fr: "Le modèle trimestriel des contrats de plus de 10 000 $ a récemment été mis à jour avec de nouveaux champs de données et des règles de validation des données conformément aux Lignes directrices sur la divulgation proactive des marchés. Les utilisateurs devraient examiner les règles de validation des données dans l’onglet de référence du modèle pour chaque champ de données sous « validation » pour plus d’informations afin de s’assurer que les données peuvent être téléchargées dans le registre. Remarque : Plusieurs règles de validation ont été incluses dans le modèle, mais elles ne seront pas activées avant le 1er janvier 2022"
 
 template_version: 3
-template_updated: 2022-04-1
+template_updated: 2022-04-11
 
 portal_type: info
 collection: pd

--- a/ckanext/canada/tables/contracts.yaml
+++ b/ckanext/canada/tables/contracts.yaml
@@ -9,7 +9,7 @@ upload_info:
   fr: "Le modèle trimestriel des contrats de plus de 10 000 $ a récemment été mis à jour avec de nouveaux champs de données et des règles de validation des données conformément aux Lignes directrices sur la divulgation proactive des marchés. Les utilisateurs devraient examiner les règles de validation des données dans l’onglet de référence du modèle pour chaque champ de données sous « validation » pour plus d’informations afin de s’assurer que les données peuvent être téléchargées dans le registre. Remarque : Plusieurs règles de validation ont été incluses dans le modèle, mais elles ne seront pas activées avant le 1er janvier 2022"
 
 template_version: 3
-template_updated: 2020-10-07
+template_updated: 2022-04-1
 
 portal_type: info
 collection: pd
@@ -1743,7 +1743,7 @@ iii. Quand un contrat porte sur plus d’un article économique, il est recomman
         Cette zone peut seulement contenir « 0 » si l’acquisition a été identifiée comme étant concurrentielle (invitation ouverte à soumissionner (OB) ou concurrentielle - traditionnelle (TC) ou Concurrentielle – Appel d’offres sélectif (ST)).
     datastore_type: text
     excel_full_text_choices: false
-    excel_error_formula: 'OR({default_formula},AND({cell}<>"0",NOT(OR({solicitation_procedure}="TN",{solicitation_procedure}="AC"))))'
+    excel_error_formula: 'OR({default_formula},AND(VALUE({cell})<>0,NOT(OR({solicitation_procedure}="TN",{solicitation_procedure}="AC"))))'
     choices:
       "0":
         en: Not applicable
@@ -1790,7 +1790,7 @@ iii. Quand un contrat porte sur plus d’un article économique, il est recomman
         champ Type d’instrument.
     datastore_type: text
     excel_full_text_choices: false
-    excel_error_formula: 'OR({default_formula},AND({cell}<>"0",OR({solicitation_procedure}="TN",{solicitation_procedure}="AC",{instrument_type}="A")))'
+    excel_error_formula: 'OR({default_formula},AND(VALUE({cell})<>0,OR({solicitation_procedure}="TN",{solicitation_procedure}="AC",{instrument_type}="A")))'
     choices:
       "0":
         en: Not applicable


### PR DESCRIPTION
converted any remaining
{cell}<>"0" to VALUE({cell})<>0

this should pass validation if the cell contains numeric 0 or string 0

also updated the template date since the client specifically asked for it to be updated