### PR TITLE
Modified org form template. Added `scheming_required` to some of the …

### DIFF
--- a/ckanext/canada/plugins.py
+++ b/ckanext/canada/plugins.py
@@ -616,6 +616,8 @@ class DataGCCAForms(p.SingletonPlugin, DefaultDatasetForm):
                 validators.canada_sort_prop_status,
             'no_future_date':
                 validators.no_future_date,
+            'canada_org_title_translated_save':
+                validators.canada_org_title_translated_save,
             'canada_org_title_translated_output':
                 validators.canada_org_title_translated_output,
             'protect_reporting_requirements':

--- a/ckanext/canada/schemas/organization.yaml
+++ b/ckanext/canada/schemas/organization.yaml
@@ -40,7 +40,7 @@ fields:
     size: 75
   display_snippet: fluent_text.html
   error_snippet: fluent_text.html
-  validators: fluent_text unicode scheming_required
+  validators: fluent_text unicode scheming_required canada_org_title_translated_save
   output_validators: canada_org_title_translated_output
 
 # Field = Short Form.
@@ -198,7 +198,7 @@ fields:
     value: "adminaircraft"
   form_snippet: multiple_checkbox.html
   display_snippet: multiple_choice.html
-  validators: scheming_multiple_choice protect_reporting_requirements ati_email_validate
+  validators: scheming_required scheming_multiple_choice protect_reporting_requirements ati_email_validate
   output_validators: scheming_multiple_choice_output
 
 # Field = ATI Email.
@@ -210,7 +210,7 @@ fields:
   help_text:
     en: The email for access to information completed request summaries
     fr: Courriel de la accès à l’information sommaires de demandes complétées
-  validators: email_validator
+  validators: scheming_required email_validator
   display_snippet: email_with_parameters.html
 
 # Field = Opengov Email.
@@ -222,5 +222,5 @@ fields:
   help_text:
     en: The email for open government
     fr: Courriel de la gouvernement ouvert
-  validators: email_validator
+  validators: scheming_required email_validator
   display_snippet: email_with_parameters.html

--- a/ckanext/canada/templates/internal/organization/base_form_page.html
+++ b/ckanext/canada/templates/internal/organization/base_form_page.html
@@ -2,6 +2,6 @@
 
 {% block primary_content_inner %}
   {% block form %}
-    {{ c.form | safe }}
+    {{ form | safe }}
   {% endblock %}
 {% endblock %}

--- a/ckanext/canada/validators.py
+++ b/ckanext/canada/validators.py
@@ -261,6 +261,14 @@ def no_future_date(key, data, errors, context):
     return value
 
 
+def canada_org_title_translated_save(key, data, errors, context):
+    try:
+        title_translated = fluent_text_output(data[key])
+        data[('title',)] = title_translated['en'] + ' | ' + title_translated['fr']
+    except KeyError:
+        raise StopOnError
+
+
 def canada_org_title_translated_output(key, data, errors, context):
     """
     Return a value for the title field in organization schema using a multilingual dict in the form EN | FR.


### PR DESCRIPTION
…org fields. Added `canada_org_title_translated_save` validator to the org `title_translated` field to save the title into that database.

This is the interim solution for us to schemas and translations not being executed with groups/orgs in ckan.

It just adds the validator which basically mimics the existing output validator for `title_translated`