### PR TITLE
HTTP Error Message due to no Webob or Paste

### DIFF
--- a/ckanext/canada/templates/internal/error_document_template.html
+++ b/ckanext/canada/templates/internal/error_document_template.html
@@ -9,9 +9,7 @@
 {% block primary %}
   <div class="row">
     <div class="col-md-12">
-      {% set err_msg = content.split('</h1>') %}
-      {% set err_reason = content.split('<h1>') %}
-      <p class="mrgn-tp-lg"><strong>{{ err_reason[0] | striptags }}: </strong>{{ err_msg[1] | striptags }}</p>
+      <p class="mrgn-tp-lg"><strong>{{ content }}</strong></p>
       {% if code[0] == '403' %}
         {% if not c.userobj %}
         <p class="mrgn-tp-lg">{{ _('You are not logged in to the Open Government Registry.

--- a/ckanext/canada/view.py
+++ b/ckanext/canada/view.py
@@ -223,7 +223,7 @@ def create_pd_record(owner_org, resource_name):
             {'user': g.user, 'auth_user_obj': g.userobj},
             {'resource_id': res['id']})
     except NotAuthorized:
-        return abort(403, _('Unauthorized'))
+        return abort(403, _('Unauthorized to create a resource for this package'))
 
     choice_fields = {
         f['datastore_id']: [
@@ -317,7 +317,7 @@ def update_pd_record(owner_org, resource_name, pk):
             {'user': g.user, 'auth_user_obj': g.userobj},
             {'resource_id': res['id']})
     except NotAuthorized:
-        abort(403, _('Unauthorized'))
+        abort(403, _('Unauthorized to update dataset'))
 
     choice_fields = {
         f['datastore_id']: [
@@ -333,7 +333,7 @@ def update_pd_record(owner_org, resource_name, pk):
         resource_id=res['id'],
         filters=pk_filter)['records']
     if len(records) == 0:
-        abort(404, _('Not found'))
+        abort(404, _('Not Found'))
     if len(records) > 1:
         abort(400, _('Multiple records found'))
     record = records[0]
@@ -542,7 +542,7 @@ def delete_datastore_table(id, resource_id):
                 force=True,  # FIXME: check url_type first?
             )
         except NotAuthorized:
-            return abort(403, _('Unauthorized'))
+            return abort(403, _(u'Unauthorized to delete resource %s') % resource_id)
         # FIXME else: render confirmation page for non-JS users
         return h.redirect_to(
             'xloader.resource_data',


### PR DESCRIPTION
fix(dev): http error messages;

- Added more verbose error messages due to no webob or paste.

As discussed, webob and paste do not have their HTTPException classes in the flask web stack dance party.

It seems like it was mainly the 403 Unothorized messages that we needed to fix. As it would just output `Unauthorized`.

I also needed to fix up the error template a little bit, as the template is only supplied with the raw exception message (a string) instead of the HTML string/render that webob/paste provided via that middleware class.