### PR TITLE
SOLR 8 Default Operators for Search and Query Request Handlers

### DIFF
--- a/conf/solr/ati/solrconfig.xml
+++ b/conf/solr/ati/solrconfig.xml
@@ -698,6 +698,7 @@
     <lst name="defaults">
       <str name="echoParams">explicit</str>
       <int name="rows">10</int>
+      <str name="q.op">AND</str>
       <!-- Default search field
          <str name="df">text</str> 
         -->
@@ -765,6 +766,7 @@
       <str name="echoParams">explicit</str>
       <str name="wt">json</str>
       <str name="indent">true</str>
+      <str name="q.op">AND</str>
     </lst>
   </requestHandler>
 

--- a/conf/solr/solrconfig.xml
+++ b/conf/solr/solrconfig.xml
@@ -698,6 +698,7 @@
     <lst name="defaults">
       <str name="echoParams">explicit</str>
       <int name="rows">10</int>
+      <str name="q.op">AND</str>
       <!-- Default search field
          <str name="df">text</str> 
         -->
@@ -765,6 +766,7 @@
       <str name="echoParams">explicit</str>
       <str name="wt">json</str>
       <str name="indent">true</str>
+      <str name="q.op">AND</str>
     </lst>
   </requestHandler>
 


### PR DESCRIPTION
fix(solr): added default operator to request handlers;

- Added `q.op` default value to select and query request handlers.