### PR TITLE
Redirecting "contact us" footer lc messages

### DIFF
--- a/ckanext/canada/i18n/en/LC_MESSAGES/ckanext-canada.po
+++ b/ckanext/canada/i18n/en/LC_MESSAGES/ckanext-canada.po
@@ -1261,7 +1261,7 @@ msgid "/en/forms/contact-us"
 msgstr ""
 
 #: ckanext/canada/templates/public/footer.html:11
-msgid "All Contacts"
+msgid "All contacts"
 msgstr ""
 
 #: ckanext/canada/templates/public/footer.html:12

--- a/ckanext/canada/i18n/en/LC_MESSAGES/ckanext-canada.po
+++ b/ckanext/canada/i18n/en/LC_MESSAGES/ckanext-canada.po
@@ -1261,7 +1261,7 @@ msgid "/en/forms/contact-us"
 msgstr ""
 
 #: ckanext/canada/templates/public/footer.html:11
-msgid "Contact Open Government"
+msgid "All Contacts"
 msgstr ""
 
 #: ckanext/canada/templates/public/footer.html:12

--- a/ckanext/canada/i18n/fr/LC_MESSAGES/ckanext-canada.po
+++ b/ckanext/canada/i18n/fr/LC_MESSAGES/ckanext-canada.po
@@ -1400,7 +1400,7 @@ msgid "{actor} deleted the record {datastore} {datastore_detail}"
 msgstr "{actor} a supprimé le jeu de données {datastore} {datastore_detail}"
 
 # Footer links
-msgid "All Contacts"
+msgid "All contacts"
 msgstr "Toutes les coordonnées"
 
 msgid "Specialized enquiries"

--- a/ckanext/canada/i18n/fr/LC_MESSAGES/ckanext-canada.po
+++ b/ckanext/canada/i18n/fr/LC_MESSAGES/ckanext-canada.po
@@ -1400,8 +1400,8 @@ msgid "{actor} deleted the record {datastore} {datastore_detail}"
 msgstr "{actor} a supprimé le jeu de données {datastore} {datastore_detail}"
 
 # Footer links
-msgid "Contact Open Government"
-msgstr "Contactez-nous du gouvernement ouvert"
+msgid "All Contacts"
+msgstr "Toutes les coordonnées"
 
 msgid "Specialized enquiries"
 msgstr "Requêtes particulières"

--- a/ckanext/canada/templates/public/footer.html
+++ b/ckanext/canada/templates/public/footer.html
@@ -8,7 +8,7 @@
         <h2>About government</h2>
         <ul class="list-unstyled colcount-sm-2 colcount-md-3">
         {% block foot_content_inner %}
-          <li><a href="{{ _('https://open.canada.ca/en/forms/contact-us') }}" class="gl-footer">{{ _( 'Contact Open Government') }}</a></li>
+          <li><a href="{{ _('https://open.canada.ca/en/forms/contact-us') }}" class="gl-footer">{{ _( 'All contacts') }}</a></li>
           <li><a href="{{ _('https://www.canada.ca/en/government/dept.html') }}">{{ _('Departments and agencies') }}</a></li>
           <li><a href="{{ _('https://www.canada.ca/en/government/publicservice.html') }}">{{ _('Public service and military') }}</a></li>
           <li><a href="{{ _('http://news.gc.ca/') }}">{{ _('News') }}</a></li>


### PR DESCRIPTION
Hoping I updated all the "Contact Us" links directly to state "All Contacts"