### PR TITLE
Added `readonly` and `size` form attributes to the organization `name…

### DIFF
--- a/ckanext/canada/schemas/organization.yaml
+++ b/ckanext/canada/schemas/organization.yaml
@@ -86,6 +86,9 @@ fields:
         langues puis l'utiliser une fois, par ex. pour "statcan", l'URL est créée sous la forme https://registry.open.canada.ca/en/organization/statcan
   required: true
   validators: not_empty unicode name_validator group_name_validator
+  form_attrs:
+    readonly: true
+    size: 45
 
 # Field = Department Number.
 # {The organization's Department Number}


### PR DESCRIPTION
…` (`url`) field.

I also added size 45 to the field to make the generated url more visible to the biz team. The generated url can get long if the English and French abbreviations are different from each other.