### PR TITLE
Remove Custom Licence Validator

### DIFF
--- a/ckanext/canada/plugins.py
+++ b/ckanext/canada/plugins.py
@@ -449,6 +449,9 @@ ckanext.canada:schemas/prop.yaml
         # Enable our custom DCAT profile.
         config['ckanext.dcat.rdf.profiles'] = 'euro_dcat_ap_2'
 
+        # Enable license restriction
+        config['ckan.dataset.restrict_license_choices'] = True
+
         if 'ckan.i18n_directory' in config:
             # Reload when translaton files change, because I'm slowly going
             # insane.
@@ -637,8 +640,6 @@ class DataGCCAForms(p.SingletonPlugin, DefaultDatasetForm):
                 validators.ati_email_validate,
             'isodate':
                 validators.isodate,
-            'licence_choices':
-                validators.licence_choices,
             'string_safe':
                 validators.string_safe,
             'string_safe_stop':

--- a/ckanext/canada/schemas/presets.yaml
+++ b/ckanext/canada/schemas/presets.yaml
@@ -2356,7 +2356,7 @@ presets:
       fr: Licence s’appliquant au jeu de données
     required: true
     display_snippet: canada_license.html
-    validators: scheming_required string_safe licence_choices
+    validators: scheming_required string_safe license_choices
 
 #Field = Access Restrictions.
 #Default Value = Unrestricted.

--- a/ckanext/canada/validators.py
+++ b/ckanext/canada/validators.py
@@ -326,12 +326,6 @@ def isodate(value, context):
         raise Invalid(_('Date format incorrect. Expecting YYYY-MM-DD'))
     return date
 
-def licence_choices(value, context):
-    licences = base.model.Package.get_license_register()
-    if value in licences:
-        return value
-    raise Invalid(_('Invalid licence'))
-
 def string_safe(value, context):
     if isinstance(value, text_type):
         return value


### PR DESCRIPTION
feat(dev): removed custom validator in favor of core;

- Removed custom `licence_choices` to use core `license_choices` validator and config option.

Goes with open-data/ckan PR to add `license_choices` validator.