### PR TITLE
Updated download uri for country codes.

### DIFF
--- a/bin/download_country.py
+++ b/bin/download_country.py
@@ -9,7 +9,7 @@ import os.path
 OUTPUT_FILE = os.path.join(os.path.split(__file__)[0],
     '../ckanext/canada/tables/choices/country.json')
 
-DATA_URL = 'https://raw.github.com/datasets/country-codes/master/data/country-codes.csv'
+DATA_URL = 'https://raw.githubusercontent.com/datasets/country-codes/master/data/country-codes.csv'
 
 choices = {}
 


### PR DESCRIPTION
Old download URI 503 errors: https://raw.github.com/datasets/country-codes/master/data/country-codes.csv