### PR TITLE
add user required error

### DIFF
--- a/ckanext/canada/commands.py
+++ b/ckanext/canada/commands.py
@@ -212,6 +212,8 @@ class CanadaCommand(CkanCommand):
         and apply the package updates to the portal instance for all
         packages with published_date set to any time in the past.
         """
+        if self.options.ckan_user is None:
+            raise ValueError('--ckan-user is required for portal_update')
         tries = self.options.tries
         self._portal_update_completed = False
         self._portal_update_activity_date = activity_date


### PR DESCRIPTION
portal-update command fails in an obscure way if `--ckan-user` is not provided. Add a more helpful error message