### PR TITLE
Added `NotFound` exception handling to `portal_update` processing to …

### DIFF
--- a/ckanext/canada/commands.py
+++ b/ckanext/canada/commands.py
@@ -353,11 +353,12 @@ class CanadaCommand(CkanCommand):
         for result in data:
             package_id = result['package_id']
             try:
-              source_package = registry.action.package_show(id=package_id)
-              source_package = get_datastore_and_views(source_package, registry)
-              packages.append(json.dumps(source_package))
+                source_package = registry.action.package_show(id=package_id)
             except NotFound:
-              print package_id + " not found in database."
+                print package_id + " not found in database."
+            else:
+                source_package = get_datastore_and_views(source_package, registry)
+                packages.append(json.dumps(source_package))
 
         if data:
             since_time = isodate(data[-1]['timestamp'], None)

--- a/ckanext/canada/commands.py
+++ b/ckanext/canada/commands.py
@@ -352,9 +352,12 @@ class CanadaCommand(CkanCommand):
         packages = []
         for result in data:
             package_id = result['package_id']
-            source_package = registry.action.package_show(id=package_id)
-            source_package = get_datastore_and_views(source_package, registry)
-            packages.append(json.dumps(source_package))
+            try:
+              source_package = registry.action.package_show(id=package_id)
+              source_package = get_datastore_and_views(source_package, registry)
+              packages.append(json.dumps(source_package))
+            except NotFound:
+              print package_id + " not found in database."
 
         if data:
             since_time = isodate(data[-1]['timestamp'], None)


### PR DESCRIPTION
…not fail on purged packages.

The dataset_purge action does not delete related activities. Our `portal_update` command gathers the `object_id`s from the activities table, and uses those ids to gather the package objects. However if you have purged a package, this cases and error.

This new try catch will handle the `NotFound` exception that is raised from the `package_show` action call.