### PR TITLE
Removed Old API Key Generation Ability

### DIFF
--- a/ckanext/canada/templates/internal/user/edit_user_form.html
+++ b/ckanext/canada/templates/internal/user/edit_user_form.html
@@ -39,17 +39,17 @@
   </fieldset>
 
   <div class="form-actions">
+    {{ form.required_message() }}
     {% block delete_button %}
       {% if h.check_access('user_delete', {'id': data.id})  %}
         <a class="btn btn-danger pull-left" href="{% url_for 'user_delete', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this User?') }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
       {% endif %}
     {% endblock %}
     {% block generate_button %}
-      {% if h.check_access('user_generate_apikey', {'id': data.id})  %}
-        <a class="btn btn-warning" href="{% url_for 'user.generate_apikey', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to regenerate the API key?') }}">{% block generate_button_text %}{{ _('Regenerate API Key') }}{% endblock %}</a>
+      {% if h.check_access('api_token_create', {'user': data.id})  %}
+        <a class="btn btn-warning mrgn-lft-md" href="{% url_for 'user.api_tokens', id=data.name %}">{% block generate_button_text %}{{ _('Create API Token') }}{% endblock %}</a>
       {% endif %}
     {% endblock %}
-    {{ form.required_message() }}
-    <button class="btn btn-primary" type="submit" name="save">{{ _('Update Profile') }}</button>
+    <button class="btn btn-primary mrgn-lft-md" type="submit" name="save">{{ _('Update Profile') }}</button>
   </div>
 </form>

--- a/ckanext/canada/templates/public/user/edit_user_form.html
+++ b/ckanext/canada/templates/public/user/edit_user_form.html
@@ -42,17 +42,17 @@
   </details>
 
   <div class="form-actions">
+    {{ form.required_message() }}
     {% block delete_button %}
       {% if h.check_access('user_delete', {'id': data.id})  %}
         <a class="btn btn-danger pull-left" href="{% url_for 'user_delete', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this User?') }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
       {% endif %}
     {% endblock %}
     {% block generate_button %}
-      {% if h.check_access('user_generate_apikey', {'id': data.id})  %}
-        <a class="btn btn-warning" href="{% url_for 'user.generate_apikey', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to regenerate the API key?') }}">{% block generate_button_text %}{{ _('Regenerate API Key') }}{% endblock %}</a>
+      {% if h.check_access('api_token_create', {'user': data.id})  %}
+        <a class="btn btn-warning mrgn-lft-md" href="{% url_for 'user.api_tokens', id=data.name %}">{% block generate_button_text %}{{ _('Create API Token') }}{% endblock %}</a>
       {% endif %}
     {% endblock %}
-    {{ form.required_message() }}
-    <button class="btn btn-primary" type="submit" name="save">{{ _('Update Profile') }}</button>
+    <button class="btn btn-primary mrgn-lft-md" type="submit" name="save">{{ _('Update Profile') }}</button>
   </div>
 </form>

--- a/ckanext/canada/templates/public/user/read_base.html
+++ b/ckanext/canada/templates/public/user/read_base.html
@@ -51,7 +51,7 @@
         <div class="col-md-12 left-center"><strong>{{ _('Member Since') }}</strong></div>
         <div class="col-md-12 left-center">{{ h.render_datetime(user.created) }}</div>
       </div>
-      {% if is_myself %}
+      {% if is_myself and user.apikey %}
       <div class="row mrgn-tp-md">
         <div class="col-md-12 left-center"><strong>{{ _('API Key') }} <span
             class="label" title="{{ _('This means only you can see this') }}">{{ _('Private') }}</span></strong></div>


### PR DESCRIPTION
feat(users): api keys to tokens;

- Removed links to generate old API keys.
- Added button links to the new tokens page.

As discussed, we are going to prevent the generation of the old user API Keys, and try to move users to create the new API Tokens. We need to keep the old API Keys still to allow users to use the API with them. And we will keep the "Show API Key" popup link still for users that already have a generated old API Key.

To discuss:
* What will the communication to users be with the move from API Keys to Tokens?
* Will we need to add more messaging in the user pages to help with API Token generation and usage?
* Will we want to eventually fully discontinue the old API Keys?