### PR TITLE
Brought back canada_activity plugin and simplified it. Added dataset …

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ The CKAN ini file needs the following settings for the registry server:
 
 ```ini
 ckan.plugins = dcat dcat_json_interface googleanalytics canada_forms canada_internal
-        canada_public canada_package canada_activity datastore recombinant
-        scheming_datasets fluent extendedactivity
+        canada_public canada_package datastore recombinant
+        scheming_datasets fluent
 ```
 
 For the public server use only:

--- a/ckanext/canada/plugins.py
+++ b/ckanext/canada/plugins.py
@@ -406,11 +406,15 @@ ckanext.canada:schemas/prop.yaml
 
     def group_facets(self, facets_dict, group_type, package_type):
         ''' Update the facets_dict and return it. '''
+        if group_type == 'organization':
+            return self.dataset_facets(facets_dict, package_type)
         return facets_dict
 
     def organization_facets(self, facets_dict, organization_type,
                             package_type):
         return self.dataset_facets(facets_dict, package_type)
+
+    
 
     def get_helpers(self):
         return dict((h, getattr(helpers, h)) for h in [
@@ -789,6 +793,21 @@ def datastore_delete(up_func, context, data_dict):
     return result
 
 
+class CanadaActivity(p.SingletonPlugin):
+    p.implements(p.IActions)
+    p.implements(p.IConfigurer)
+
+    def get_actions(self):
+        return ({'datastore_upsert':datastore_upsert,
+                'datastore_delete': datastore_delete})
+
+    def update_config(self, config):
+        logic_validators.object_id_validators.update({
+            'changed datastore': logic_validators.package_id_exists,
+            'deleted datastore': logic_validators.package_id_exists,
+        })
+
+
 class CanadaOpenByDefault(p.SingletonPlugin):
     """
     Plugin for public-facing version of Open By Default site
@@ -833,6 +852,8 @@ ckanext.canada:schemas/doc.yaml
 
     def group_facets(self, facets_dict, group_type, package_type):
         ''' Update the facets_dict and return it. '''
+        if group_type == 'organization':
+            return self.dataset_facets(facets_dict, package_type)
         return facets_dict
 
     def organization_facets(self, facets_dict, organization_type,

--- a/ckanext/canada/plugins.py
+++ b/ckanext/canada/plugins.py
@@ -380,6 +380,12 @@ ckanext.canada:schemas/prop.yaml
 
         hlp.build_nav_main = build_nav_main
 
+        # migration from `canada_activity` and `ckanext-extendedactivity` - Aug 2022
+        logic_validators.object_id_validators.update({
+            'changed datastore': logic_validators.package_id_exists,
+            'deleted datastore': logic_validators.package_id_exists,
+        })
+
     def dataset_facets(self, facets_dict, package_type):
         ''' Update the facets_dict and return it. '''
 
@@ -497,8 +503,11 @@ ckanext.canada:schemas/prop.yaml
         )
         return map
 
+    # `datastore_upsert` and `datastore_delete` migrated from `canada_activity` and `ckanext-extendedactivity` - Aug 2022
     def get_actions(self):
-        return {'inventory_votes_show': logic.inventory_votes_show}
+        return {'inventory_votes_show': logic.inventory_votes_show,
+                'datastore_upsert': datastore_upsert,
+                'datastore_delete': datastore_delete}
 
     def get_auth_functions(self):
         return {
@@ -792,21 +801,6 @@ def datastore_delete(up_func, context, data_dict):
                                    'resource_id': res_id}
                                   )
     return result
-
-
-class CanadaActivity(p.SingletonPlugin):
-    p.implements(p.IActions)
-    p.implements(p.IConfigurer)
-
-    def get_actions(self):
-        return ({'datastore_upsert':datastore_upsert,
-                'datastore_delete': datastore_delete})
-
-    def update_config(self, config):
-        logic_validators.object_id_validators.update({
-            'changed datastore': logic_validators.package_id_exists,
-            'deleted datastore': logic_validators.package_id_exists,
-        })
 
 
 class CanadaOpenByDefault(p.SingletonPlugin):

--- a/ckanext/canada/plugins.py
+++ b/ckanext/canada/plugins.py
@@ -404,6 +404,7 @@ ckanext.canada:schemas/prop.yaml
 
         return facets_dict
 
+    #FIXME: remove `group_facets` method once issue https://github.com/ckan/ckan/issues/7017 is patched into <2.9
     def group_facets(self, facets_dict, group_type, package_type):
         ''' Update the facets_dict and return it. '''
         if group_type == 'organization':
@@ -850,6 +851,7 @@ ckanext.canada:schemas/doc.yaml
 
         return facets_dict
 
+    #FIXME: remove `group_facets` method once issue https://github.com/ckan/ckan/issues/7017 is patched into <2.9
     def group_facets(self, facets_dict, group_type, package_type):
         ''' Update the facets_dict and return it. '''
         if group_type == 'organization':

--- a/ckanext/canada/view.py
+++ b/ckanext/canada/view.py
@@ -29,6 +29,6 @@ class CanadaResourceEditView(ResourceEditView):
         response = super(CanadaResourceEditView, self).post(package_type, id, resource_id)
         if hasattr(response, 'status_code'):
             if response.status_code == 200 or response.status_code == 302:
-                 h.flash_success(_(u'Resource updated.'))
+                h.flash_success(_(u'Resource updated.'))
         return response
 

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     canada_public=ckanext.canada.plugins:DataGCCAPublic
     canada_forms=ckanext.canada.plugins:DataGCCAForms
     canada_package=ckanext.canada.plugins:DataGCCAPackageController
+    canada_activity=ckanext.canada.plugins:CanadaActivity
     canada_obd=ckanext.canada.plugins:CanadaOpenByDefault
 
     [paste.paster_command]

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
     canada_public=ckanext.canada.plugins:DataGCCAPublic
     canada_forms=ckanext.canada.plugins:DataGCCAForms
     canada_package=ckanext.canada.plugins:DataGCCAPackageController
-    canada_activity=ckanext.canada.plugins:CanadaActivity
     canada_obd=ckanext.canada.plugins:CanadaOpenByDefault
 
     [paste.paster_command]


### PR DESCRIPTION
…facets to group_facets plugin implementation.

This contains the simplifying of the canada_activity plugin, not needing the extendedactivity extension anymore. (yay!)

This also contains the fixes for the organization facets not loading. So just adding those checks to the `group_facets`. ckan/ckan has labelled this already for back port: https://github.com/ckan/ckan/issues/7017 so we might see this soon in a patch and be able to remove those `group_type` checks.