### PR TITLE
override datatable_column_label block 

### DIFF
--- a/ckanext/canada/templates/public/datatables/datatables_form.html
+++ b/ckanext/canada/templates/public/datatables/datatables_form.html
@@ -1,6 +1,6 @@
 {% ckan_extends %}
 
-{%- block dict_field_label scoped -%}
+{%- block dict_field_label -%}
   {%- set label = 'label_' + h.lang() -%}
   {{ f.get('info', {})[label] }}
 {%- endblock -%}

--- a/ckanext/canada/templates/public/datatables/datatables_form.html
+++ b/ckanext/canada/templates/public/datatables/datatables_form.html
@@ -1,0 +1,6 @@
+{% ckan_extends %}
+
+{%- block dict_field_label scoped -%}
+  {%- set label = 'label_' + h.lang() -%}
+  {{ f.get('info', {})[label] }}
+{%- endblock -%}

--- a/ckanext/canada/templates/public/datatables/datatables_view.html
+++ b/ckanext/canada/templates/public/datatables/datatables_view.html
@@ -1,0 +1,11 @@
+{% ckan_extends %}
+
+{%- block datatable_column_label -%}
+  {%- set label = 'label_' + h.lang() -%}
+  {%- if label in field.info and field.info[label] -%}
+    {{ field.info[label] }}
+  {%- else -%}
+    {{ field.id }}
+  {%- endif -%}
+{%- endblock -%}
+

--- a/ckanext/canada/templates/public/datatables/datatables_view.html
+++ b/ckanext/canada/templates/public/datatables/datatables_view.html
@@ -3,7 +3,8 @@
 {%- block datatable_column_label -%}
   {%- set label = 'label_' + h.lang() -%}
   {%- if label in field.info and field.info[label] -%}
-    {{ field.info[label] }}
+    {# remove encode when upgrading to CKAN 2.9 - applied as a fix for OPEN-2054 #}
+    {{ field.info[label].encode('ascii', 'xmlcharrefreplace') | safe }}
   {%- else -%}
     {{ field.id }}
   {%- endif -%}


### PR DESCRIPTION
override `datatable_column_label` block in datatables ckan extension to display language specific column labels