### PR TITLE
Added `scheming_required` to some organization fields. Minor js fix f…

### DIFF
--- a/ckanext/canada/internal/static/registry_package_edit.js
+++ b/ckanext/canada/internal/static/registry_package_edit.js
@@ -1,14 +1,16 @@
-$(document).ready(function() {
-  // late init for date polyfill on scheming subforms
-  $('fieldset[name=scheming-repeating-subfields]').on('scheming.subfield-group-init', function() {
-    $(this).find('div.scheming-subfield-group').last()
-        .find('span.wb-date-wrap.input-group').each(function(i, obj) {
-      // discard broken polyfill
-      var $clean = $(obj).clone().find('input').first()
-        .removeClass('wb-init wb-date-inited picker-field');
-      $(obj).replaceWith($clean);
+window.addEventListener('load',function(_e){
+  $(document).ready(function() {
+    // late init for date polyfill on scheming subforms
+    $('fieldset[name=scheming-repeating-subfields]').on('scheming.subfield-group-init', function() {
+      $(this).find('div.scheming-subfield-group').last()
+          .find('span.wb-date-wrap.input-group').each(function(i, obj) {
+        // discard broken polyfill
+        var $clean = $(obj).clone().find('input').first()
+          .removeClass('wb-init wb-date-inited picker-field');
+        $(obj).replaceWith($clean);
+      });
+      // reapply polyfills, make sure to use wet's jQuery object
+      $wetjq('input[type=date]').trigger('wb-init.wb-date');
     });
-    // reapply polyfills, make sure to use wet's jQuery object
-    $wetjq('input[type=date]').trigger('wb-init.wb-date');
   });
 });

--- a/ckanext/canada/plugins.py
+++ b/ckanext/canada/plugins.py
@@ -50,7 +50,6 @@ class DataGCCAInternal(p.SingletonPlugin):
     p.implements(p.IActions)
     p.implements(p.IResourceUrlChange)
     p.implements(p.IBlueprint)
-    p.implements(p.IOrganizationController)
 
     def update_config(self, config):
         p.toolkit.add_template_directory(config, 'templates/internal')
@@ -232,22 +231,13 @@ ckanext.validation:presets.json
         """
         All datasets on registry should now be marked private
         """
-        from ckan.model.group import Group
-        if isinstance(pkg, Group):
-            try:
-                title_tranlated = pkg._extras['title_translated'].value
-                pkg.title = title_tranlated['en'] + " | " + title_tranlated['fr']
-            except TypeError:
-                title_tranlated = json.loads(pkg._extras['title_translated'].value)
-                pkg.title = title_tranlated['en'] + " | " + title_tranlated['fr']
-        else:
-            pkg.private = True
+        pkg.private = True
 
     def edit(self, pkg):
         """
         All datasets on registry should now be marked private
         """
-        self.create(pkg)
+        pkg.private = True
 
     def get_actions(self):
         return dict(

--- a/ckanext/canada/schemas/organization.yaml
+++ b/ckanext/canada/schemas/organization.yaml
@@ -198,7 +198,7 @@ fields:
     value: "adminaircraft"
   form_snippet: multiple_checkbox.html
   display_snippet: multiple_choice.html
-  validators: scheming_multiple_choice protect_reporting_requirements ati_email_validate
+  validators: scheming_required scheming_multiple_choice protect_reporting_requirements ati_email_validate
   output_validators: scheming_multiple_choice_output
 
 # Field = ATI Email.
@@ -210,7 +210,7 @@ fields:
   help_text:
     en: The email for access to information completed request summaries
     fr: Courriel de la accès à l’information sommaires de demandes complétées
-  validators: email_validator
+  validators: scheming_required email_validator
   display_snippet: email_with_parameters.html
 
 # Field = Opengov Email.
@@ -222,5 +222,5 @@ fields:
   help_text:
     en: The email for open government
     fr: Courriel de la gouvernement ouvert
-  validators: email_validator
+  validators: scheming_required email_validator
   display_snippet: email_with_parameters.html

--- a/ckanext/canada/templates/internal/organization/base_form_page.html
+++ b/ckanext/canada/templates/internal/organization/base_form_page.html
@@ -2,6 +2,6 @@
 
 {% block primary_content_inner %}
   {% block form %}
-    {{ c.form | safe }}
+    {{ form | safe }}
   {% endblock %}
 {% endblock %}

--- a/ckanext/canada/templates/internal/recombinant/resource_edit.html
+++ b/ckanext/canada/templates/internal/recombinant/resource_edit.html
@@ -1,9 +1,7 @@
 {% ckan_extends %}
 
-{% import 'macros/canada_read.html' as cr %}
-
 {% block organization_display %}
-  {{- cr.split_bilingual_field(org.title, h.lang()) | truncate(60) -}}
+  {{- h.get_translated(org, 'title') | truncate(60) -}}
 {% endblock %}
 
 {# we want a wide display for the table #}

--- a/ckanext/canada/templates/internal/scheming/form_snippets/_organization_select.html
+++ b/ckanext/canada/templates/internal/scheming/form_snippets/_organization_select.html
@@ -1,0 +1,4 @@
+{% ckan_extends %}
+
+{% set organizations_available = h.organizations_available('create_dataset', include_translated=True) %}
+{{ super() }}

--- a/ckanext/canada/templates/internal/scheming/form_snippets/_organization_select.html
+++ b/ckanext/canada/templates/internal/scheming/form_snippets/_organization_select.html
@@ -1,4 +1,0 @@
-{% ckan_extends %}
-
-{% set organizations_available = h.organizations_available('create_dataset', include_translated=True) %}
-{{ super() }}

--- a/ckanext/canada/templates/internal/scheming/form_snippets/organization.html
+++ b/ckanext/canada/templates/internal/scheming/form_snippets/organization.html
@@ -1,7 +1,8 @@
 {% ckan_extends %}
 
 {% block organization_option %}
-  <option value="{{ organization.id }}" {% if selected_org %} selected="selected" {% endif %}>{{ organization.title }}</option>
+  {% set title = h.get_translated(organization, 'title') %}
+  <option value="{{ organization.id }}" {% if selected_org %} selected="selected" {% endif %}>{{ title }}</option>
 {% endblock %}
 
 {% block package_metadata_fields_visibility %}

--- a/ckanext/canada/templates/internal/scheming/form_snippets/organization.html
+++ b/ckanext/canada/templates/internal/scheming/form_snippets/organization.html
@@ -1,10 +1,7 @@
 {% ckan_extends %}
 
-{% import 'macros/canada_read.html' as cr %}
-
 {% block organization_option %}
-  {% set title = cr.split_bilingual_field(organization.title, h.lang())[:70] %}
-  <option value="{{ organization.id }}" {% if selected_org %} selected="selected" {% endif %}>{{ title }}</option>
+  <option value="{{ organization.id }}" {% if selected_org %} selected="selected" {% endif %}>{{ organization.title }}</option>
 {% endblock %}
 
 {% block package_metadata_fields_visibility %}

--- a/ckanext/canada/templates/internal/scheming/form_snippets/organization.html
+++ b/ckanext/canada/templates/internal/scheming/form_snippets/organization.html
@@ -1,7 +1,7 @@
 {% ckan_extends %}
 
 {% block organization_option %}
-  {% set title = h.get_translated(organization, 'title') %}
+  {% set title = h.get_translated(organization, 'title')[:70] %}
   <option value="{{ organization.id }}" {% if selected_org %} selected="selected" {% endif %}>{{ title }}</option>
 {% endblock %}
 

--- a/ckanext/canada/templates/internal/scheming/form_snippets/ro_org.html
+++ b/ckanext/canada/templates/internal/scheming/form_snippets/ro_org.html
@@ -5,7 +5,7 @@
 <div class="col-md-8">
 {% if data[field.field_name] %}
 {% set org = h.get_organization(data[field.field_name]) %}
-{{cr.split_bilingual_field(org.title or org.name, h.lang())}}
+{{ h.get_translated(org, 'title') }}
 {% endif %}
 </div>
 </div>

--- a/ckanext/canada/templates/internal/snippets/publish_facet.html
+++ b/ckanext/canada/templates/internal/snippets/publish_facet.html
@@ -1,5 +1,3 @@
-{% import 'macros/canada_read.html' as cr %}
-
 {% set facet_name = title + 's' %}
 
 {% with items = items or h.get_facet_items_dict(name, limit=5) %}

--- a/ckanext/canada/templates/internal/user/read_base.html
+++ b/ckanext/canada/templates/internal/user/read_base.html
@@ -1,5 +1,4 @@
 {% ckan_extends %}
-{% import 'macros/canada_read.html' as cr %}
 
 {% block breadcrumb_content %}
   {{ h.build_nav('user.index', _('Users')) }}
@@ -22,7 +21,7 @@
         <dd><ul>
           {% for org in h.user_organizations(user) %}
             {% set url = h.url_for(org.type ~ '_read', action='read', id=org.name) %}
-            <li><a href="{{ url }}">{{cr.split_bilingual_field(org.title, h.lang())}}</a></li>
+            <li><a href="{{ url }}">{{ h.get_translated(org, 'title') }}</a></li>
           {% endfor %}
         </ul></dd>
       </dl>

--- a/ckanext/canada/templates/public/organization/edit_base.html
+++ b/ckanext/canada/templates/public/organization/edit_base.html
@@ -1,3 +1,2 @@
 {% ckan_extends %}
-{% import 'macros/canada_read.html' as cr %}
-{% block subtitle %}{{ cr.split_bilingual_field(c.group_dict.display_name, client_lang) }}{% endblock %}
+{% block subtitle %}{{ h.get_translated(c.group_dict, 'title') }}{% endblock %}

--- a/ckanext/canada/templates/public/organization/read_base.html
+++ b/ckanext/canada/templates/public/organization/read_base.html
@@ -1,5 +1,4 @@
 {% ckan_extends %}
-{% import 'macros/canada_read.html' as cr %}
 
 {% block breadcrumb_content %}
   <li>{% link_for _('Organizations'), controller='organization', action='index' %}</li>

--- a/ckanext/canada/templates/public/organization/snippets/organization_item.html
+++ b/ckanext/canada/templates/public/organization/snippets/organization_item.html
@@ -1,11 +1,10 @@
-{% import 'macros/canada_read.html' as cr %}
 {% set url = h.url_for(organization.type ~ '_read', action='read', id=organization.name) %}
 <dt style="width:auto;"><a href="{{ url }}" title="{%- if organization.description -%}
      {{ h.truncate(organization.description, length=80, whole_word=True)}}
    {%- else -%}
      {{ _('This organization has no description') }}
   {%- endif -%}">
-  {{ h.truncate(cr.split_bilingual_field(organization.display_name, h.lang()), length=70, whole_word=True) }}</a>
+  {{ h.truncate( h.get_translated(organization, 'title'), length=70, whole_word=True) }}</a>
 </dt>
 <dd class="text-right">
   {%- if organization.package_count -%}

--- a/ckanext/canada/templates/public/package/deleted.html
+++ b/ckanext/canada/templates/public/package/deleted.html
@@ -1,5 +1,4 @@
 {% ckan_extends %}
-{% import 'macros/canada_read.html' as cr %}
 
 {% block primary_content_inner %}
 <div clss="module info alert alert-info">
@@ -13,7 +12,7 @@
     <dd>{{ h.date_str_to_datetime(modified).strftime('%Y-%m-%d') }}</dd>
     {% if organization %}
     <dt>{{ _('Organization') }}</dt>
-    <dd>{{ cr.split_bilingual_field(organization, h.lang()) }}</dd>
+    <dd>{{ h.get_translated(organization, 'title') }}</dd>
     {% endif %}
   </dl>
   <p class="module-content">

--- a/ckanext/canada/templates/public/package/read.html
+++ b/ckanext/canada/templates/public/package/read.html
@@ -1,5 +1,4 @@
 {% ckan_extends %}
-{% import 'macros/canada_read.html' as cr %}
 
 {% set pkg = c.pkg_dict %}
 {% set client_lang = h.lang() %}
@@ -50,7 +49,7 @@
     {%- endblock -%}
 
     {% if (pkg.organization.name == 'ab' or pkg.organization.name == 'qc' or pkg.organization.name == 'bc-cb' or pkg.organization.name == 'on') %}
-    {% set owner_org_title = cr.split_bilingual_field(pkg.organization.title, h.lang()) %}
+    {% set owner_org_title = h.get_translated(pkg.organization, 'title') %}
     <section>
       <details class="alert alert-info" id="alberta-content" open="open">
         <summary class="h4">
@@ -71,7 +70,7 @@
         {# For legacy reasons, organization titles are not stores the same way as
         other multilingual fields, so special case it. #}
         {% set owner_org = h.scheming_field_by_name(schema.dataset_fields, 'owner_org') %}
-        {% set owner_org_title = cr.split_bilingual_field(pkg.organization.title, h.lang()) %}
+        {% set owner_org_title = h.get_translated(pkg.organization, 'title') %}
         <li class="list-group-item">
           <strong>{{ h.scheming_language_text(owner_org.label) }}:</strong>
           {{ owner_org_title }}

--- a/ckanext/canada/templates/public/package/read_base.html
+++ b/ckanext/canada/templates/public/package/read_base.html
@@ -16,7 +16,7 @@
 {% endblock %}
 
 {%- block adobe_analytics_creator -%}
-  {% set owner_org_title = cr.split_bilingual_field(pkg.organization.title, h.lang()) %}
+  {% set owner_org_title = h.get_translated(pkg.organization, 'title') %}
   {# remove encode when moving from fanstatic - applied as a fix for OPEN-1566 #}
   <meta property="dcterms:creator" content="{{ _('Treasury Board of Canada Secretariat').encode('ascii', 'xmlcharrefreplace') | safe }}"
   {%- if 'org_section' in pkg and h.scheming_language_text(pkg.org_section) %}

--- a/ckanext/canada/templates/public/package/search.html
+++ b/ckanext/canada/templates/public/package/search.html
@@ -1,6 +1,5 @@
 {# vim: set filetype=jinja sw=2 sts=2: #}
 {% ckan_extends %}
-{% import 'macros/canada_read.html' as cr %}
 
 {%- block api_access_info -%}
   <!-- We want this block to be empty in the canada extension -->

--- a/ckanext/canada/templates/public/package/snippets/schemaorg.html
+++ b/ckanext/canada/templates/public/package/snippets/schemaorg.html
@@ -46,7 +46,7 @@
         {% if date_published in data %}<span property="datePublished">{{ data.date_published[:10] }}</span>{% endif %}
         <span property="dateModified">{{ data.metadata_modified[:10] }}</span>
         <span property="publisher" typeof="Organization">
-    <span property="name">{{ cr.split_bilingual_field(data.organization.title, h.lang()) }}</span>
+    <span property="name">{{ h.get_translated(data.organization, 'title') }}</span>
         <span property="email">{{ data.maintainer_email }}</span>
         </span>
         {%- if data.get('time_period_coverage_start') -%}

--- a/ckanext/canada/templates/public/snippets/activities/deleted_datastore.html
+++ b/ckanext/canada/templates/public/snippets/activities/deleted_datastore.html
@@ -1,5 +1,3 @@
-{% import 'macros/canada_read.html' as cr %}
-
 <li class="item {{ activity.activity_type|replace(' ', '-')|lower }}">
   <i class="fa icon fa-file"></i>
   <p>

--- a/ckanext/canada/templates/public/snippets/facet_list.html
+++ b/ckanext/canada/templates/public/snippets/facet_list.html
@@ -1,5 +1,4 @@
 {% ckan_extends %}
-{% import 'macros/canada_read.html' as cr %}
 
 {% set facet_name = title + 's' %}
 
@@ -22,7 +21,7 @@
               <ul class="list-unstyled list-facets">
                 {% for item in items %}
                   {% do item.update({'label': h.scheming_choices_label(scheming_choices, item.name)
-                    if scheming_choices else cr.split_bilingual_field(item.display_name, h.lang()) }) %}
+                    if scheming_choices else h.get_translated(item, 'title') }) %}
                 {% endfor %}
 
                 {%- macro _text_key(d) -%}

--- a/ckanext/canada/templates/public/snippets/organization.html
+++ b/ckanext/canada/templates/public/snippets/organization.html
@@ -11,7 +11,6 @@ Example:
 
 #}
 
-{% import 'macros/canada_read.html' as cr %}
 
 {% with truncate=truncate or 0, url=h.url_for(controller='organization', action='read', id=organization.name) %}
 <div class="panel panel-info">

--- a/ckanext/canada/templates/public/user/dashboard.html
+++ b/ckanext/canada/templates/public/user/dashboard.html
@@ -1,7 +1,5 @@
 {% ckan_extends %}
 
-{% import 'macros/canada_read.html' as cr %}
-
 {% block font_awesome %}<link href="{{ wet_server }}/font-awesome/css/font-awesome.css" rel="stylesheet">{% endblock %}
 
 {% block primary_content_inner %}

--- a/ckanext/canada/templates/public/user/read.html
+++ b/ckanext/canada/templates/public/user/read.html
@@ -17,7 +17,6 @@
 {% endblock %}
 
 
-{% import 'macros/canada_read.html' as cr %}
 
 {%- block other_info -%}
   <h3>{{_('Organizations')}}</h3>
@@ -25,7 +24,7 @@
 
   {% for org in h.user_organizations(user) %}
     {% set url = h.url_for(org.type ~ '_read', action='read', id=org.name) %}
-    <li><a href="{{ url }}">{{cr.split_bilingual_field(org.title, h.lang())}}</a></li>
+    <li><a href="{{ url }}">{{ h.get_translated(org, 'title') }}</a></li>
   {% endfor %}
   </ul>
 {%- endblock -%}


### PR DESCRIPTION
…or package edit to catch some errors. Fixed organization edit form, flask view no longer uses `c.form`. Implemented `IOrganizationController` in `canada_internal` plugin to process the organization titles and save them into the database. Simplified the organization select options form snippet to just access the title field directly.

I tested this with the API and it works with the web form and the API action.