### PR TITLE
Removed `license_title`, `license_title_fra`, `license_url_fra`, and …

### DIFF
--- a/ckanext/canada/commands.py
+++ b/ckanext/canada/commands.py
@@ -760,8 +760,7 @@ def _trim_package(pkg):
             'version', 'tracking_summary',
             'tags', # just because we don't use them
             'num_tags', 'num_resources', 'maintainer',
-            'isopen', 'relationships_as_object', 'license_title',
-            'license_title_fra', 'license_url_fra', 'license_url',
+            'isopen', 'relationships_as_object',
             'author',
             'groups', # just because we don't use them
             'relationships_as_subject', 'department_number',


### PR DESCRIPTION
…`license_url` from the `_trim_package` method.