### PR TITLE
Babel Config File & Updated PO's

### DIFF
--- a/ckanext/canada/i18n/ckanext-canada.pot
+++ b/ckanext/canada/i18n/ckanext-canada.pot
@@ -1,14 +1,14 @@
 # Translations template for ckanext-canada.
-# Copyright (C) 2020 ORGANIZATION
+# Copyright (C) 2023 ORGANIZATION
 # This file is distributed under the same license as the ckanext-canada project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2023.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-canada 0.4.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-01-02 13:56-0500\n"
+"POT-Creation-Date: 2023-06-28 18:22+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,11 +17,24 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.3.4\n"
 
-#: ckanext/canada/controller.py:157 ckanext/canada/controller.py:521
+#: ckanext/canada/controller.py:162 ckanext/canada/controller.py:606
 msgid "Not authorized to see this page"
 msgstr ""
 
-#: ckanext/canada/controller.py:235
+#: ckanext/canada/controller.py:246
+#: ckanext/canada/templates/internal/organization/edit_base.html:26
+#: ckanext/canada/templates/internal/package/resource_edit.html:3
+#: ckanext/canada/templates/internal/package/resource_edit_base.html:7
+#: ckanext/canada/templates/internal/package/wet_datatable.html:19
+#: ckanext/canada/templates/public/organization/read_base.html:27
+#: ckanext/canada/templates/public/organization/snippets/organization_item.html:17
+#: ckanext/canada/templates/public/package/edit.html:4
+#: ckanext/canada/templates/public/package/edit.html:8
+#: ckanext/canada/templates/public/package/snippets/resource_item.html:75
+msgid "Edit"
+msgstr ""
+
+#: ckanext/canada/controller.py:266
 msgid ""
 "<strong>Note</strong><br> The dataset has been removed from the Open "
 "Government Portal. <br/> The record may re-appear if it is re-harvested or "
@@ -29,35 +42,72 @@ msgid ""
 "catalogue in order to prevent it from reappearing."
 msgstr ""
 
-#: ckanext/canada/controller.py:253
+#: ckanext/canada/controller.py:284
 msgid "<strong>Note</strong><br> The record has been restored."
 msgstr ""
 
-#: ckanext/canada/controller.py:323
+#: ckanext/canada/controller.py:354
+msgid ""
+"The status has been added / updated for this suggested  dataset. This update "
+"will be reflected on open.canada.ca shortly."
+msgstr ""
+
+#: ckanext/canada/controller.py:363
 msgid "Resource updated."
 msgstr ""
 
-#: ckanext/canada/controller.py:355
+#: ckanext/canada/controller.py:395
 msgid "<strong>Note</strong><br>{0} is now logged in"
 msgstr ""
 
-#: ckanext/canada/controller.py:368
+#: ckanext/canada/controller.py:408
 msgid "Login failed. Bad username or password."
 msgstr ""
 
-#: ckanext/canada/controller.py:389
+#: ckanext/canada/controller.py:428
 msgid "Unauthorized to create a user"
 msgstr ""
 
-#: ckanext/canada/controller.py:457
+#: ckanext/canada/controller.py:502 ckanext/canada/controller.py:542
 msgid "Open Government Dataset Feed"
 msgstr ""
 
-#: ckanext/canada/controller.py:556
+#: ckanext/canada/controller.py:518
+msgid "Dataset not found"
+msgstr ""
+
+#: ckanext/canada/controller.py:634
+msgid " record(s) published."
+msgstr ""
+
+#: ckanext/canada/controller.py:650
+#, python-format
+msgid "Action name not known: %s"
+msgstr ""
+
+#: ckanext/canada/controller.py:671
+#, python-format
+msgid "JSON Error: %s"
+msgstr ""
+
+#: ckanext/canada/controller.py:677
+#, python-format
+msgid "Bad request data: %s"
+msgstr ""
+
+#: ckanext/canada/controller.py:703
+msgid "Access denied"
+msgstr ""
+
+#: ckanext/canada/controller.py:712 ckanext/canada/controller.py:980
+msgid "Not found"
+msgstr ""
+
+#: ckanext/canada/controller.py:771
 msgid "Account Created"
 msgstr ""
 
-#: ckanext/canada/controller.py:558
+#: ckanext/canada/controller.py:773
 msgid ""
 "Thank you for creating your account for the Open Government registry. "
 "Although your account is active, it has not yet been linked to your "
@@ -65,7 +115,7 @@ msgid ""
 "able to create or modify datasets in the registry."
 msgstr ""
 
-#: ckanext/canada/controller.py:565
+#: ckanext/canada/controller.py:780
 msgid ""
 "You should receive an email within the next business day once the account "
 "activation process has been completed. If you require faster processing of "
@@ -73,218 +123,442 @@ msgid ""
 "ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a>"
 msgstr ""
 
-#: ckanext/canada/controller.py:650 ckanext/canada/controller.py:739
+#: ckanext/canada/controller.py:872 ckanext/canada/controller.py:964
+#: ckanext/canada/controller.py:1131
 msgid "Unauthorized"
 msgstr ""
 
-#: ckanext/canada/controller.py:688
+#: ckanext/canada/controller.py:913
 msgid "This record already exists"
 msgstr ""
 
-#: ckanext/canada/controller.py:703
+#: ckanext/canada/controller.py:928
 msgid "Record Created"
 msgstr ""
 
-#: ckanext/canada/controller.py:752
-msgid "Not found"
-msgstr ""
-
-#: ckanext/canada/controller.py:754
+#: ckanext/canada/controller.py:982
 msgid "Multiple records found"
 msgstr ""
 
-#: ckanext/canada/controller.py:801
+#: ckanext/canada/controller.py:1032
 #, python-format
 msgid "Record %s Updated"
 msgstr ""
 
-#: ckanext/canada/controller.py:832
-#: ckanext/canada/templates/public/snippets/search_result_text.html:30
+#: ckanext/canada/controller.py:1063
 msgid "No organizations found"
 msgstr ""
 
-#: ckanext/canada/controller.py:836
+#: ckanext/canada/controller.py:1067
 msgid "Recombinant resource_name not found"
 msgstr ""
 
-#: ckanext/canada/controller.py:879
+#: ckanext/canada/controller.py:1109
 msgid "Number required"
 msgstr ""
 
-#: ckanext/canada/controller.py:884
+#: ckanext/canada/controller.py:1114
 msgid "Integer required"
 msgstr ""
 
-#: ckanext/canada/helpers.py:343
+#: ckanext/canada/helpers.py:387
 msgid "A system administrator"
 msgstr ""
 
-#: ckanext/canada/plugins.py:296
+#: ckanext/canada/plugins.py:365
 #: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:26
-#: ckanext/canada/templates/public/package/snippets/all_resources_list.html:35
 msgid "Portal Type"
 msgstr ""
 
-#: ckanext/canada/plugins.py:297 ckanext/canada/plugins.py:681
-#: ckanext/canada/templates/internal/user/new_user_form.html:14
+#: ckanext/canada/plugins.py:366 ckanext/canada/plugins.py:833
+#: ckanext/canada/templates/internal/user/new_user_form.html:18
 #: ckanext/canada/templates/public/package/deleted.html:15
-#: ckanext/canada/templates/public/snippets/package_item.html:52
+#: ckanext/canada/templates/public/snippets/package_item.html:61
 msgid "Organization"
 msgstr ""
 
-#: ckanext/canada/plugins.py:298
+#: ckanext/canada/plugins.py:367
 msgid "Collection Type"
 msgstr ""
 
-#: ckanext/canada/plugins.py:299 ckanext/canada/plugins.py:300
-#: ckanext/canada/plugins.py:682 ckanext/canada/plugins.py:683
+#: ckanext/canada/plugins.py:368 ckanext/canada/plugins.py:369
+#: ckanext/canada/plugins.py:834 ckanext/canada/plugins.py:835
 msgid "Keywords"
 msgstr ""
 
-#: ckanext/canada/plugins.py:301
+#: ckanext/canada/plugins.py:370
 msgid "Subject"
 msgstr ""
 
-#: ckanext/canada/plugins.py:302 ckanext/canada/plugins.py:684
-#: ckanext/canada/templates/public/package/snippets/resources_list.html:17
+#: ckanext/canada/plugins.py:371 ckanext/canada/plugins.py:836
 msgid "Format"
 msgstr ""
 
-#: ckanext/canada/plugins.py:303 ckanext/canada/plugins.py:685
-#: ckanext/canada/templates/public/package/snippets/resources_list.html:16
+#: ckanext/canada/plugins.py:372 ckanext/canada/plugins.py:837
 msgid "Resource Type"
 msgstr ""
 
-#: ckanext/canada/plugins.py:304
+#: ckanext/canada/plugins.py:373
 msgid "Maintenance and Update Frequency"
 msgstr ""
 
-#: ckanext/canada/plugins.py:305
+#: ckanext/canada/plugins.py:374
 msgid "Topic Categories"
 msgstr ""
 
-#: ckanext/canada/plugins.py:306
+#: ckanext/canada/plugins.py:375
 msgid "Spatial Representation Type"
 msgstr ""
 
-#: ckanext/canada/plugins.py:307
+#: ckanext/canada/plugins.py:376
 msgid "Map Viewer"
 msgstr ""
 
-#: ckanext/canada/plugins.py:308
+#: ckanext/canada/plugins.py:377
 msgid "Record Status"
 msgstr ""
 
-#: ckanext/canada/plugins.py:309
+#: ckanext/canada/plugins.py:378
 msgid "IMSO Approval"
 msgstr ""
 
-#: ckanext/canada/plugins.py:310
+#: ckanext/canada/plugins.py:379
 msgid "Jurisdiction"
 msgstr ""
 
-#: ckanext/canada/plugins.py:566
+#: ckanext/canada/plugins.py:380
+msgid "Suggestion Status"
+msgstr ""
+
+#: ckanext/canada/plugins.py:714
 #, python-format
 msgid "Your record %s has been saved."
 msgstr ""
 
-#: ckanext/canada/plugins.py:686
+#: ckanext/canada/plugins.py:838
 msgid "Resource Language"
 msgstr ""
 
-#: ckanext/canada/plugins.py:750
+#: ckanext/canada/plugins.py:904
 #: ckanext/canada/templates/public/package/snippets/resource_form.html:8
 msgid "Previous"
 msgstr ""
 
-#: ckanext/canada/plugins.py:750
+#: ckanext/canada/plugins.py:904
 msgid "Next"
 msgstr ""
 
-#: ckanext/canada/validators.py:73
+#: ckanext/canada/strings.py:8
+msgid ""
+"This field must be populated with an NA if an amendment is disclosed under "
+"Instrument Type."
+msgstr ""
+
+#: ckanext/canada/strings.py:9
+msgid ""
+"If N/A, then Instrument Type must be identified as a standing offer/supply "
+"arrangement (SOSA)"
+msgstr ""
+
+#: ckanext/canada/strings.py:10
+msgid ""
+"If the value XX (none) is entered, then no other value can be entered in this"
+" field."
+msgstr ""
+
+#: ckanext/canada/strings.py:11
+msgid ""
+"If the value NA (not applicable) is entered, then no other value can be "
+"entered in this field."
+msgstr ""
+
+#: ckanext/canada/strings.py:12
+msgid ""
+"This field must be NA (not applicable) if the Agreement Type or Trade "
+"Agreement field is not 0 (none) or XX (none), as applicable."
+msgstr ""
+
+#: ckanext/canada/strings.py:14
+msgid ""
+"If the value 00 (none) is entered, then no other value can be entered in this"
+" field."
+msgstr ""
+
+#: ckanext/canada/strings.py:15
+msgid ""
+"This field must contain the first three digits of a postal code in A1A format"
+" or the value \"NA\""
+msgstr ""
+
+#: ckanext/canada/strings.py:16
+msgid ""
+"This field must be N, No or Non, if the Agreement Type or Trade Agreement "
+"field is not 0 (none) or XX (none), as applicable."
+msgstr ""
+
+#: ckanext/canada/strings.py:18
+msgid ""
+"This field must be N, No or Non, if the Procurement Strategy for Aboriginal "
+"Business field is MS or VS."
+msgstr ""
+
+#: ckanext/canada/strings.py:19
+msgid ""
+"This field may only be populated with a 1 if the solicitation procedure is "
+"identified as non-competitive (TN) or Advance Contract Award Notice (AC)"
+msgstr ""
+
+#: ckanext/canada/strings.py:21
+msgid ""
+"This field may only be populated with a 0 if a Call-up against a standing "
+"offer or supply arrangement was identified in the Contracting Entity data "
+"field"
+msgstr ""
+
+#: ckanext/canada/strings.py:23
+msgid ""
+"This field may only be populated with \"0\" if the procurement was identified"
+" as non-competitive (TN) or advance contract award notice (AC)."
+msgstr ""
+
+#: ckanext/canada/strings.py:25
+msgid ""
+"This field may not be populated with 1, 2, 3 or 4 if the procurement was "
+"identified as non-competitive or Advance Contract Award Notice."
+msgstr ""
+
+#: ckanext/canada/strings.py:27
+msgid ""
+"Commodity Type of G for Goods which requires a Delivery Date and not a "
+"Contract Period Start Date. Please either change the Commodity Type to S or "
+"remove the date from the Contract Period Start Date field"
+msgstr ""
+
+#: ckanext/canada/strings.py:30
+msgid ""
+"If the value XX (none) is entered here, then the following three fields must "
+"be identified as NA or N, as applicable: Comprehensive Land Claim Agreement, "
+"Procurement Strategy for Aboriginal Business, Procurement Strategy for "
+"Aboriginal Business Incidental Indicator"
+msgstr ""
+
+#: ckanext/canada/validators.py:117
 #, python-format
 msgid "Tag \"%s\" length is less than minimum %s"
 msgstr ""
 
-#: ckanext/canada/validators.py:77
+#: ckanext/canada/validators.py:121
 #, python-format
 msgid "Tag \"%s\" length is more than maximum %i"
 msgstr ""
 
-#: ckanext/canada/validators.py:80
+#: ckanext/canada/validators.py:124
 #, python-format
 msgid "Tag \"%s\" may not contain commas"
 msgstr ""
 
-#: ckanext/canada/validators.py:83
+#: ckanext/canada/validators.py:127
 #, python-format
 msgid "Tag \"%s\" may not contain consecutive spaces"
 msgstr ""
 
-#: ckanext/canada/validators.py:90
+#: ckanext/canada/validators.py:134
 #, python-format
 msgid "Tag \"%s\" may not contain unprintable character U+%04x"
 msgstr ""
 
-#: ckanext/canada/validators.py:94
+#: ckanext/canada/validators.py:138
 #, python-format
 msgid "Tag \"%s\" may not contain separator charater U+%04x"
 msgstr ""
 
-#: ckanext/canada/validators.py:110
+#: ckanext/canada/validators.py:154
 msgid "Badly formed hexadecimal UUID string"
 msgstr ""
 
 #: ckanext/canada/templates/internal/user/new_user_form.html:6
-#: ckanext/canada/validators.py:122 ckanext/canada/validators.py:124
+#: ckanext/canada/validators.py:166 ckanext/canada/validators.py:168
 msgid "Please enter a valid email address."
 msgstr ""
 
-#: ckanext/canada/validators.py:139
+#: ckanext/canada/validators.py:183
 msgid "Invalid GeoJSON"
+msgstr ""
+
+#: ckanext/canada/validators.py:260
+msgid "Date may not be in the future when this record is marked ready to publish"
+msgstr ""
+
+#: ckanext/canada/validators.py:326
+msgid "Date format incorrect. Expecting YYYY-MM-DD"
+msgstr ""
+
+#: ckanext/canada/validators.py:333
+msgid "Invalid licence"
+msgstr ""
+
+#: ckanext/canada/validators.py:346 ckanext/canada/validators.py:360
+msgid "Must be a Unicode string value"
+msgstr ""
+
+#: ckanext/canada/validators.py:367 ckanext/canada/validators.py:378
+msgid "Must be a JSON string"
+msgstr ""
+
+#: ckanext/canada/validators.py:374
+msgid "JSON object must contain \"en\" key"
+msgstr ""
+
+#: ckanext/canada/validators.py:376
+msgid "JSON object must contain \"fr\" key"
 msgstr ""
 
 #: ckanext/canada/templates/internal/base.html:5
 msgid "Open Data Registry"
 msgstr ""
 
-#: ckanext/canada/templates/internal/header.html:16
-#: ckanext/canada/templates/internal/menu.html:9
-#: ckanext/canada/templates/public/package/snippets/schemaorg.html:23
-msgid "http://open.canada.ca"
+#: ckanext/canada/templates/internal/error_document_template.html:5
+#: ckanext/canada/templates/internal/home/quick_links.html:2
+msgid "Open Government Registry"
 msgstr ""
 
-#: ckanext/canada/templates/internal/header.html:16
-#: ckanext/canada/templates/internal/menu.html:9
-msgid "Open.Canada.ca"
+#: ckanext/canada/templates/internal/error_document_template.html:17
+msgid ""
+"You are not logged in to the Open Government Registry. Note that your login "
+"expires after 1 hour of inactivity. Click on the log in button below to log "
+"in."
 msgstr ""
 
-#: ckanext/canada/templates/internal/header.html:19
-#: ckanext/canada/templates/internal/menu.html:11
-msgid "Add to Portal"
+#: ckanext/canada/templates/internal/error_document_template.html:21
+#: ckanext/canada/templates/internal/header.html:39
+#: ckanext/canada/templates/internal/page.html:20
+#: ckanext/canada/templates/internal/user/snippets/login_form.html:22
+#: ckanext/canada/templates/public/snippets/user.html:61
+#: ckanext/canada/templates/public/user/snippets/login_form.html:22
+msgid "Log in"
 msgstr ""
 
-#: ckanext/canada/templates/internal/header.html:21
-#: ckanext/canada/templates/internal/menu.html:14
+#: ckanext/canada/templates/internal/error_document_template.html:25
+#: ckanext/canada/templates/public/error_document_template.html:6
+msgid "We couldn't find that Web page"
+msgstr ""
+
+#: ckanext/canada/templates/internal/error_document_template.html:27
+msgid ""
+"We encountered an error and are unable to serve your request. Please try "
+"again in short time or contact <a href=\"mailto:open-ouvert@tbs-sct.gc.ca"
+"\">open-ouvert@tbs-sct.gc.ca</a> if you need immediate assistance or if this "
+"issue persists. Note that your login expires after 1 hour of inactivity."
+msgstr ""
+
+#: ckanext/canada/templates/internal/error_document_template.html:29
+#: ckanext/canada/templates/public/error_document_template.html:8
+msgid "We encountered an error"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:14
+#: ckanext/canada/templates/public/snippets/user.html:11
+msgid "Signed in as"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:15
+#: ckanext/canada/templates/public/snippets/user.html:12
+msgid "View profile"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:24
+#: ckanext/canada/templates/internal/header.html:26
+#: ckanext/canada/templates/public/snippets/user.html:48
+#: ckanext/canada/templates/public/snippets/user.html:50
+msgid "Log out"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:57
+msgid "Home"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:59
+#: ckanext/canada/templates/internal/header.html:61
+#: ckanext/canada/templates/internal/home/quick_links.html:65
 #: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:30
 #: ckanext/canada/templates/internal/snippets/dataset_facets.html:2
 #: ckanext/canada/templates/public/macros/canada_read.html:180
 #: ckanext/canada/templates/public/snippets/dataset_facets.html:2
+#: ckanext/canada/templates/public/snippets/package_item.html:12
 msgid "Open Data"
 msgstr ""
 
-#: ckanext/canada/templates/internal/header.html:22
-#: ckanext/canada/templates/internal/menu.html:16
+#: ckanext/canada/templates/internal/header.html:63
+msgid "Create an Open Data Record"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:71
+#: ckanext/canada/templates/internal/home/quick_links.html:80
 #: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:32
 #: ckanext/canada/templates/internal/snippets/dataset_facets.html:4
 #: ckanext/canada/templates/public/macros/canada_read.html:181
 #: ckanext/canada/templates/public/snippets/dataset_facets.html:3
+#: ckanext/canada/templates/public/snippets/package_item.html:18
 msgid "Open Information"
 msgstr ""
 
+#: ckanext/canada/templates/internal/header.html:72
+#: ckanext/canada/templates/internal/header.html:74
+#: ckanext/canada/templates/internal/snippets/dataset_facets.html:32
+#: ckanext/canada/templates/public/macros/canada_read.html:202
+#: ckanext/canada/templates/public/snippets/package_item.html:16
+#: ckanext/canada/templates/public/snippets/package_item.html:22
+msgid "Proactive Disclosure"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:86
+msgid "Reports Tabled in Parliament"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:90
+#: ckanext/canada/templates/internal/home/quick_links.html:171
+msgid "Briefing packages"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:92
+msgid "New or incoming ministers"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:93
+msgid "New or incoming deputy heads"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:94
+msgid "Parliamentary Committee appearances for ministers"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:95
+msgid "Parliamentary Committee appearances for deputy heads"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:100
+#: ckanext/canada/templates/internal/home/quick_links.html:92
+#: ckanext/canada/templates/internal/snippets/dataset_facets.html:5
+#: ckanext/canada/templates/public/macros/canada_read.html:182
+#: ckanext/canada/templates/public/snippets/dataset_facets.html:4
+msgid "Suggested Datasets"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:101
+#: ckanext/canada/templates/internal/header.html:103
+#: ckanext/canada/templates/internal/home/quick_links.html:104
+#: ckanext/canada/templates/internal/snippets/dataset_facets.html:3
+#: ckanext/canada/templates/public/snippets/package_item.html:20
+msgid "Open Dialogue"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:106
+msgid "Consultations master dataset"
+msgstr ""
+
 #: ckanext/canada/templates/internal/admin/publish_search.html:20
-#: ckanext/canada/templates/internal/header.html:49
-#: ckanext/canada/templates/internal/menu.html:43
+#: ckanext/canada/templates/internal/header.html:111
+#: ckanext/canada/templates/internal/home/quick_links.html:117
 #: ckanext/canada/templates/public/header.html:15
 #: ckanext/canada/templates/public/header.html:26
 #: ckanext/canada/templates/public/snippets/search_form.html:67
@@ -293,10 +567,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: ckanext/canada/templates/internal/header.html:50
-#: ckanext/canada/templates/internal/menu.html:44
-#: ckanext/canada/templates/internal/snippets/menu.html:27
-#: ckanext/canada/templates/internal/snippets/menu.html:29
+#: ckanext/canada/templates/internal/header.html:112
 #: ckanext/canada/templates/internal/user/read_base.html:21
 #: ckanext/canada/templates/public/organization/index.html:26
 #: ckanext/canada/templates/public/organization/read_base.html:5
@@ -304,35 +575,12 @@ msgstr ""
 msgid "Organizations"
 msgstr ""
 
-#: ckanext/canada/templates/internal/header.html:51
-#: ckanext/canada/templates/internal/menu.html:45
+#: ckanext/canada/templates/internal/header.html:114
 msgid "FAQ"
 msgstr ""
 
-#: ckanext/canada/templates/internal/header.html:53
-#: ckanext/canada/templates/internal/menu.html:47
-#: ckanext/canada/templates/internal/snippets/menu.html:35
-#: ckanext/canada/templates/internal/snippets/menu.html:37
-#: ckanext/canada/templates/internal/snippets/user.html:49
-#: ckanext/canada/templates/internal/snippets/user.html:51
-#: ckanext/canada/templates/public/snippets/user.html:48
-#: ckanext/canada/templates/public/snippets/user.html:50
-msgid "Log out"
-msgstr ""
-
-#: ckanext/canada/templates/internal/header.html:55
-#: ckanext/canada/templates/internal/menu.html:49
-#: ckanext/canada/templates/internal/snippets/menu.html:40
-#: ckanext/canada/templates/internal/snippets/menu.html:42
-#: ckanext/canada/templates/internal/snippets/user.html:62
-#: ckanext/canada/templates/internal/user/snippets/login_form.html:20
-#: ckanext/canada/templates/public/snippets/user.html:61
-#: ckanext/canada/templates/public/user/snippets/login_form.html:22
-msgid "Log in"
-msgstr ""
-
-#: ckanext/canada/templates/internal/header.html:68
-#: ckanext/canada/templates/public/header.html:49
+#: ckanext/canada/templates/internal/header.html:124
+#: ckanext/canada/templates/public/header.html:52
 msgid "You are here:"
 msgstr ""
 
@@ -340,23 +588,49 @@ msgstr ""
 msgid "Frequently Asked Questions (FAQ)"
 msgstr ""
 
-#: ckanext/canada/templates/internal/menu.html:6
-#: ckanext/canada/templates/public/snippets/menu.html:2
-msgid "Topics menu"
+#: ckanext/canada/templates/internal/page.html:9
+msgid "Your user sessions has timed out due to inactivity"
+msgstr ""
+
+#: ckanext/canada/templates/internal/page.html:15
+msgid ""
+"If you are currently entering data on this page, you may lose it when "
+"submitted. To avoid this, you can click on the log in button below to log in "
+"again in a new tab without losing your progress and you can then keep working"
+" on this page. If you have any issues please contact <a href=\"mailto:open-"
+"ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a>."
+msgstr ""
+
+#: ckanext/canada/templates/internal/page.html:36
+msgid ""
+"Internet Explorer is no longer being supported within the Open Government "
+"Registry. Some features will not work as expected, including publication of "
+"records. Please use MS Edge or Google Chrome, or contact <a href=\"mailto"
+":open-ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a> for additional "
+"support."
 msgstr ""
 
 #: ckanext/canada/templates/internal/admin/base.html:4
-#: ckanext/canada/templates/internal/user/list.html:4
+#: ckanext/canada/templates/internal/snippets/user.html:14
+#: ckanext/canada/templates/public/snippets/user.html:23
+msgid "Admin"
+msgstr ""
+
+#: ckanext/canada/templates/internal/admin/base.html:8
+#: ckanext/canada/templates/internal/user/list.html:9
+#: ckanext/canada/templates/internal/user/list.html:17
+#: ckanext/canada/templates/internal/user/list.html:24
+#: ckanext/canada/templates/internal/user/list.html:73
 #: ckanext/canada/templates/internal/user/read_base.html:5
 msgid "Users"
 msgstr ""
 
-#: ckanext/canada/templates/internal/admin/base.html:6
+#: ckanext/canada/templates/internal/admin/base.html:9
 #: ckanext/canada/templates/public/admin/trash.html:38
 msgid "Trash"
 msgstr ""
 
-#: ckanext/canada/templates/internal/admin/base.html:7
+#: ckanext/canada/templates/internal/admin/base.html:10
 msgid "Publish Records"
 msgstr ""
 
@@ -400,7 +674,7 @@ msgstr ""
 msgid "Clear All"
 msgstr ""
 
-#: ckanext/canada/templates/internal/admin/snippets/package_item.html:8
+#: ckanext/canada/templates/internal/admin/snippets/package_item.html:9
 msgid "Publish?"
 msgstr ""
 
@@ -412,11 +686,39 @@ msgstr ""
 msgid "Publish Selected Records"
 msgstr ""
 
-#: ckanext/canada/templates/internal/home/quick_links.html:2
-msgid "Quick Links"
+#: ckanext/canada/templates/internal/ajax_snippets/api_info.html:5
+msgid "Create"
 msgstr ""
 
-#: ckanext/canada/templates/internal/home/quick_links.html:22
+#: ckanext/canada/templates/internal/ajax_snippets/api_info.html:9
+msgid "Update / Insert"
+msgstr ""
+
+#: ckanext/canada/templates/internal/datastore/snippets/dictionary_form.html:3
+msgid "Field {num}."
+msgstr ""
+
+#: ckanext/canada/templates/internal/datastore/snippets/dictionary_form.html:12
+msgid "Type Override"
+msgstr ""
+
+#: ckanext/canada/templates/internal/datastore/snippets/dictionary_form.html:20
+msgid "English Label"
+msgstr ""
+
+#: ckanext/canada/templates/internal/datastore/snippets/dictionary_form.html:24
+msgid "French Label"
+msgstr ""
+
+#: ckanext/canada/templates/internal/datastore/snippets/dictionary_form.html:28
+msgid "English Description"
+msgstr ""
+
+#: ckanext/canada/templates/internal/datastore/snippets/dictionary_form.html:32
+msgid "French Description"
+msgstr ""
+
+#: ckanext/canada/templates/internal/home/quick_links.html:58
 msgid ""
 "Welcome to the Open Government Registry. Use the Registry to add government "
 "resources that will be published on the Open Government Portal. For more "
@@ -424,59 +726,20 @@ msgid ""
 "href=\"mailto:open-ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a>."
 msgstr ""
 
-#: ckanext/canada/templates/internal/home/quick_links.html:29
-msgid "Open Data Records"
-msgstr ""
-
-#: ckanext/canada/templates/internal/home/quick_links.html:30
-msgid ""
-"Add data about Government of Canada services, financials or national "
-"demographic information that is relevant to Canadians."
-msgstr ""
-
-#: ckanext/canada/templates/internal/home/quick_links.html:33
-msgid "Open Information Records"
-msgstr ""
-
-#: ckanext/canada/templates/internal/home/quick_links.html:34
-msgid "Add information about government programs, activities and publications."
-msgstr ""
-
-#: ckanext/canada/templates/internal/home/quick_links.html:58
-msgid "Search your Organization Records"
-msgstr ""
-
-#: ckanext/canada/templates/internal/home/quick_links.html:59
-msgid "Search all records in the Registry, for your Organization."
-msgstr ""
-
-#: ckanext/canada/templates/internal/home/quick_links.html:63
-msgid "Search All Records"
-msgstr ""
-
-#: ckanext/canada/templates/internal/home/quick_links.html:64
-msgid "Add all Open Data and Information records in the Registry."
-msgstr ""
-
-#: ckanext/canada/templates/internal/home/quick_links.html:68
-msgid "View Members of your Organization"
-msgstr ""
-
-#: ckanext/canada/templates/internal/home/quick_links.html:69
-msgid "View the list of members linked to your organization."
+#: ckanext/canada/templates/internal/home/quick_links.html:146
+msgid "Proactive Publication"
 msgstr ""
 
 #: ckanext/canada/templates/internal/organization/edit_base.html:10
 #: ckanext/canada/templates/internal/package/search.html:6
 #: ckanext/canada/templates/public/organization/read_base.html:16
-#: ckanext/canada/templates/public/snippets/organization.html:38
+#: ckanext/canada/templates/public/snippets/organization.html:36
 #: ckanext/canada/templates/public/user/read.html:12
 msgid "Datasets"
 msgstr ""
 
 #: ckanext/canada/templates/internal/organization/edit_base.html:13
 #: ckanext/canada/templates/public/organization/read_base.html:19
-#: ckanext/canada/templates/public/package/activity.html:7
 msgid "Activity"
 msgstr ""
 
@@ -485,165 +748,92 @@ msgstr ""
 msgid "Edit Members"
 msgstr ""
 
-#: ckanext/canada/templates/internal/organization/edit_base.html:26
-#: ckanext/canada/templates/internal/package/resource_edit.html:3
-#: ckanext/canada/templates/internal/package/resource_edit_base.html:7
-#: ckanext/canada/templates/public/organization/read_base.html:27
-#: ckanext/canada/templates/public/organization/snippets/organization_item.html:17
-#: ckanext/canada/templates/public/package/edit.html:4
-#: ckanext/canada/templates/public/package/edit.html:8
-#: ckanext/canada/templates/public/package/read.html:18
-#: ckanext/canada/templates/public/package/snippets/all_resources_list.html:80
-#: ckanext/canada/templates/public/package/snippets/resource_item.html:47
-msgid "Edit"
+#: ckanext/canada/templates/internal/package/base_form_page.html:4
+msgid "Create Dataset"
 msgstr ""
 
-#: ckanext/canada/templates/internal/organization/member_new.html:31
-msgid "Existing User"
+#: ckanext/canada/templates/internal/package/edit_base.html:5
+msgid "Edit metadata"
 msgstr ""
 
-#: ckanext/canada/templates/internal/organization/member_new.html:35
-msgid "If you wish to add an existing user, search for their username below."
+#: ckanext/canada/templates/internal/package/edit_base.html:6
+#: ckanext/canada/templates/public/package/resources.html:5
+#: ckanext/canada/templates/public/package/snippets/resources.html:9
+msgid "Resources"
 msgstr ""
 
-#: ckanext/canada/templates/internal/organization/member_new.html:43
-#: ckanext/canada/templates/internal/user/list.html:12
-#: ckanext/canada/templates/internal/user/new_user_form.html:7
-#: ckanext/canada/templates/internal/user/snippets/login_form.html:13
-#: ckanext/canada/templates/public/user/edit_user_form.html:9
-#: ckanext/canada/templates/public/user/read_base.html:43
-#: ckanext/canada/templates/public/user/request_reset.html:11
-#: ckanext/canada/templates/public/user/snippets/login_form.html:13
-msgid "Username"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/member_new.html:50
-msgid "or"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/member_new.html:54
-msgid "New User"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/member_new.html:57
-msgid "If you wish to invite a new user, enter their email address."
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/member_new.html:60
-msgid "Email address"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/member_new.html:66
-#: ckanext/canada/templates/internal/user/list.html:14
-msgid "Role"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/member_new.html:69
-msgid "Select the role this user should have within this organization."
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/member_new.html:82
-msgid "Are you sure you want to delete this member?"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/member_new.html:83
-#: ckanext/canada/templates/internal/organization/snippets/organization_form.html:49
-#: ckanext/canada/templates/public/scheming/package/read.html:26
-msgid "Delete"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/member_new.html:85
-msgid "Update Member"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/member_new.html:89
-msgid "Add Member"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/new_organization_form.html:9
-msgid "Update Organization"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/new_organization_form.html:11
-msgid "Create Organization"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/snippets/organization_form.html:10
-#: ckanext/canada/templates/public/package/snippets/all_resources_list.html:33
-msgid "Title"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/snippets/organization_form.html:10
-msgid "My Organization"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/snippets/organization_form.html:18
-#: ckanext/canada/templates/public/package/snippets/resource_form.html:4
-msgid "URL"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/snippets/organization_form.html:18
-msgid "my-organization"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/snippets/organization_form.html:20
-msgid "Description"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/snippets/organization_form.html:20
-msgid "A little information about my organization..."
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/snippets/organization_form.html:48
-msgid "Are you sure you want to delete this Organization?"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/snippets/organization_form.html:52
-msgid "Save Organization"
-msgstr ""
-
-#: ckanext/canada/templates/internal/package/read.html:8
-#: ckanext/canada/templates/public/package/read_base.html:109
-msgid "Openness Rating"
-msgstr ""
-
-#: ckanext/canada/templates/internal/package/read.html:13
-#: ckanext/canada/templates/public/package/read_base.html:114
-msgid "one star"
+#: ckanext/canada/templates/internal/package/read.html:7
+#: ckanext/canada/templates/internal/package/read.html:9
+msgid "View on Portal"
 msgstr ""
 
 #: ckanext/canada/templates/internal/package/read.html:14
-#: ckanext/canada/templates/public/package/read_base.html:115
-msgid "two stars"
-msgstr ""
-
-#: ckanext/canada/templates/internal/package/read.html:15
-#: ckanext/canada/templates/public/package/read_base.html:116
-msgid "three stars"
+msgid "This dataset has been deleted and is no longer accessible to non-admin users"
 msgstr ""
 
 #: ckanext/canada/templates/internal/package/read.html:16
-#: ckanext/canada/templates/public/package/read_base.html:117
+msgid "Undelete"
+msgstr ""
+
+#: ckanext/canada/templates/internal/package/read.html:26
+#: ckanext/canada/templates/public/package/read_base.html:88
+msgid "Openness Rating"
+msgstr ""
+
+#: ckanext/canada/templates/internal/package/read.html:31
+#: ckanext/canada/templates/public/package/read_base.html:93
+msgid "one star"
+msgstr ""
+
+#: ckanext/canada/templates/internal/package/read.html:32
+#: ckanext/canada/templates/public/package/read_base.html:94
+msgid "two stars"
+msgstr ""
+
+#: ckanext/canada/templates/internal/package/read.html:33
+#: ckanext/canada/templates/public/package/read_base.html:95
+msgid "three stars"
+msgstr ""
+
+#: ckanext/canada/templates/internal/package/read.html:34
+#: ckanext/canada/templates/public/package/read_base.html:96
 msgid "four stars"
 msgstr ""
 
-#: ckanext/canada/templates/internal/package/read.html:17
-#: ckanext/canada/templates/public/package/read_base.html:118
+#: ckanext/canada/templates/internal/package/read.html:35
+#: ckanext/canada/templates/public/package/read_base.html:97
 msgid "five stars"
 msgstr ""
 
+#: ckanext/canada/templates/internal/package/read_base.html:4
+msgid "Dataset"
+msgstr ""
+
+#: ckanext/canada/templates/internal/package/read_base.html:5
+#: ckanext/canada/templates/public/organization/activity_stream.html:4
+#: ckanext/canada/templates/public/user/activity_stream.html:12
+msgid "Activity Stream"
+msgstr ""
+
 #: ckanext/canada/templates/internal/package/resource_edit.html:15
-#: ckanext/canada/templates/public/package/activity.html:15
 msgid "Go back"
 msgstr ""
 
-#: ckanext/canada/templates/internal/package/resource_edit_base.html:14
+#: ckanext/canada/templates/internal/package/resource_edit_base.html:15
 msgid "DataStore"
 msgstr ""
 
-#: ckanext/canada/templates/internal/package/wet_datatable.html:2
-#: ckanext/canada/templates/public/package/snippets/resource_item.html:44
+#: ckanext/canada/templates/internal/package/wet_datatable.html:11
+#: ckanext/canada/templates/public/package/snippets/resource_item.html:52
 msgid "Preview"
+msgstr ""
+
+#: ckanext/canada/templates/internal/package/wet_datatable.html:17
+msgid "Select"
+msgstr ""
+
+#: ckanext/canada/templates/internal/package/wet_datatable.html:79
+msgid "Edit in Excel"
 msgstr ""
 
 #: ckanext/canada/templates/internal/package/snippets/stages.html:21
@@ -664,6 +854,22 @@ msgstr ""
 
 #: ckanext/canada/templates/internal/package/snippets/stages.html:39
 msgid "Add data"
+msgstr ""
+
+#: ckanext/canada/templates/internal/package/snippets/view_form.html:8
+msgid "Title (English)"
+msgstr ""
+
+#: ckanext/canada/templates/internal/package/snippets/view_form.html:9
+msgid "Title (French)"
+msgstr ""
+
+#: ckanext/canada/templates/internal/package/snippets/view_form.html:10
+msgid "Description (English)"
+msgstr ""
+
+#: ckanext/canada/templates/internal/package/snippets/view_form.html:11
+msgid "Description (French)"
 msgstr ""
 
 #: ckanext/canada/templates/internal/recombinant/create_pd_record.html:3
@@ -694,23 +900,36 @@ msgstr ""
 
 #: ckanext/canada/templates/internal/recombinant/create_pd_record.html:82
 #: ckanext/canada/templates/internal/recombinant/update_pd_record.html:85
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:68
 msgid "Save"
 msgstr ""
 
-#: ckanext/canada/templates/internal/recombinant/resource_edit.html:19
+#: ckanext/canada/templates/internal/recombinant/resource_edit.html:16
+#, python-format
+msgid ""
+"Informal Requests for ATI Records Previously Released are being sent to "
+"<strong>%s.</strong> Please contact <a href=\"mailto:open-ouvert@tbs-"
+"sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a> if that address is no longer valid."
+msgstr ""
+
+#: ckanext/canada/templates/internal/recombinant/resource_edit.html:20
+msgid ""
+"Your organization does not have an Access to Information email on file. "
+"Please contact <a href=\"mailto:open-ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-"
+"sct.gc.ca</a> with the email for your organization's Access to Information "
+"Coordinator."
+msgstr ""
+
+#: ckanext/canada/templates/internal/recombinant/resource_edit.html:33
 msgid "Guide"
 msgstr ""
 
-#: ckanext/canada/templates/internal/recombinant/resource_edit.html:24
+#: ckanext/canada/templates/internal/recombinant/resource_edit.html:38
 #, python-format
 msgid ""
 "For information on how to prepare, maintain and upload templates to the "
 "Registry, refer to the appropriate documentation posted on <a "
 "href=\"%(gclink)s\">GCPEDIA</a>"
-msgstr ""
-
-#: ckanext/canada/templates/internal/recombinant/resource_edit.html:54
-msgid "Column visibility"
 msgstr ""
 
 #: ckanext/canada/templates/internal/recombinant/update_pd_record.html:3
@@ -737,6 +956,52 @@ msgstr ""
 
 #: ckanext/canada/templates/internal/recombinant/snippets/xls_upload.html:57
 msgid "Invalid choice for"
+msgstr ""
+
+#: ckanext/canada/templates/internal/scheming/form_snippets/imso_approval_select.html:38
+msgid ""
+"<small class='text-info' style='margin-bottom: 15px; display: inline-block'> "
+"<p>Has approval been obtained? By selecting yes, you have ensured that the "
+"following statements are true:</p> <ol> <li><b>Confidentiality</b> - The data"
+" or information resource is not subject to confidentiality restrictions, such"
+" as Cabinet confidences, solicitor-client privilege, classified or protected "
+"information, advice or recommendations, third party information, or "
+"information obtained in confidence.</li> <li><b>Authority to Release</b> - "
+"The institution has the mandate, legislative authority or permission from a "
+"third party provider to release the data or information resources under the "
+"<a href='https://open.canada.ca/en/open-government-licence-canada'><u>Open "
+"Government Licence – Canada</u></a>.</li> <li><b>Formats</b> - The data or "
+"information resource is in an open and accessible format that complies with "
+"<a href='https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=23601'><u>the Standard"
+" on Web Accessibility</u></a>.</li> <li><b>Privacy</b> - The data or "
+"information resource does not contain personal information, as defined in "
+"section 3 of the <a href='https://www.priv.gc.ca/en/privacy-topics/privacy-"
+"laws-in-canada/the-privacy-act/'><u>Privacy Act</u></a>, unless the "
+"individual to whom it relates has consented to its release or unless it meets"
+" criteria outlined in section 8(2) of the Privacy Act.</li> <li><b>Official "
+"Languages</b> - The data or information resource is available in both "
+"official languages and conforms to the requirements of the <a href='https"
+"://laws-lois.justice.gc.ca/eng/acts/O-3.01/'><u>Official Languages "
+"Act</u></a>.</li> <li><b>Security</b> - The data or information resource does"
+" not increase security risks to the institution, to other institutions, or to"
+" the government as a whole and conforms to the requirements of the <a "
+"href='https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=16578'><u>Policy on "
+"Government Security</u></a> and its related instruments.</li> <li><b>Other - "
+"Legal / Regulatory / Policy / Contractual</b> - The release of data or other "
+"information resource complies with all other relevant legal, regulatory, "
+"contractual, and policy requirements (e.g., it is confirmed that there are no"
+" relevant legal, contractual, or third party, policy restrictions or "
+"limitations).</li> </ol> </small>"
+msgstr ""
+
+#: ckanext/canada/templates/internal/scheming/form_snippets/repeating_subfields.html:8
+#: ckanext/canada/templates/public/macros/canada_read.html:151
+#: ckanext/canada/templates/public/macros/form.html:248
+msgid "Remove"
+msgstr ""
+
+#: ckanext/canada/templates/internal/scheming/form_snippets/repeating_subfields.html:17
+msgid "Add"
 msgstr ""
 
 #: ckanext/canada/templates/internal/scheming/form_snippets/upload_only.html:7
@@ -772,33 +1037,38 @@ msgid ""
 " describe the record type and the placement in the registry"
 msgstr ""
 
-#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:35
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:34
+#: ckanext/canada/templates/public/snippets/package_item.html:14
+msgid "Suggested Dataset"
+msgstr ""
+
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:37
 msgid ""
 "The portal to which the metadata record belongs (Open Data or Open "
 "Information)"
 msgstr ""
 
-#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:38
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:40
 msgid "Metadata Scheme"
 msgstr ""
 
-#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:41
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:43
 msgid "The name of the metadata scheme used (including profile name)"
 msgstr ""
 
-#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:44
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:46
 msgid "Metadata Scheme Version"
 msgstr ""
 
-#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:47
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:49
 msgid "The version of the metadata scheme used (version of the profile)"
 msgstr ""
 
-#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:50
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:52
 msgid "Metadata Record Identifier"
 msgstr ""
 
-#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:53
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:55
 msgid ""
 "A unique phrase or string which identifies the metadata record within the "
 "Open Government Portal"
@@ -820,67 +1090,32 @@ msgstr ""
 msgid "Use the Download URL field above to link to the related record."
 msgstr ""
 
+#: ckanext/canada/templates/internal/scheming/package/snippets/resource_form.html:60
+msgid "Data Validation"
+msgstr ""
+
 #: ckanext/canada/templates/internal/scheming/snippets/errors.html:5
 msgid "Errors in form"
 msgstr ""
 
-#: ckanext/canada/templates/internal/snippets/dataset_facets.html:3
-msgid "Open Dialogue"
+#: ckanext/canada/templates/internal/scheming/snippets/form_field.html:4
+msgid "Are you sure you want to delete this status?"
 msgstr ""
 
-#: ckanext/canada/templates/internal/snippets/dataset_facets.html:14
-#: ckanext/canada/templates/public/macros/canada_read.html:193
-msgid "Proactive Disclosure"
+#: ckanext/canada/templates/internal/scheming/snippets/form_field.html:21
+#: ckanext/canada/templates/public/organization/member_new.html:62
+#: ckanext/canada/templates/public/scheming/package/read.html:26
+msgid "Delete"
+msgstr ""
+
+#: ckanext/canada/templates/internal/snippets/dataset_facets.html:24
+#: ckanext/canada/templates/public/macros/canada_read.html:190
+#: ckanext/canada/templates/public/snippets/package_item.html:101
+msgid "Request sent to data owner – awaiting response"
 msgstr ""
 
 #: ckanext/canada/templates/internal/snippets/home_breadcrumb_item.html:2
-msgid "Home"
-msgstr ""
-
-#: ckanext/canada/templates/internal/snippets/menu.html:20
-#: ckanext/canada/templates/internal/snippets/menu.html:22
-msgid "Search Data"
-msgstr ""
-
-#: ckanext/canada/templates/internal/snippets/menu.html:49
-#: ckanext/canada/templates/internal/snippets/menu.html:51
-#: ckanext/canada/templates/internal/snippets/user.html:60
-#: ckanext/canada/templates/public/snippets/user.html:59
-msgid "Register"
-msgstr ""
-
-#: ckanext/canada/templates/internal/snippets/menu.html:58
-msgid "My Account"
-msgstr ""
-
-#: ckanext/canada/templates/internal/snippets/menu.html:60
-#: ckanext/canada/templates/internal/snippets/user.html:33
-#: ckanext/canada/templates/public/snippets/user.html:32
-msgid "Dashboard"
-msgstr ""
-
-#: ckanext/canada/templates/internal/snippets/menu.html:61
-#: ckanext/canada/templates/public/user/edit_base.html:5
-msgid "My Profile"
-msgstr ""
-
-#: ckanext/canada/templates/internal/snippets/menu.html:62
-#: ckanext/canada/templates/internal/snippets/user.html:40
-#: ckanext/canada/templates/internal/snippets/user.html:42
-#: ckanext/canada/templates/public/snippets/user.html:39
-#: ckanext/canada/templates/public/snippets/user.html:41
-msgid "Edit Profile"
-msgstr ""
-
-#: ckanext/canada/templates/internal/snippets/menu.html:65
-msgid "Publish Datasets"
-msgstr ""
-
-#: ckanext/canada/templates/internal/snippets/menu.html:71
-#: ckanext/canada/templates/internal/snippets/menu.html:73
-#: ckanext/canada/templates/public/user/dashboard.html:54
-#: ckanext/canada/templates/public/user/dashboard.html:60
-msgid "Add Dataset"
+msgid "Registry Home"
 msgstr ""
 
 #: ckanext/canada/templates/internal/snippets/publish_facet.html:22
@@ -896,7 +1131,7 @@ msgid "Pending"
 msgstr ""
 
 #: ckanext/canada/templates/internal/snippets/publish_facet.html:40
-#: ckanext/canada/templates/public/package/read.html:57
+#: ckanext/canada/templates/public/package/read.html:12
 msgid "Draft"
 msgstr ""
 
@@ -911,26 +1146,11 @@ msgid "Social"
 msgstr ""
 
 #: ckanext/canada/templates/internal/snippets/user.html:12
-#: ckanext/canada/templates/public/snippets/user.html:11
-msgid "Signed in as"
-msgstr ""
-
-#: ckanext/canada/templates/internal/snippets/user.html:13
-#: ckanext/canada/templates/public/snippets/user.html:12
-msgid "View profile"
-msgstr ""
-
-#: ckanext/canada/templates/internal/snippets/user.html:22
 #: ckanext/canada/templates/public/snippets/user.html:21
 msgid "Sysadmin settings"
 msgstr ""
 
-#: ckanext/canada/templates/internal/snippets/user.html:24
-#: ckanext/canada/templates/public/snippets/user.html:23
-msgid "Admin"
-msgstr ""
-
-#: ckanext/canada/templates/internal/snippets/user.html:30
+#: ckanext/canada/templates/internal/snippets/user.html:20
 #: ckanext/canada/templates/public/snippets/user.html:29
 #, python-format
 msgid "Dashboard (%(num)d new item)"
@@ -938,9 +1158,30 @@ msgid_plural "Dashboard (%(num)d new items)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ckanext/canada/templates/internal/snippets/user.html:34
+#: ckanext/canada/templates/internal/snippets/user.html:23
+#: ckanext/canada/templates/public/snippets/user.html:32
+msgid "Dashboard"
+msgstr ""
+
+#: ckanext/canada/templates/internal/snippets/user.html:24
 #: ckanext/canada/templates/public/snippets/user.html:33
 msgid ": "
+msgstr ""
+
+#: ckanext/canada/templates/internal/snippets/user.html:30
+#: ckanext/canada/templates/internal/snippets/user.html:32
+#: ckanext/canada/templates/public/snippets/user.html:39
+#: ckanext/canada/templates/public/snippets/user.html:41
+msgid "Edit Profile"
+msgstr ""
+
+#: ckanext/canada/templates/internal/snippets/user.html:39
+msgid "Help using the Open Government Registry"
+msgstr ""
+
+#: ckanext/canada/templates/internal/snippets/user.html:40
+#: ckanext/canada/templates/internal/snippets/user.html:43
+msgid "Get Help"
 msgstr ""
 
 #: ckanext/canada/templates/internal/snippets/activities/changed_datastore.html:6
@@ -951,22 +1192,45 @@ msgstr ""
 msgid "{actor} deleted the record {datastore} {datastore_detail}"
 msgstr ""
 
-#: ckanext/canada/templates/internal/user/list.html:6
+#: ckanext/canada/templates/internal/user/list.html:26
 msgid "Create an Account"
 msgstr ""
 
-#: ckanext/canada/templates/internal/user/list.html:13
+#: ckanext/canada/templates/internal/user/list.html:35
+#: ckanext/canada/templates/internal/user/new_user_form.html:7
+#: ckanext/canada/templates/internal/user/snippets/login_form.html:15
+#: ckanext/canada/templates/public/organization/member_new.html:29
+#: ckanext/canada/templates/public/user/edit_user_form.html:9
+#: ckanext/canada/templates/public/user/read_base.html:43
+#: ckanext/canada/templates/public/user/snippets/login_form.html:13
+msgid "Username"
+msgstr ""
+
+#: ckanext/canada/templates/internal/user/list.html:36
 #: ckanext/canada/templates/public/snippets/geomap_dynamic.html:18
 #: ckanext/canada/templates/public/snippets/geomap_static.html:15
 msgid "Name"
 msgstr ""
 
-#: ckanext/canada/templates/internal/user/list.html:27
+#: ckanext/canada/templates/internal/user/list.html:37
+#: ckanext/canada/templates/public/organization/member_new.html:59
+msgid "Role"
+msgstr ""
+
+#: ckanext/canada/templates/internal/user/list.html:52
 msgid "Sysadmin"
 msgstr ""
 
-#: ckanext/canada/templates/internal/user/list.html:27
+#: ckanext/canada/templates/internal/user/list.html:52
 msgid "Member"
+msgstr ""
+
+#: ckanext/canada/templates/internal/user/list.html:78
+msgid "Search and view users."
+msgstr ""
+
+#: ckanext/canada/templates/internal/user/list.html:80
+msgid "Search and manage users."
 msgstr ""
 
 #: ckanext/canada/templates/internal/user/login.html:9
@@ -1035,7 +1299,7 @@ msgstr ""
 #: ckanext/canada/templates/internal/user/new_user_form.html:8
 msgid ""
 "Use only lowercase letters (a-z) and numbers (0-9) with optional hyphens (-) "
-"and underscores (_)"
+"and underscores (_). Example: joe-bloggs"
 msgstr ""
 
 #: ckanext/canada/templates/internal/user/new_user_form.html:10
@@ -1043,31 +1307,39 @@ msgid "Full Name"
 msgstr ""
 
 #: ckanext/canada/templates/internal/user/new_user_form.html:11
+msgid "Example: Joe Bloggs"
+msgstr ""
+
+#: ckanext/canada/templates/internal/user/new_user_form.html:13
 #: ckanext/canada/templates/public/user/edit_user_form.html:13
-#: ckanext/canada/templates/public/user/read_base.html:49
+#: ckanext/canada/templates/public/user/read_base.html:50
 msgid "Email"
 msgstr ""
 
 #: ckanext/canada/templates/internal/user/new_user_form.html:14
-msgid "Treasury Board Secretariat"
+msgid "Example: joe.bloggs@tbs-sct.gc.ca"
 msgstr ""
 
-#: ckanext/canada/templates/internal/user/new_user_form.html:15
+#: ckanext/canada/templates/internal/user/new_user_form.html:19
 msgid "Phone Number"
 msgstr ""
 
-#: ckanext/canada/templates/internal/user/new_user_form.html:16
-#: ckanext/canada/templates/internal/user/snippets/login_form.html:15
+#: ckanext/canada/templates/internal/user/new_user_form.html:20
+msgid "Example: 000 000 0000"
+msgstr ""
+
+#: ckanext/canada/templates/internal/user/new_user_form.html:22
+#: ckanext/canada/templates/internal/user/snippets/login_form.html:17
 #: ckanext/canada/templates/public/user/edit_user_form.html:32
 #: ckanext/canada/templates/public/user/snippets/login_form.html:15
 msgid "Password"
 msgstr ""
 
-#: ckanext/canada/templates/internal/user/new_user_form.html:17
+#: ckanext/canada/templates/internal/user/new_user_form.html:23
 msgid "Confirm"
 msgstr ""
 
-#: ckanext/canada/templates/internal/user/new_user_form.html:20
+#: ckanext/canada/templates/internal/user/new_user_form.html:26
 msgid ""
 " <h2>Terms and Conditions for the Open Government Registry</h2> "
 "<p><em>Privacy Statement</em></p> <p>The Government of Canada is committed to"
@@ -1148,20 +1420,21 @@ msgid ""
 "not have access to the Registry.</p> "
 msgstr ""
 
-#: ckanext/canada/templates/internal/user/new_user_form.html:65
+#: ckanext/canada/templates/internal/user/new_user_form.html:71
 msgid "I agree"
 msgstr ""
 
-#: ckanext/canada/templates/internal/user/new_user_form.html:66
+#: ckanext/canada/templates/internal/user/new_user_form.html:72
 msgid "I do not agree"
 msgstr ""
 
 #: ckanext/canada/templates/internal/user/perform_reset.html:8
+#, python-format
 msgid ""
 "1. Passwords must contain characters from at least 3 of the following 4 "
 "classes: * Upper Case Letters: A, B, C, … Z * Lower Case Letters: a, b, c, … "
 "z * Westernised Arabic Numerals: 0, 1, 2, … 9 * Special characters: "
-"({}[],.<>;:'\"?/|\\`~!@#$%^&*()_-+=). 2. No accented characters are "
+"({}[],.<>;:'\"?/|\\`~!@#$%%^&*()_-+=). 2. No accented characters are "
 "permitted. 3. All passwords must be at least 8 characters long. "
 msgstr ""
 
@@ -1175,6 +1448,24 @@ msgstr ""
 
 #: ckanext/canada/templates/internal/user/reports.html:6
 msgid "No reports are available"
+msgstr ""
+
+#: ckanext/canada/templates/internal/user/snippets/user_search.html:2
+#: ckanext/canada/templates/internal/user/snippets/user_search.html:5
+#: ckanext/canada/templates/internal/user/snippets/user_search.html:6
+msgid "Search Users"
+msgstr ""
+
+#: ckanext/canada/templates/internal/xloader/resource_data.html:8
+msgid "Are you sure you want to delete this DataStore table and Data Dictionary?"
+msgstr ""
+
+#: ckanext/canada/templates/internal/xloader/resource_data.html:9
+msgid "Delete DataStore table"
+msgstr ""
+
+#: ckanext/canada/templates/internal/xloader/resource_data.html:18
+msgid "Upload to DataStore"
 msgstr ""
 
 #: ckanext/canada/templates/obd/package/search.html:3
@@ -1192,7 +1483,6 @@ msgid "Rate this dataset"
 msgstr ""
 
 #: ckanext/canada/templates/obd/package/snippets/socialmedia.html:9
-#: ckanext/canada/templates/public/package/snippets/socialmedia.html:9
 msgid "Comment(s)"
 msgstr ""
 
@@ -1208,28 +1498,14 @@ msgid ""
 "href=\"http://open.canada.ca/en/forms/contact-us\">contact us</a>."
 msgstr ""
 
-#: ckanext/canada/templates/public/base.html:12
+#: ckanext/canada/templates/public/base.html:14
+#: ckanext/canada/templates/public/datatables/datatables_view.html:24
+#: ckanext/canada/templates/public/package/read_base.html:21
 msgid "Treasury Board of Canada Secretariat"
 msgstr ""
 
-#: ckanext/canada/templates/public/error_document_template.html:6
-msgid "We couldn't find that Web page"
-msgstr ""
-
-#: ckanext/canada/templates/public/error_document_template.html:8
-msgid "We encountered an error"
-msgstr ""
-
-#: ckanext/canada/templates/public/error_document_template.html:18
-msgid ""
-"We encountered an error and are unable to serve your request. Please try "
-"again in short time or contact <a href=\"mailto:open-ouvert@tbs-sct.gc.ca"
-"\">open-ouvert@tbs-sct.gc.ca</a> if you need immediate assistance or if this "
-"issue persists. Note that your login expires after 1 hour of inactivity."
-msgstr ""
-
 #: ckanext/canada/templates/public/footer.html:11
-msgid "/en/forms/contact-us"
+msgid "https://open.canada.ca/en/forms/contact-us"
 msgstr ""
 
 #: ckanext/canada/templates/public/footer.html:11
@@ -1357,7 +1633,7 @@ msgid "Search Canada.ca"
 msgstr ""
 
 #: ckanext/canada/templates/public/organization/about.html:4
-#: ckanext/canada/templates/public/page.html:60
+#: ckanext/canada/templates/public/page.html:39
 #: ckanext/canada/templates/public/user/edit_user_form.html:15
 msgid "About"
 msgstr ""
@@ -1426,6 +1702,65 @@ msgstr ""
 msgid " <p>Purge deleted datasets forever and irreversibly.</p> "
 msgstr ""
 
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:9
+msgid "CKAN Data API"
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:13
+msgid "Access resource data via a web API with powerful query support"
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:14
+msgid ""
+"Further information in the <a "
+"href=\"http://docs.ckan.org/en/latest/maintaining/datastore.html\" "
+"target=\"_blank\">main CKAN Data API and DataStore documentation</a>.</p>"
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:19
+msgid "Endpoints"
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:23
+msgid "The Data API can be accessed via the following actions of the CKAN action API."
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:29
+msgid "Query"
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:33
+msgid "Query (via SQL)"
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:45
+msgid "Querying"
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:49
+msgid "Query example (first 5 results)"
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:54
+msgid "Query example (results containing 'jones')"
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:59
+msgid "Query example (via SQL statement)"
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:70
+msgid "Example: Javascript"
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:74
+msgid "A simple ajax (JSONP) request to the data API using jQuery."
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:95
+msgid "Example: Python"
+msgstr ""
+
 #: ckanext/canada/templates/public/fgpv_vpgf/index.html:2
 #: ckanext/canada/templates/public/fgpv_vpgf/index.html:5
 #: ckanext/canada/templates/public/fgpv_vpgf/index.html:10
@@ -1436,31 +1771,30 @@ msgstr ""
 msgid "Search Open Maps"
 msgstr ""
 
-#: ckanext/canada/templates/public/fgpv_vpgf/index.html:41
+#: ckanext/canada/templates/public/fgpv_vpgf/index.html:42
 #: ckanext/canada/templates/public/snippets/search_form.html:53
 msgid "List Cart Items"
 msgstr ""
 
-#: ckanext/canada/templates/public/fgpv_vpgf/index.html:76
+#: ckanext/canada/templates/public/fgpv_vpgf/index.html:75
 msgid ""
 "This interactive map requires JavaScript. To view this content please enable "
 "JavaScript in your browser or download a browser that supports it."
+msgstr ""
+
+#: ckanext/canada/templates/public/fgpv_vpgf/index.html:82
+msgid "We’re sorry, your browser version is not supported by Open Maps"
 msgstr ""
 
 #: ckanext/canada/templates/public/macros/canada_read.html:36
 msgid "Keyword"
 msgstr ""
 
-#: ckanext/canada/templates/public/macros/canada_read.html:151
-#: ckanext/canada/templates/public/macros/form.html:248
-msgid "Remove"
-msgstr ""
-
-#: ckanext/canada/templates/public/macros/canada_read.html:217
+#: ckanext/canada/templates/public/macros/canada_read.html:226
 msgid "entry"
 msgstr ""
 
-#: ckanext/canada/templates/public/macros/canada_read.html:217
+#: ckanext/canada/templates/public/macros/canada_read.html:226
 msgid "entries"
 msgstr ""
 
@@ -1478,22 +1812,12 @@ msgstr ""
 msgid "(required)"
 msgstr ""
 
-#: ckanext/canada/templates/public/macros/form.html:418
-msgid " Or "
-msgstr ""
-
-#: ckanext/canada/templates/public/macros/form.html:426
+#: ckanext/canada/templates/public/macros/form.html:438
 msgid "Clear Upload"
 msgstr ""
 
-#: ckanext/canada/templates/public/organization/activity_stream.html:4
-#: ckanext/canada/templates/public/package/activity.html:3
-#: ckanext/canada/templates/public/user/activity_stream.html:12
-msgid "Activity Stream"
-msgstr ""
-
 #: ckanext/canada/templates/public/organization/activity_stream.html:11
-#: ckanext/canada/templates/public/package/read_base.html:179
+#: ckanext/canada/templates/public/package/read_base.html:159
 msgid "Atom Feed"
 msgstr ""
 
@@ -1518,11 +1842,56 @@ msgstr ""
 msgid "How about creating one?"
 msgstr ""
 
-#: ckanext/canada/templates/public/organization/member_new.html:11
+#: ckanext/canada/templates/public/organization/member_new.html:8
+msgid "Back to all members"
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/member_new.html:9
+msgid "Edit Member"
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/member_new.html:9
+#: ckanext/canada/templates/public/organization/member_new.html:68
+msgid "Add Member"
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/member_new.html:17
+msgid "Existing User"
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/member_new.html:20
+msgid "If you wish to add an existing user, search for their username below."
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/member_new.html:39
+msgid "or"
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/member_new.html:45
+msgid "New User"
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/member_new.html:48
+msgid "If you wish to invite a new user, enter their email address."
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/member_new.html:51
+msgid "Email address"
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/member_new.html:62
+msgid "Are you sure you want to delete this member?"
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/member_new.html:64
+msgid "Update Member"
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/member_new.html:81
 msgid "What are roles?"
 msgstr ""
 
-#: ckanext/canada/templates/public/organization/member_new.html:14
+#: ckanext/canada/templates/public/organization/member_new.html:84
 msgid ""
 " <p><strong>Admin:</strong> Can add/edit and delete datasets, as well as "
 "manage organization members.</p> <p><strong>Editor:</strong> Can add and edit"
@@ -1532,7 +1901,7 @@ msgid ""
 msgstr ""
 
 #: ckanext/canada/templates/public/organization/members.html:3
-#: ckanext/canada/templates/public/snippets/organization.html:32
+#: ckanext/canada/templates/public/snippets/organization.html:30
 msgid "Members"
 msgstr ""
 
@@ -1605,48 +1974,36 @@ msgstr ""
 msgid "Return to Index"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read.html:19
-msgid "History"
-msgstr ""
-
-#: ckanext/canada/templates/public/package/read.html:23
-msgid "Undelete"
-msgstr ""
-
-#: ckanext/canada/templates/public/package/read.html:34
-msgid "This dataset has been deleted and is no longer accessible to non-admin users"
-msgstr ""
-
-#: ckanext/canada/templates/public/package/read.html:42
-#, python-format
-msgid ""
-" You're currently viewing an old version of this dataset. Some resources may "
-"no longer exist or the dataset may not display correctly. To see the current "
-"version, click <a href=\"%(url)s\">here</a>. "
-msgstr ""
-
-#: ckanext/canada/templates/public/package/read.html:60
-#: ckanext/canada/templates/public/package/read.html:66
-#: ckanext/canada/templates/public/package/snippets/resource_item.html:24
-#: ckanext/canada/templates/public/scheming/display_snippets/fluent_tags.html:17
-#: ckanext/canada/templates/public/snippets/package_item.html:29
-#: ckanext/canada/templates/public/snippets/package_item.html:43
+#: ckanext/canada/templates/public/package/read.html:15
+#: ckanext/canada/templates/public/package/read.html:40
+#: ckanext/canada/templates/public/package/snippets/resource_item.html:12
+#: ckanext/canada/templates/public/scheming/display_snippets/fluent_tags.html:9
+#: ckanext/canada/templates/public/snippets/package_item.html:38
+#: ckanext/canada/templates/public/snippets/package_item.html:52
 msgid ""
 "This third party metadata element has been translated using an automated "
-"translation tool. To report any discrepancies please contact open-"
-"ouvert@tbs-sct.gc.ca"
+"translation tool. To report any discrepancies please contact open-ouvert@tbs-"
+"sct.gc.ca"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read.html:72
+#: ckanext/canada/templates/public/package/read.html:30
+#, python-format
+msgid ""
+"You're currently viewing an old version of this dataset. Some resources may "
+"no longer exist or the dataset may not display correctly. To see the current "
+"version, click <a href=\"%(url)s\">here</a>."
+msgstr ""
+
+#: ckanext/canada/templates/public/package/read.html:46
 #: ckanext/canada/templates/public/snippets/search_form.html:54
 msgid "View on Map"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read.html:82
-msgid "Made available by the Government of Alberta"
+#: ckanext/canada/templates/public/package/read.html:57
+msgid "Made available by the "
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read.html:84
+#: ckanext/canada/templates/public/package/read.html:59
 msgid ""
 "<p>These resources are not under the control of the Government of Canada and "
 "the link is provided solely for the convenience of our website visitors. We "
@@ -1663,152 +2020,118 @@ msgid ""
 "this non-government website before providing personal information.</p>"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read.html:125
-#: ckanext/canada/templates/public/snippets/package_item.html:58
+#: ckanext/canada/templates/public/package/read.html:97
+#: ckanext/canada/templates/public/snippets/package_item.html:67
 msgid "Issued by"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read.html:142
-msgid "Licence"
-msgstr ""
-
-#: ckanext/canada/templates/public/package/read.html:166
-#: ckanext/canada/templates/public/package/snippets/all_resources_list.html:27
+#: ckanext/canada/templates/public/package/read.html:133
 msgid "Related Items"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read.html:183
+#: ckanext/canada/templates/public/package/read.html:150
 msgid "Geographic Information"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read.html:216
+#: ckanext/canada/templates/public/package/read.html:185
 msgid "Contact Information"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read.html:218
+#: ckanext/canada/templates/public/package/read.html:187
 msgid "Delivery Point"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read.html:221
+#: ckanext/canada/templates/public/package/read.html:190
 msgid "City"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read.html:224
+#: ckanext/canada/templates/public/package/read.html:193
 msgid "Administrative Area"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read.html:227
+#: ckanext/canada/templates/public/package/read.html:196
 msgid "Postal Code"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read.html:230
+#: ckanext/canada/templates/public/package/read.html:199
 msgid "Country"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read.html:233
+#: ckanext/canada/templates/public/package/read.html:202
 msgid "Electronic Mail Address"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:19
+#: ckanext/canada/templates/public/package/read.html:231
+msgid "Similar records"
+msgstr ""
+
+#: ckanext/canada/templates/public/package/read_base.html:29
 msgid "{record_title} - Open Data Portal - Open Data"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:35
+#: ckanext/canada/templates/public/package/read_base.html:43
+#: ckanext/canada/templates/public/scheming/package/resource_read.html:7
 msgid "Additional Information"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:93
+#: ckanext/canada/templates/public/package/read_base.html:72
 msgid "Temporal Coverage"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:96
+#: ckanext/canada/templates/public/package/read_base.html:75
 msgid "to"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:98
+#: ckanext/canada/templates/public/package/read_base.html:77
 msgid "to undefined"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:100
+#: ckanext/canada/templates/public/package/read_base.html:79
 msgid "undefined to"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:129
+#: ckanext/canada/templates/public/package/read_base.html:109
 msgid "About this Record"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:134
+#: ckanext/canada/templates/public/package/read_base.html:114
 msgid "Record Released"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:138
+#: ckanext/canada/templates/public/package/read_base.html:118
 msgid "Record Modified"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:142
+#: ckanext/canada/templates/public/package/read_base.html:122
 msgid "Record ID"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:146
+#: ckanext/canada/templates/public/package/read_base.html:126
 msgid "Metadata"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:150
+#: ckanext/canada/templates/public/package/read_base.html:130
 msgid "Link to JSON format"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:156
+#: ckanext/canada/templates/public/package/read_base.html:136
 msgid "DCAT (JSON-LD)"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:163
+#: ckanext/canada/templates/public/package/read_base.html:143
 msgid "DCAT (XML)"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:171
+#: ckanext/canada/templates/public/package/read_base.html:151
 msgid "FGP Metadata"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:173
+#: ckanext/canada/templates/public/package/read_base.html:153
 msgid "HNAP ISO:19115 Metadata Record"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/resource_read.html:32
-msgid "Download"
-msgstr ""
-
-#: ckanext/canada/templates/public/package/resource_read.html:36
-msgid "From the asset abstract"
-msgstr ""
-
-#: ckanext/canada/templates/public/package/resource_read.html:39
-#, python-format
-msgid "Source: <a href=\"%(url)s\">%(dataset)s</a>"
-msgstr ""
-
-#: ckanext/canada/templates/public/package/resource_views.html:4
-msgid "View"
-msgstr ""
-
-#: ckanext/canada/templates/public/package/resource_views.html:10
-msgid "New view"
-msgstr ""
-
-#: ckanext/canada/templates/public/package/resource_views.html:28
-msgid "This resource has no views"
-msgstr ""
-
-#: ckanext/canada/templates/public/package/resources.html:4
-#: ckanext/canada/templates/public/package/snippets/resources.html:9
-#: ckanext/canada/templates/public/package/snippets/resources_list.html:7
-msgid "Resources"
-msgstr ""
-
-#: ckanext/canada/templates/public/package/resources.html:12
-#, python-format
-msgid ""
-" <p class=\"empty\">This asset has no resources, <a href=\"%(url)s\">why not "
-"add some?</a></p> "
+#: ckanext/canada/templates/public/package/resource_read.html:46
+msgid "Data Dictionary"
 msgstr ""
 
 #: ckanext/canada/templates/public/package/search.html:15
@@ -1860,23 +2183,8 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/snippets/all_resources_list.html:34
-msgid "Relationship"
-msgstr ""
-
-#: ckanext/canada/templates/public/package/snippets/all_resources_list.html:36
-#: ckanext/canada/templates/public/package/snippets/resources_list.html:18
-msgid "Language"
-msgstr ""
-
-#: ckanext/canada/templates/public/package/snippets/all_resources_list.html:37
-#: ckanext/canada/templates/public/package/snippets/resources_list.html:19
-msgid "Links"
-msgstr ""
-
-#: ckanext/canada/templates/public/package/snippets/all_resources_list.html:78
-#: ckanext/canada/templates/public/package/snippets/resource_item.html:41
-msgid "Access"
+#: ckanext/canada/templates/public/package/snippets/resource_form.html:4
+msgid "URL"
 msgstr ""
 
 #: ckanext/canada/templates/public/package/snippets/resource_form.html:4
@@ -1887,19 +2195,12 @@ msgstr ""
 msgid "Save & add another"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/snippets/resource_item.html:40
-msgid "Resource"
+#: ckanext/canada/templates/public/package/snippets/resource_item.html:63
+msgid "Go to resource"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/snippets/resources_list.html:15
-msgid "Resource Name"
-msgstr ""
-
-#: ckanext/canada/templates/public/package/snippets/resources_list.html:34
-#, python-format
-msgid ""
-" <p class=\"empty\">This dataset has no data, <a href=\"%(url)s\">why not add"
-" some?</a> "
+#: ckanext/canada/templates/public/package/snippets/resource_item.html:66
+msgid "Download"
 msgstr ""
 
 #: ckanext/canada/templates/public/package/snippets/schemaorg.html:5
@@ -1910,6 +2211,10 @@ msgstr ""
 msgid ""
 "This catalog contains metadata records describing open datasets available "
 "from the Government of Canada"
+msgstr ""
+
+#: ckanext/canada/templates/public/package/snippets/schemaorg.html:23
+msgid "http://open.canada.ca"
 msgstr ""
 
 #: ckanext/canada/templates/public/package/snippets/schemaorg.html:26
@@ -1926,11 +2231,19 @@ msgid ""
 "Government Licence - Canada"
 msgstr ""
 
+#: ckanext/canada/templates/public/package/snippets/socialmedia.html:9
+msgid "Provide feedback"
+msgstr ""
+
+#: ckanext/canada/templates/public/scheming/display_snippets/email_with_parameters.html:7
+msgid "The following is a question related to the record {url} found on {site}"
+msgstr ""
+
 #: ckanext/canada/templates/public/snippets/activity_item.html:3
 msgid "New activity item"
 msgstr ""
 
-#: ckanext/canada/templates/public/snippets/dataset_facets.html:58
+#: ckanext/canada/templates/public/snippets/dataset_facets.html:59
 msgid "Viewable on Map"
 msgstr ""
 
@@ -1952,31 +2265,36 @@ msgstr ""
 msgid "Spatial Feature"
 msgstr ""
 
-#: ckanext/canada/templates/public/snippets/organization.html:25
+#: ckanext/canada/templates/public/snippets/menu.html:2
+msgid "Topics menu"
+msgstr ""
+
+#: ckanext/canada/templates/public/snippets/organization.html:23
 msgid "read more"
 msgstr ""
 
-#: ckanext/canada/templates/public/snippets/package_item.html:11
-msgid "Provincial"
-msgstr ""
-
-#: ckanext/canada/templates/public/snippets/package_item.html:13
-msgid "Federal"
-msgstr ""
-
-#: ckanext/canada/templates/public/snippets/package_item.html:47
+#: ckanext/canada/templates/public/snippets/package_item.html:56
 msgid "This dataset has no description"
 msgstr ""
 
-#: ckanext/canada/templates/public/snippets/package_item.html:66
+#: ckanext/canada/templates/public/snippets/package_item.html:86
+#: ckanext/canada/templates/public/snippets/package_item.html:99
+msgid "Status"
+msgstr ""
+
+#: ckanext/canada/templates/public/snippets/package_item.html:94
+msgid "Date"
+msgstr ""
+
+#: ckanext/canada/templates/public/snippets/package_item.html:107
 msgid "Resource Formats"
 msgstr ""
 
-#: ckanext/canada/templates/public/snippets/package_item.html:80
+#: ckanext/canada/templates/public/snippets/package_item.html:123
 msgid "Add to Map Cart"
 msgstr ""
 
-#: ckanext/canada/templates/public/snippets/package_item.html:83
+#: ckanext/canada/templates/public/snippets/package_item.html:126
 msgid "Remove from Map Cart"
 msgstr ""
 
@@ -2031,58 +2349,20 @@ msgstr ""
 msgid "Empty Cart"
 msgstr ""
 
-#: ckanext/canada/templates/public/snippets/search_result_text.html:15
-msgid "{number} dataset found"
-msgid_plural "{number} datasets found"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ckanext/canada/templates/public/snippets/search_result_text.html:16
-msgid "No datasets found"
-msgstr ""
-
-#: ckanext/canada/templates/public/snippets/search_result_text.html:21
-msgid "{number} group found for \"{query}\""
-msgid_plural "{number} groups found for \"{query}\""
-msgstr[0] ""
-msgstr[1] ""
-
-#: ckanext/canada/templates/public/snippets/search_result_text.html:22
-msgid "No groups found for \"{query}\""
-msgstr ""
-
-#: ckanext/canada/templates/public/snippets/search_result_text.html:23
-msgid "{number} group found"
-msgid_plural "{number} groups found"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ckanext/canada/templates/public/snippets/search_result_text.html:24
-msgid "No groups found"
-msgstr ""
-
-#: ckanext/canada/templates/public/snippets/search_result_text.html:27
-msgid "{number} organization found for \"{query}\""
-msgid_plural "{number} organizations found for \"{query}\""
-msgstr[0] ""
-msgstr[1] ""
-
-#: ckanext/canada/templates/public/snippets/search_result_text.html:28
-msgid "No organizations found for \"{query}\""
-msgstr ""
-
-#: ckanext/canada/templates/public/snippets/search_result_text.html:29
-msgid "{number} organization found"
-msgid_plural "{number} organizations found"
-msgstr[0] ""
-msgstr[1] ""
-
 #: ckanext/canada/templates/public/snippets/sort_by.html:12
 msgid "Order by"
 msgstr ""
 
 #: ckanext/canada/templates/public/snippets/sort_by.html:14
 msgid "Relevance"
+msgstr ""
+
+#: ckanext/canada/templates/public/snippets/user.html:59
+msgid "Register"
+msgstr ""
+
+#: ckanext/canada/templates/public/snippets/activities/deleted_datastore.html:6
+msgid "{actor} {activity_type} for resource \"{resource}\""
 msgstr ""
 
 #: ckanext/canada/templates/public/snippets/wet-boew/brand.html:4
@@ -2117,6 +2397,19 @@ msgstr ""
 
 #: ckanext/canada/templates/public/user/dashboard.html:48
 msgid "You do not have any datasets"
+msgstr ""
+
+#: ckanext/canada/templates/public/user/dashboard.html:54
+#: ckanext/canada/templates/public/user/dashboard.html:60
+msgid "Add Dataset"
+msgstr ""
+
+#: ckanext/canada/templates/public/user/edit.html:8
+msgid "Manage"
+msgstr ""
+
+#: ckanext/canada/templates/public/user/edit_base.html:5
+msgid "My Profile"
 msgstr ""
 
 #: ckanext/canada/templates/public/user/edit_user_form.html:7
@@ -2195,26 +2488,32 @@ msgstr ""
 msgid "Open ID"
 msgstr ""
 
-#: ckanext/canada/templates/public/user/read_base.html:50
-#: ckanext/canada/templates/public/user/read_base.html:61
+#: ckanext/canada/templates/public/user/read_base.html:51
+#: ckanext/canada/templates/public/user/read_base.html:62
 msgid "This means only you can see this"
 msgstr ""
 
-#: ckanext/canada/templates/public/user/read_base.html:50
-#: ckanext/canada/templates/public/user/read_base.html:61
+#: ckanext/canada/templates/public/user/read_base.html:51
+#: ckanext/canada/templates/public/user/read_base.html:62
 msgid "Private"
 msgstr ""
 
-#: ckanext/canada/templates/public/user/read_base.html:55
+#: ckanext/canada/templates/public/user/read_base.html:56
 msgid "Member Since"
 msgstr ""
 
-#: ckanext/canada/templates/public/user/read_base.html:60
+#: ckanext/canada/templates/public/user/read_base.html:61
+#: ckanext/canada/templates/public/user/read_base.html:69
 msgid "API Key"
 msgstr ""
 
-#: ckanext/canada/templates/public/user/request_reset.html:16
-msgid "Request Reset"
+#: ckanext/canada/templates/public/user/read_base.html:64
+msgid "Show API Key"
+msgstr ""
+
+#: ckanext/canada/templates/public/user/read_base.html:70
+#: ckanext/canada/templates/public/user/read_base.html:76
+msgid "Close"
 msgstr ""
 
 #: ckanext/canada/templates/public/user/snippets/followee_dropdown.html:13
@@ -2232,3 +2531,4 @@ msgstr ""
 #: ckanext/canada/templates/public/user/snippets/login_form.html:17
 msgid "Remember me"
 msgstr ""
+

--- a/ckanext/canada/i18n/en/LC_MESSAGES/ckanext-canada.po
+++ b/ckanext/canada/i18n/en/LC_MESSAGES/ckanext-canada.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  CKAN\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-01-02 13:56-0500\n"
+"POT-Creation-Date: 2023-06-28 18:22+0000\n"
 "PO-Revision-Date: 2014-01-23 13:04+0000\n"
 "Last-Translator: Sean Hammond <sean.hammond@okfn.org>\n"
 "Language: en\n"
@@ -19,11 +19,24 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.3.4\n"
 
-#: ckanext/canada/controller.py:157 ckanext/canada/controller.py:521
+#: ckanext/canada/controller.py:162 ckanext/canada/controller.py:606
 msgid "Not authorized to see this page"
 msgstr ""
 
-#: ckanext/canada/controller.py:235
+#: ckanext/canada/controller.py:246
+#: ckanext/canada/templates/internal/organization/edit_base.html:26
+#: ckanext/canada/templates/internal/package/resource_edit.html:3
+#: ckanext/canada/templates/internal/package/resource_edit_base.html:7
+#: ckanext/canada/templates/internal/package/wet_datatable.html:19
+#: ckanext/canada/templates/public/organization/read_base.html:27
+#: ckanext/canada/templates/public/organization/snippets/organization_item.html:17
+#: ckanext/canada/templates/public/package/edit.html:4
+#: ckanext/canada/templates/public/package/edit.html:8
+#: ckanext/canada/templates/public/package/snippets/resource_item.html:75
+msgid "Edit"
+msgstr ""
+
+#: ckanext/canada/controller.py:266
 msgid ""
 "<strong>Note</strong><br> The dataset has been removed from the Open "
 "Government Portal. <br/> The record may re-appear if it is re-harvested "
@@ -31,35 +44,73 @@ msgid ""
 "source catalogue in order to prevent it from reappearing."
 msgstr ""
 
-#: ckanext/canada/controller.py:253
+#: ckanext/canada/controller.py:284
 msgid "<strong>Note</strong><br> The record has been restored."
 msgstr ""
 
-#: ckanext/canada/controller.py:323
+#: ckanext/canada/controller.py:354
+msgid ""
+"The status has been added / updated for this suggested  dataset. This "
+"update will be reflected on open.canada.ca shortly."
+msgstr ""
+
+#: ckanext/canada/controller.py:363
 msgid "Resource updated."
 msgstr ""
 
-#: ckanext/canada/controller.py:355
+#: ckanext/canada/controller.py:395
 msgid "<strong>Note</strong><br>{0} is now logged in"
 msgstr ""
 
-#: ckanext/canada/controller.py:368
+#: ckanext/canada/controller.py:408
 msgid "Login failed. Bad username or password."
 msgstr ""
 
-#: ckanext/canada/controller.py:389
+#: ckanext/canada/controller.py:428
 msgid "Unauthorized to create a user"
 msgstr ""
 
-#: ckanext/canada/controller.py:457
+#: ckanext/canada/controller.py:502 ckanext/canada/controller.py:542
 msgid "Open Government Dataset Feed"
 msgstr ""
 
-#: ckanext/canada/controller.py:556
+#: ckanext/canada/controller.py:518
+#, fuzzy
+msgid "Dataset not found"
+msgstr "No records found"
+
+#: ckanext/canada/controller.py:634
+msgid " record(s) published."
+msgstr ""
+
+#: ckanext/canada/controller.py:650
+#, python-format
+msgid "Action name not known: %s"
+msgstr ""
+
+#: ckanext/canada/controller.py:671
+#, python-format
+msgid "JSON Error: %s"
+msgstr ""
+
+#: ckanext/canada/controller.py:677
+#, python-format
+msgid "Bad request data: %s"
+msgstr ""
+
+#: ckanext/canada/controller.py:703
+msgid "Access denied"
+msgstr ""
+
+#: ckanext/canada/controller.py:712 ckanext/canada/controller.py:980
+msgid "Not found"
+msgstr ""
+
+#: ckanext/canada/controller.py:771
 msgid "Account Created"
 msgstr ""
 
-#: ckanext/canada/controller.py:558
+#: ckanext/canada/controller.py:773
 msgid ""
 "Thank you for creating your account for the Open Government registry. "
 "Although your account is active, it has not yet been linked to your "
@@ -67,7 +118,7 @@ msgid ""
 "be able to create or modify datasets in the registry."
 msgstr ""
 
-#: ckanext/canada/controller.py:565
+#: ckanext/canada/controller.py:780
 msgid ""
 "You should receive an email within the next business day once the account"
 " activation process has been completed. If you require faster processing "
@@ -75,221 +126,449 @@ msgid ""
 ":open-ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a>"
 msgstr ""
 
-#: ckanext/canada/controller.py:650 ckanext/canada/controller.py:739
+#: ckanext/canada/controller.py:872 ckanext/canada/controller.py:964
+#: ckanext/canada/controller.py:1131
 msgid "Unauthorized"
 msgstr ""
 
-#: ckanext/canada/controller.py:688
+#: ckanext/canada/controller.py:913
 #, fuzzy
 msgid "This record already exists"
 msgstr "Record id already exists"
 
-#: ckanext/canada/controller.py:703
+#: ckanext/canada/controller.py:928
 msgid "Record Created"
 msgstr ""
 
-#: ckanext/canada/controller.py:752
-msgid "Not found"
-msgstr ""
-
-#: ckanext/canada/controller.py:754
+#: ckanext/canada/controller.py:982
 msgid "Multiple records found"
 msgstr ""
 
-#: ckanext/canada/controller.py:801
+#: ckanext/canada/controller.py:1032
 #, python-format
 msgid "Record %s Updated"
 msgstr ""
 
-#: ckanext/canada/controller.py:832
-#: ckanext/canada/templates/public/snippets/search_result_text.html:30
+#: ckanext/canada/controller.py:1063
 msgid "No organizations found"
 msgstr ""
 
-#: ckanext/canada/controller.py:836
+#: ckanext/canada/controller.py:1067
 msgid "Recombinant resource_name not found"
 msgstr ""
 
-#: ckanext/canada/controller.py:879
+#: ckanext/canada/controller.py:1109
 #, fuzzy
 msgid "Number required"
 msgstr ""
 
-#: ckanext/canada/controller.py:884
+#: ckanext/canada/controller.py:1114
 msgid "Integer required"
 msgstr ""
 
-#: ckanext/canada/helpers.py:343
+#: ckanext/canada/helpers.py:387
 msgid "A system administrator"
 msgstr ""
 
-#: ckanext/canada/plugins.py:296
+#: ckanext/canada/plugins.py:365
 #: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:26
-#: ckanext/canada/templates/public/package/snippets/all_resources_list.html:35
 msgid "Portal Type"
 msgstr ""
 
-#: ckanext/canada/plugins.py:297 ckanext/canada/plugins.py:681
-#: ckanext/canada/templates/internal/user/new_user_form.html:14
+#: ckanext/canada/plugins.py:366 ckanext/canada/plugins.py:833
+#: ckanext/canada/templates/internal/user/new_user_form.html:18
 #: ckanext/canada/templates/public/package/deleted.html:15
-#: ckanext/canada/templates/public/snippets/package_item.html:52
+#: ckanext/canada/templates/public/snippets/package_item.html:61
 msgid "Organization"
 msgstr ""
 
-#: ckanext/canada/plugins.py:298
+#: ckanext/canada/plugins.py:367
 msgid "Collection Type"
 msgstr ""
 
-#: ckanext/canada/plugins.py:299 ckanext/canada/plugins.py:300
-#: ckanext/canada/plugins.py:682 ckanext/canada/plugins.py:683
+#: ckanext/canada/plugins.py:368 ckanext/canada/plugins.py:369
+#: ckanext/canada/plugins.py:834 ckanext/canada/plugins.py:835
 msgid "Keywords"
 msgstr ""
 
-#: ckanext/canada/plugins.py:301
+#: ckanext/canada/plugins.py:370
 msgid "Subject"
 msgstr ""
 
-#: ckanext/canada/plugins.py:302 ckanext/canada/plugins.py:684
-#: ckanext/canada/templates/public/package/snippets/resources_list.html:17
+#: ckanext/canada/plugins.py:371 ckanext/canada/plugins.py:836
 msgid "Format"
 msgstr ""
 
-#: ckanext/canada/plugins.py:303 ckanext/canada/plugins.py:685
-#: ckanext/canada/templates/public/package/snippets/resources_list.html:16
+#: ckanext/canada/plugins.py:372 ckanext/canada/plugins.py:837
 msgid "Resource Type"
 msgstr ""
 
-#: ckanext/canada/plugins.py:304
+#: ckanext/canada/plugins.py:373
 msgid "Maintenance and Update Frequency"
 msgstr ""
 
-#: ckanext/canada/plugins.py:305
+#: ckanext/canada/plugins.py:374
 msgid "Topic Categories"
 msgstr ""
 
-#: ckanext/canada/plugins.py:306
+#: ckanext/canada/plugins.py:375
 msgid "Spatial Representation Type"
 msgstr ""
 
-#: ckanext/canada/plugins.py:307
+#: ckanext/canada/plugins.py:376
 #, fuzzy
 msgid "Map Viewer"
 msgstr "Viewable on Map"
 
-#: ckanext/canada/plugins.py:308
+#: ckanext/canada/plugins.py:377
 msgid "Record Status"
 msgstr ""
 
-#: ckanext/canada/plugins.py:309
+#: ckanext/canada/plugins.py:378
 msgid "IMSO Approval"
 msgstr ""
 
-#: ckanext/canada/plugins.py:310
+#: ckanext/canada/plugins.py:379
 msgid "Jurisdiction"
 msgstr ""
 
-#: ckanext/canada/plugins.py:566
+#: ckanext/canada/plugins.py:380
+msgid "Suggestion Status"
+msgstr ""
+
+#: ckanext/canada/plugins.py:714
 #, python-format
 msgid "Your record %s has been saved."
 msgstr ""
 
-#: ckanext/canada/plugins.py:686
+#: ckanext/canada/plugins.py:838
 msgid "Resource Language"
 msgstr ""
 
-#: ckanext/canada/plugins.py:750
+#: ckanext/canada/plugins.py:904
 #: ckanext/canada/templates/public/package/snippets/resource_form.html:8
 msgid "Previous"
 msgstr ""
 
-#: ckanext/canada/plugins.py:750
+#: ckanext/canada/plugins.py:904
 msgid "Next"
 msgstr ""
 
-#: ckanext/canada/validators.py:73
+#: ckanext/canada/strings.py:8
+msgid ""
+"This field must be populated with an NA if an amendment is disclosed "
+"under Instrument Type."
+msgstr ""
+
+#: ckanext/canada/strings.py:9
+msgid ""
+"If N/A, then Instrument Type must be identified as a standing "
+"offer/supply arrangement (SOSA)"
+msgstr ""
+
+#: ckanext/canada/strings.py:10
+msgid ""
+"If the value XX (none) is entered, then no other value can be entered in "
+"this field."
+msgstr ""
+
+#: ckanext/canada/strings.py:11
+msgid ""
+"If the value NA (not applicable) is entered, then no other value can be "
+"entered in this field."
+msgstr ""
+
+#: ckanext/canada/strings.py:12
+msgid ""
+"This field must be NA (not applicable) if the Agreement Type or Trade "
+"Agreement field is not 0 (none) or XX (none), as applicable."
+msgstr ""
+
+#: ckanext/canada/strings.py:14
+msgid ""
+"If the value 00 (none) is entered, then no other value can be entered in "
+"this field."
+msgstr ""
+
+#: ckanext/canada/strings.py:15
+msgid ""
+"This field must contain the first three digits of a postal code in A1A "
+"format or the value \"NA\""
+msgstr ""
+
+#: ckanext/canada/strings.py:16
+msgid ""
+"This field must be N, No or Non, if the Agreement Type or Trade Agreement"
+" field is not 0 (none) or XX (none), as applicable."
+msgstr ""
+
+#: ckanext/canada/strings.py:18
+msgid ""
+"This field must be N, No or Non, if the Procurement Strategy for "
+"Aboriginal Business field is MS or VS."
+msgstr ""
+
+#: ckanext/canada/strings.py:19
+msgid ""
+"This field may only be populated with a 1 if the solicitation procedure "
+"is identified as non-competitive (TN) or Advance Contract Award Notice "
+"(AC)"
+msgstr ""
+
+#: ckanext/canada/strings.py:21
+msgid ""
+"This field may only be populated with a 0 if a Call-up against a standing"
+" offer or supply arrangement was identified in the Contracting Entity "
+"data field"
+msgstr ""
+
+#: ckanext/canada/strings.py:23
+msgid ""
+"This field may only be populated with \"0\" if the procurement was "
+"identified as non-competitive (TN) or advance contract award notice (AC)."
+msgstr ""
+
+#: ckanext/canada/strings.py:25
+msgid ""
+"This field may not be populated with 1, 2, 3 or 4 if the procurement was "
+"identified as non-competitive or Advance Contract Award Notice."
+msgstr ""
+
+#: ckanext/canada/strings.py:27
+msgid ""
+"Commodity Type of G for Goods which requires a Delivery Date and not a "
+"Contract Period Start Date. Please either change the Commodity Type to S "
+"or remove the date from the Contract Period Start Date field"
+msgstr ""
+
+#: ckanext/canada/strings.py:30
+msgid ""
+"If the value XX (none) is entered here, then the following three fields "
+"must be identified as NA or N, as applicable: Comprehensive Land Claim "
+"Agreement, Procurement Strategy for Aboriginal Business, Procurement "
+"Strategy for Aboriginal Business Incidental Indicator"
+msgstr ""
+
+#: ckanext/canada/validators.py:117
 #, python-format
 msgid "Tag \"%s\" length is less than minimum %s"
 msgstr ""
 
-#: ckanext/canada/validators.py:77
+#: ckanext/canada/validators.py:121
 #, python-format
 msgid "Tag \"%s\" length is more than maximum %i"
 msgstr ""
 
-#: ckanext/canada/validators.py:80
+#: ckanext/canada/validators.py:124
 #, python-format
 msgid "Tag \"%s\" may not contain commas"
 msgstr ""
 
-#: ckanext/canada/validators.py:83
+#: ckanext/canada/validators.py:127
 #, python-format
 msgid "Tag \"%s\" may not contain consecutive spaces"
 msgstr ""
 
-#: ckanext/canada/validators.py:90
+#: ckanext/canada/validators.py:134
 #, python-format
 msgid "Tag \"%s\" may not contain unprintable character U+%04x"
 msgstr ""
 
-#: ckanext/canada/validators.py:94
+#: ckanext/canada/validators.py:138
 #, python-format
 msgid "Tag \"%s\" may not contain separator charater U+%04x"
 msgstr ""
 
-#: ckanext/canada/validators.py:110
+#: ckanext/canada/validators.py:154
 msgid "Badly formed hexadecimal UUID string"
 msgstr ""
 
 #: ckanext/canada/templates/internal/user/new_user_form.html:6
-#: ckanext/canada/validators.py:122 ckanext/canada/validators.py:124
+#: ckanext/canada/validators.py:166 ckanext/canada/validators.py:168
 msgid "Please enter a valid email address."
 msgstr ""
 
-#: ckanext/canada/validators.py:139
+#: ckanext/canada/validators.py:183
 msgid "Invalid GeoJSON"
+msgstr ""
+
+#: ckanext/canada/validators.py:260
+msgid "Date may not be in the future when this record is marked ready to publish"
+msgstr ""
+
+#: ckanext/canada/validators.py:326
+msgid "Date format incorrect. Expecting YYYY-MM-DD"
+msgstr ""
+
+#: ckanext/canada/validators.py:333
+msgid "Invalid licence"
+msgstr ""
+
+#: ckanext/canada/validators.py:346 ckanext/canada/validators.py:360
+msgid "Must be a Unicode string value"
+msgstr ""
+
+#: ckanext/canada/validators.py:367 ckanext/canada/validators.py:378
+msgid "Must be a JSON string"
+msgstr ""
+
+#: ckanext/canada/validators.py:374
+msgid "JSON object must contain \"en\" key"
+msgstr ""
+
+#: ckanext/canada/validators.py:376
+msgid "JSON object must contain \"fr\" key"
 msgstr ""
 
 #: ckanext/canada/templates/internal/base.html:5
 msgid "Open Data Registry"
 msgstr ""
 
-#: ckanext/canada/templates/internal/header.html:16
-#: ckanext/canada/templates/internal/menu.html:9
-#: ckanext/canada/templates/public/package/snippets/schemaorg.html:23
-msgid "http://open.canada.ca"
+#: ckanext/canada/templates/internal/error_document_template.html:5
+#: ckanext/canada/templates/internal/home/quick_links.html:2
+#, fuzzy
+msgid "Open Government Registry"
+msgstr "Open Government E-mail"
+
+#: ckanext/canada/templates/internal/error_document_template.html:17
+msgid ""
+"You are not logged in to the Open Government Registry. Note that your "
+"login expires after 1 hour of inactivity. Click on the log in button "
+"below to log in."
 msgstr ""
 
-#: ckanext/canada/templates/internal/header.html:16
-#: ckanext/canada/templates/internal/menu.html:9
-msgid "Open.Canada.ca"
+#: ckanext/canada/templates/internal/error_document_template.html:21
+#: ckanext/canada/templates/internal/header.html:39
+#: ckanext/canada/templates/internal/page.html:20
+#: ckanext/canada/templates/internal/user/snippets/login_form.html:22
+#: ckanext/canada/templates/public/snippets/user.html:61
+#: ckanext/canada/templates/public/user/snippets/login_form.html:22
+msgid "Log in"
 msgstr ""
 
-#: ckanext/canada/templates/internal/header.html:19
-#: ckanext/canada/templates/internal/menu.html:11
-msgid "Add to Portal"
+#: ckanext/canada/templates/internal/error_document_template.html:25
+#: ckanext/canada/templates/public/error_document_template.html:6
+msgid "We couldn't find that Web page"
 msgstr ""
 
-#: ckanext/canada/templates/internal/header.html:21
-#: ckanext/canada/templates/internal/menu.html:14
+#: ckanext/canada/templates/internal/error_document_template.html:27
+msgid ""
+"We encountered an error and are unable to serve your request. Please try "
+"again in short time or contact <a href=\"mailto:open-ouvert@tbs-sct.gc.ca"
+"\">open-ouvert@tbs-sct.gc.ca</a> if you need immediate assistance or if "
+"this issue persists. Note that your login expires after 1 hour of "
+"inactivity."
+msgstr ""
+
+#: ckanext/canada/templates/internal/error_document_template.html:29
+#: ckanext/canada/templates/public/error_document_template.html:8
+msgid "We encountered an error"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:14
+#: ckanext/canada/templates/public/snippets/user.html:11
+msgid "Signed in as"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:15
+#: ckanext/canada/templates/public/snippets/user.html:12
+msgid "View profile"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:24
+#: ckanext/canada/templates/internal/header.html:26
+#: ckanext/canada/templates/public/snippets/user.html:48
+#: ckanext/canada/templates/public/snippets/user.html:50
+msgid "Log out"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:57
+msgid "Home"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:59
+#: ckanext/canada/templates/internal/header.html:61
+#: ckanext/canada/templates/internal/home/quick_links.html:65
 #: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:30
 #: ckanext/canada/templates/internal/snippets/dataset_facets.html:2
 #: ckanext/canada/templates/public/macros/canada_read.html:180
 #: ckanext/canada/templates/public/snippets/dataset_facets.html:2
+#: ckanext/canada/templates/public/snippets/package_item.html:12
 msgid "Open Data"
 msgstr ""
 
-#: ckanext/canada/templates/internal/header.html:22
-#: ckanext/canada/templates/internal/menu.html:16
+#: ckanext/canada/templates/internal/header.html:63
+msgid "Create an Open Data Record"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:71
+#: ckanext/canada/templates/internal/home/quick_links.html:80
 #: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:32
 #: ckanext/canada/templates/internal/snippets/dataset_facets.html:4
 #: ckanext/canada/templates/public/macros/canada_read.html:181
 #: ckanext/canada/templates/public/snippets/dataset_facets.html:3
+#: ckanext/canada/templates/public/snippets/package_item.html:18
 msgid "Open Information"
 msgstr ""
 
+#: ckanext/canada/templates/internal/header.html:72
+#: ckanext/canada/templates/internal/header.html:74
+#: ckanext/canada/templates/internal/snippets/dataset_facets.html:32
+#: ckanext/canada/templates/public/macros/canada_read.html:202
+#: ckanext/canada/templates/public/snippets/package_item.html:16
+#: ckanext/canada/templates/public/snippets/package_item.html:22
+msgid "Proactive Disclosure"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:86
+msgid "Reports Tabled in Parliament"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:90
+#: ckanext/canada/templates/internal/home/quick_links.html:171
+msgid "Briefing packages"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:92
+msgid "New or incoming ministers"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:93
+msgid "New or incoming deputy heads"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:94
+msgid "Parliamentary Committee appearances for ministers"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:95
+msgid "Parliamentary Committee appearances for deputy heads"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:100
+#: ckanext/canada/templates/internal/home/quick_links.html:92
+#: ckanext/canada/templates/internal/snippets/dataset_facets.html:5
+#: ckanext/canada/templates/public/macros/canada_read.html:182
+#: ckanext/canada/templates/public/snippets/dataset_facets.html:4
+#, fuzzy
+msgid "Suggested Datasets"
+msgstr "No edited records"
+
+#: ckanext/canada/templates/internal/header.html:101
+#: ckanext/canada/templates/internal/header.html:103
+#: ckanext/canada/templates/internal/home/quick_links.html:104
+#: ckanext/canada/templates/internal/snippets/dataset_facets.html:3
+#: ckanext/canada/templates/public/snippets/package_item.html:20
+msgid "Open Dialogue"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:106
+msgid "Consultations master dataset"
+msgstr ""
+
 #: ckanext/canada/templates/internal/admin/publish_search.html:20
-#: ckanext/canada/templates/internal/header.html:49
-#: ckanext/canada/templates/internal/menu.html:43
+#: ckanext/canada/templates/internal/header.html:111
+#: ckanext/canada/templates/internal/home/quick_links.html:117
 #: ckanext/canada/templates/public/header.html:15
 #: ckanext/canada/templates/public/header.html:26
 #: ckanext/canada/templates/public/snippets/search_form.html:67
@@ -298,10 +577,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: ckanext/canada/templates/internal/header.html:50
-#: ckanext/canada/templates/internal/menu.html:44
-#: ckanext/canada/templates/internal/snippets/menu.html:27
-#: ckanext/canada/templates/internal/snippets/menu.html:29
+#: ckanext/canada/templates/internal/header.html:112
 #: ckanext/canada/templates/internal/user/read_base.html:21
 #: ckanext/canada/templates/public/organization/index.html:26
 #: ckanext/canada/templates/public/organization/read_base.html:5
@@ -309,35 +585,12 @@ msgstr ""
 msgid "Organizations"
 msgstr ""
 
-#: ckanext/canada/templates/internal/header.html:51
-#: ckanext/canada/templates/internal/menu.html:45
+#: ckanext/canada/templates/internal/header.html:114
 msgid "FAQ"
 msgstr ""
 
-#: ckanext/canada/templates/internal/header.html:53
-#: ckanext/canada/templates/internal/menu.html:47
-#: ckanext/canada/templates/internal/snippets/menu.html:35
-#: ckanext/canada/templates/internal/snippets/menu.html:37
-#: ckanext/canada/templates/internal/snippets/user.html:49
-#: ckanext/canada/templates/internal/snippets/user.html:51
-#: ckanext/canada/templates/public/snippets/user.html:48
-#: ckanext/canada/templates/public/snippets/user.html:50
-msgid "Log out"
-msgstr ""
-
-#: ckanext/canada/templates/internal/header.html:55
-#: ckanext/canada/templates/internal/menu.html:49
-#: ckanext/canada/templates/internal/snippets/menu.html:40
-#: ckanext/canada/templates/internal/snippets/menu.html:42
-#: ckanext/canada/templates/internal/snippets/user.html:62
-#: ckanext/canada/templates/internal/user/snippets/login_form.html:20
-#: ckanext/canada/templates/public/snippets/user.html:61
-#: ckanext/canada/templates/public/user/snippets/login_form.html:22
-msgid "Log in"
-msgstr ""
-
-#: ckanext/canada/templates/internal/header.html:68
-#: ckanext/canada/templates/public/header.html:49
+#: ckanext/canada/templates/internal/header.html:124
+#: ckanext/canada/templates/public/header.html:52
 msgid "You are here:"
 msgstr ""
 
@@ -345,23 +598,49 @@ msgstr ""
 msgid "Frequently Asked Questions (FAQ)"
 msgstr ""
 
-#: ckanext/canada/templates/internal/menu.html:6
-#: ckanext/canada/templates/public/snippets/menu.html:2
-msgid "Topics menu"
+#: ckanext/canada/templates/internal/page.html:9
+msgid "Your user sessions has timed out due to inactivity"
+msgstr ""
+
+#: ckanext/canada/templates/internal/page.html:15
+msgid ""
+"If you are currently entering data on this page, you may lose it when "
+"submitted. To avoid this, you can click on the log in button below to log"
+" in again in a new tab without losing your progress and you can then keep"
+" working on this page. If you have any issues please contact <a "
+"href=\"mailto:open-ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a>."
+msgstr ""
+
+#: ckanext/canada/templates/internal/page.html:36
+msgid ""
+"Internet Explorer is no longer being supported within the Open Government"
+" Registry. Some features will not work as expected, including publication"
+" of records. Please use MS Edge or Google Chrome, or contact <a "
+"href=\"mailto:open-ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a> "
+"for additional support."
 msgstr ""
 
 #: ckanext/canada/templates/internal/admin/base.html:4
-#: ckanext/canada/templates/internal/user/list.html:4
+#: ckanext/canada/templates/internal/snippets/user.html:14
+#: ckanext/canada/templates/public/snippets/user.html:23
+msgid "Admin"
+msgstr ""
+
+#: ckanext/canada/templates/internal/admin/base.html:8
+#: ckanext/canada/templates/internal/user/list.html:9
+#: ckanext/canada/templates/internal/user/list.html:17
+#: ckanext/canada/templates/internal/user/list.html:24
+#: ckanext/canada/templates/internal/user/list.html:73
 #: ckanext/canada/templates/internal/user/read_base.html:5
 msgid "Users"
 msgstr ""
 
-#: ckanext/canada/templates/internal/admin/base.html:6
+#: ckanext/canada/templates/internal/admin/base.html:9
 #: ckanext/canada/templates/public/admin/trash.html:38
 msgid "Trash"
 msgstr "Deleted Records"
 
-#: ckanext/canada/templates/internal/admin/base.html:7
+#: ckanext/canada/templates/internal/admin/base.html:10
 msgid "Publish Records"
 msgstr ""
 
@@ -406,7 +685,7 @@ msgstr ""
 msgid "Clear All"
 msgstr ""
 
-#: ckanext/canada/templates/internal/admin/snippets/package_item.html:8
+#: ckanext/canada/templates/internal/admin/snippets/package_item.html:9
 msgid "Publish?"
 msgstr ""
 
@@ -418,11 +697,40 @@ msgstr ""
 msgid "Publish Selected Records"
 msgstr ""
 
-#: ckanext/canada/templates/internal/home/quick_links.html:2
-msgid "Quick Links"
+#: ckanext/canada/templates/internal/ajax_snippets/api_info.html:5
+msgid "Create"
 msgstr ""
 
-#: ckanext/canada/templates/internal/home/quick_links.html:22
+#: ckanext/canada/templates/internal/ajax_snippets/api_info.html:9
+msgid "Update / Insert"
+msgstr ""
+
+#: ckanext/canada/templates/internal/datastore/snippets/dictionary_form.html:3
+msgid "Field {num}."
+msgstr ""
+
+#: ckanext/canada/templates/internal/datastore/snippets/dictionary_form.html:12
+msgid "Type Override"
+msgstr ""
+
+#: ckanext/canada/templates/internal/datastore/snippets/dictionary_form.html:20
+msgid "English Label"
+msgstr ""
+
+#: ckanext/canada/templates/internal/datastore/snippets/dictionary_form.html:24
+msgid "French Label"
+msgstr ""
+
+#: ckanext/canada/templates/internal/datastore/snippets/dictionary_form.html:28
+#, fuzzy
+msgid "English Description"
+msgstr "This record has no description"
+
+#: ckanext/canada/templates/internal/datastore/snippets/dictionary_form.html:32
+msgid "French Description"
+msgstr ""
+
+#: ckanext/canada/templates/internal/home/quick_links.html:58
 msgid ""
 "Welcome to the Open Government Registry. Use the Registry to add "
 "government resources that will be published on the Open Government "
@@ -431,60 +739,20 @@ msgid ""
 "sct.gc.ca</a>."
 msgstr ""
 
-#: ckanext/canada/templates/internal/home/quick_links.html:29
-msgid "Open Data Records"
-msgstr ""
-
-#: ckanext/canada/templates/internal/home/quick_links.html:30
-msgid ""
-"Add data about Government of Canada services, financials or national "
-"demographic information that is relevant to Canadians."
-msgstr ""
-
-#: ckanext/canada/templates/internal/home/quick_links.html:33
-msgid "Open Information Records"
-msgstr ""
-
-#: ckanext/canada/templates/internal/home/quick_links.html:34
-msgid "Add information about government programs, activities and publications."
-msgstr ""
-
-#: ckanext/canada/templates/internal/home/quick_links.html:58
-#, fuzzy
-msgid "Search your Organization Records"
-msgstr ""
-
-#: ckanext/canada/templates/internal/home/quick_links.html:59
-msgid "Search all records in the Registry, for your Organization."
-msgstr ""
-
-#: ckanext/canada/templates/internal/home/quick_links.html:63
-msgid "Search All Records"
-msgstr ""
-
-#: ckanext/canada/templates/internal/home/quick_links.html:64
-msgid "Add all Open Data and Information records in the Registry."
-msgstr ""
-
-#: ckanext/canada/templates/internal/home/quick_links.html:68
-msgid "View Members of your Organization"
-msgstr ""
-
-#: ckanext/canada/templates/internal/home/quick_links.html:69
-msgid "View the list of members linked to your organization."
+#: ckanext/canada/templates/internal/home/quick_links.html:146
+msgid "Proactive Publication"
 msgstr ""
 
 #: ckanext/canada/templates/internal/organization/edit_base.html:10
 #: ckanext/canada/templates/internal/package/search.html:6
 #: ckanext/canada/templates/public/organization/read_base.html:16
-#: ckanext/canada/templates/public/snippets/organization.html:38
+#: ckanext/canada/templates/public/snippets/organization.html:36
 #: ckanext/canada/templates/public/user/read.html:12
 msgid "Datasets"
 msgstr "Records"
 
 #: ckanext/canada/templates/internal/organization/edit_base.html:13
 #: ckanext/canada/templates/public/organization/read_base.html:19
-#: ckanext/canada/templates/public/package/activity.html:7
 msgid "Activity"
 msgstr ""
 
@@ -494,166 +762,97 @@ msgstr ""
 msgid "Edit Members"
 msgstr "Keep me logged in"
 
-#: ckanext/canada/templates/internal/organization/edit_base.html:26
-#: ckanext/canada/templates/internal/package/resource_edit.html:3
-#: ckanext/canada/templates/internal/package/resource_edit_base.html:7
-#: ckanext/canada/templates/public/organization/read_base.html:27
-#: ckanext/canada/templates/public/organization/snippets/organization_item.html:17
-#: ckanext/canada/templates/public/package/edit.html:4
-#: ckanext/canada/templates/public/package/edit.html:8
-#: ckanext/canada/templates/public/package/read.html:18
-#: ckanext/canada/templates/public/package/snippets/all_resources_list.html:80
-#: ckanext/canada/templates/public/package/snippets/resource_item.html:47
-msgid "Edit"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/member_new.html:31
-msgid "Existing User"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/member_new.html:35
-msgid "If you wish to add an existing user, search for their username below."
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/member_new.html:43
-#: ckanext/canada/templates/internal/user/list.html:12
-#: ckanext/canada/templates/internal/user/new_user_form.html:7
-#: ckanext/canada/templates/internal/user/snippets/login_form.html:13
-#: ckanext/canada/templates/public/user/edit_user_form.html:9
-#: ckanext/canada/templates/public/user/read_base.html:43
-#: ckanext/canada/templates/public/user/request_reset.html:11
-#: ckanext/canada/templates/public/user/snippets/login_form.html:13
-msgid "Username"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/member_new.html:50
-msgid "or"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/member_new.html:54
-msgid "New User"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/member_new.html:57
-msgid "If you wish to invite a new user, enter their email address."
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/member_new.html:60
-msgid "Email address"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/member_new.html:66
-#: ckanext/canada/templates/internal/user/list.html:14
-msgid "Role"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/member_new.html:69
-msgid "Select the role this user should have within this organization."
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/member_new.html:82
-msgid "Are you sure you want to delete this member?"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/member_new.html:83
-#: ckanext/canada/templates/internal/organization/snippets/organization_form.html:49
-#: ckanext/canada/templates/public/scheming/package/read.html:26
-msgid "Delete"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/member_new.html:85
-msgid "Update Member"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/member_new.html:89
-msgid "Add Member"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/new_organization_form.html:9
-msgid "Update Organization"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/new_organization_form.html:11
-msgid "Create Organization"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/snippets/organization_form.html:10
-#: ckanext/canada/templates/public/package/snippets/all_resources_list.html:33
-msgid "Title"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/snippets/organization_form.html:10
-msgid "My Organization"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/snippets/organization_form.html:18
-#: ckanext/canada/templates/public/package/snippets/resource_form.html:4
-msgid "URL"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/snippets/organization_form.html:18
-msgid "my-organization"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/snippets/organization_form.html:20
-msgid "Description"
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/snippets/organization_form.html:20
-msgid "A little information about my organization..."
-msgstr ""
-
-#: ckanext/canada/templates/internal/organization/snippets/organization_form.html:48
+#: ckanext/canada/templates/internal/package/base_form_page.html:4
 #, fuzzy
-msgid "Are you sure you want to delete this Organization?"
-msgstr "Are you sure you want to delete this record?"
+msgid "Create Dataset"
+msgstr "Create record"
 
-#: ckanext/canada/templates/internal/organization/snippets/organization_form.html:52
-msgid "Save Organization"
+#: ckanext/canada/templates/internal/package/edit_base.html:5
+#, fuzzy
+msgid "Edit metadata"
+msgstr "Add record"
+
+#: ckanext/canada/templates/internal/package/edit_base.html:6
+#: ckanext/canada/templates/public/package/resources.html:5
+#: ckanext/canada/templates/public/package/snippets/resources.html:9
+msgid "Resources"
 msgstr ""
 
-#: ckanext/canada/templates/internal/package/read.html:8
-#: ckanext/canada/templates/public/package/read_base.html:109
-msgid "Openness Rating"
-msgstr ""
-
-#: ckanext/canada/templates/internal/package/read.html:13
-#: ckanext/canada/templates/public/package/read_base.html:114
-msgid "one star"
+#: ckanext/canada/templates/internal/package/read.html:7
+#: ckanext/canada/templates/internal/package/read.html:9
+msgid "View on Portal"
 msgstr ""
 
 #: ckanext/canada/templates/internal/package/read.html:14
-#: ckanext/canada/templates/public/package/read_base.html:115
-msgid "two stars"
-msgstr ""
-
-#: ckanext/canada/templates/internal/package/read.html:15
-#: ckanext/canada/templates/public/package/read_base.html:116
-msgid "three stars"
+msgid ""
+"This dataset has been deleted and is no longer accessible to non-admin "
+"users"
 msgstr ""
 
 #: ckanext/canada/templates/internal/package/read.html:16
-#: ckanext/canada/templates/public/package/read_base.html:117
+msgid "Undelete"
+msgstr ""
+
+#: ckanext/canada/templates/internal/package/read.html:26
+#: ckanext/canada/templates/public/package/read_base.html:88
+msgid "Openness Rating"
+msgstr ""
+
+#: ckanext/canada/templates/internal/package/read.html:31
+#: ckanext/canada/templates/public/package/read_base.html:93
+msgid "one star"
+msgstr ""
+
+#: ckanext/canada/templates/internal/package/read.html:32
+#: ckanext/canada/templates/public/package/read_base.html:94
+msgid "two stars"
+msgstr ""
+
+#: ckanext/canada/templates/internal/package/read.html:33
+#: ckanext/canada/templates/public/package/read_base.html:95
+msgid "three stars"
+msgstr ""
+
+#: ckanext/canada/templates/internal/package/read.html:34
+#: ckanext/canada/templates/public/package/read_base.html:96
 msgid "four stars"
 msgstr ""
 
-#: ckanext/canada/templates/internal/package/read.html:17
-#: ckanext/canada/templates/public/package/read_base.html:118
+#: ckanext/canada/templates/internal/package/read.html:35
+#: ckanext/canada/templates/public/package/read_base.html:97
 msgid "five stars"
 msgstr ""
 
+#: ckanext/canada/templates/internal/package/read_base.html:4
+#, fuzzy
+msgid "Dataset"
+msgstr "Records"
+
+#: ckanext/canada/templates/internal/package/read_base.html:5
+#: ckanext/canada/templates/public/organization/activity_stream.html:4
+#: ckanext/canada/templates/public/user/activity_stream.html:12
+msgid "Activity Stream"
+msgstr ""
+
 #: ckanext/canada/templates/internal/package/resource_edit.html:15
-#: ckanext/canada/templates/public/package/activity.html:15
 msgid "Go back"
 msgstr ""
 
-#: ckanext/canada/templates/internal/package/resource_edit_base.html:14
+#: ckanext/canada/templates/internal/package/resource_edit_base.html:15
 msgid "DataStore"
 msgstr ""
 
-#: ckanext/canada/templates/internal/package/wet_datatable.html:2
-#: ckanext/canada/templates/public/package/snippets/resource_item.html:44
+#: ckanext/canada/templates/internal/package/wet_datatable.html:11
+#: ckanext/canada/templates/public/package/snippets/resource_item.html:52
 msgid "Preview"
+msgstr ""
+
+#: ckanext/canada/templates/internal/package/wet_datatable.html:17
+msgid "Select"
+msgstr ""
+
+#: ckanext/canada/templates/internal/package/wet_datatable.html:79
+msgid "Edit in Excel"
 msgstr ""
 
 #: ckanext/canada/templates/internal/package/snippets/stages.html:21
@@ -675,6 +874,22 @@ msgstr ""
 
 #: ckanext/canada/templates/internal/package/snippets/stages.html:39
 msgid "Add data"
+msgstr ""
+
+#: ckanext/canada/templates/internal/package/snippets/view_form.html:8
+msgid "Title (English)"
+msgstr ""
+
+#: ckanext/canada/templates/internal/package/snippets/view_form.html:9
+msgid "Title (French)"
+msgstr ""
+
+#: ckanext/canada/templates/internal/package/snippets/view_form.html:10
+msgid "Description (English)"
+msgstr ""
+
+#: ckanext/canada/templates/internal/package/snippets/view_form.html:11
+msgid "Description (French)"
 msgstr ""
 
 #: ckanext/canada/templates/internal/recombinant/create_pd_record.html:3
@@ -705,23 +920,37 @@ msgstr ""
 
 #: ckanext/canada/templates/internal/recombinant/create_pd_record.html:82
 #: ckanext/canada/templates/internal/recombinant/update_pd_record.html:85
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:68
 msgid "Save"
 msgstr ""
 
-#: ckanext/canada/templates/internal/recombinant/resource_edit.html:19
+#: ckanext/canada/templates/internal/recombinant/resource_edit.html:16
+#, python-format
+msgid ""
+"Informal Requests for ATI Records Previously Released are being sent to "
+"<strong>%s.</strong> Please contact <a href=\"mailto:open-ouvert@tbs-"
+"sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a> if that address is no longer "
+"valid."
+msgstr ""
+
+#: ckanext/canada/templates/internal/recombinant/resource_edit.html:20
+msgid ""
+"Your organization does not have an Access to Information email on file. "
+"Please contact <a href=\"mailto:open-ouvert@tbs-sct.gc.ca\">open-ouvert"
+"@tbs-sct.gc.ca</a> with the email for your organization's Access to "
+"Information Coordinator."
+msgstr ""
+
+#: ckanext/canada/templates/internal/recombinant/resource_edit.html:33
 msgid "Guide"
 msgstr ""
 
-#: ckanext/canada/templates/internal/recombinant/resource_edit.html:24
+#: ckanext/canada/templates/internal/recombinant/resource_edit.html:38
 #, python-format
 msgid ""
 "For information on how to prepare, maintain and upload templates to the "
 "Registry, refer to the appropriate documentation posted on <a "
 "href=\"%(gclink)s\">GCPEDIA</a>"
-msgstr ""
-
-#: ckanext/canada/templates/internal/recombinant/resource_edit.html:54
-msgid "Column visibility"
 msgstr ""
 
 #: ckanext/canada/templates/internal/recombinant/update_pd_record.html:3
@@ -748,6 +977,55 @@ msgstr ""
 
 #: ckanext/canada/templates/internal/recombinant/snippets/xls_upload.html:57
 msgid "Invalid choice for"
+msgstr ""
+
+#: ckanext/canada/templates/internal/scheming/form_snippets/imso_approval_select.html:38
+msgid ""
+"<small class='text-info' style='margin-bottom: 15px; display: inline-"
+"block'> <p>Has approval been obtained? By selecting yes, you have ensured"
+" that the following statements are true:</p> <ol> "
+"<li><b>Confidentiality</b> - The data or information resource is not "
+"subject to confidentiality restrictions, such as Cabinet confidences, "
+"solicitor-client privilege, classified or protected information, advice "
+"or recommendations, third party information, or information obtained in "
+"confidence.</li> <li><b>Authority to Release</b> - The institution has "
+"the mandate, legislative authority or permission from a third party "
+"provider to release the data or information resources under the <a "
+"href='https://open.canada.ca/en/open-government-licence-canada'><u>Open "
+"Government Licence – Canada</u></a>.</li> <li><b>Formats</b> - The data "
+"or information resource is in an open and accessible format that complies"
+" with <a href='https://www.tbs-sct.gc.ca/pol/doc-"
+"eng.aspx?id=23601'><u>the Standard on Web Accessibility</u></a>.</li> "
+"<li><b>Privacy</b> - The data or information resource does not contain "
+"personal information, as defined in section 3 of the <a "
+"href='https://www.priv.gc.ca/en/privacy-topics/privacy-laws-in-canada"
+"/the-privacy-act/'><u>Privacy Act</u></a>, unless the individual to whom "
+"it relates has consented to its release or unless it meets criteria "
+"outlined in section 8(2) of the Privacy Act.</li> <li><b>Official "
+"Languages</b> - The data or information resource is available in both "
+"official languages and conforms to the requirements of the <a href='https"
+"://laws-lois.justice.gc.ca/eng/acts/O-3.01/'><u>Official Languages "
+"Act</u></a>.</li> <li><b>Security</b> - The data or information resource "
+"does not increase security risks to the institution, to other "
+"institutions, or to the government as a whole and conforms to the "
+"requirements of the <a href='https://www.tbs-sct.gc.ca/pol/doc-"
+"eng.aspx?id=16578'><u>Policy on Government Security</u></a> and its "
+"related instruments.</li> <li><b>Other - Legal / Regulatory / Policy / "
+"Contractual</b> - The release of data or other information resource "
+"complies with all other relevant legal, regulatory, contractual, and "
+"policy requirements (e.g., it is confirmed that there are no relevant "
+"legal, contractual, or third party, policy restrictions or "
+"limitations).</li> </ol> </small>"
+msgstr ""
+
+#: ckanext/canada/templates/internal/scheming/form_snippets/repeating_subfields.html:8
+#: ckanext/canada/templates/public/macros/canada_read.html:151
+#: ckanext/canada/templates/public/macros/form.html:248
+msgid "Remove"
+msgstr ""
+
+#: ckanext/canada/templates/internal/scheming/form_snippets/repeating_subfields.html:17
+msgid "Add"
 msgstr ""
 
 #: ckanext/canada/templates/internal/scheming/form_snippets/upload_only.html:7
@@ -783,33 +1061,39 @@ msgid ""
 "used to describe the record type and the placement in the registry"
 msgstr ""
 
-#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:35
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:34
+#: ckanext/canada/templates/public/snippets/package_item.html:14
+#, fuzzy
+msgid "Suggested Dataset"
+msgstr "No edited records"
+
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:37
 msgid ""
 "The portal to which the metadata record belongs (Open Data or Open "
 "Information)"
 msgstr ""
 
-#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:38
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:40
 msgid "Metadata Scheme"
 msgstr ""
 
-#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:41
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:43
 msgid "The name of the metadata scheme used (including profile name)"
 msgstr ""
 
-#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:44
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:46
 msgid "Metadata Scheme Version"
 msgstr ""
 
-#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:47
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:49
 msgid "The version of the metadata scheme used (version of the profile)"
 msgstr ""
 
-#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:50
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:52
 msgid "Metadata Record Identifier"
 msgstr ""
 
-#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:53
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:55
 msgid ""
 "A unique phrase or string which identifies the metadata record within the"
 " Open Government Portal"
@@ -833,70 +1117,34 @@ msgstr ""
 msgid "Use the Download URL field above to link to the related record."
 msgstr ""
 
+#: ckanext/canada/templates/internal/scheming/package/snippets/resource_form.html:60
+msgid "Data Validation"
+msgstr ""
+
 #: ckanext/canada/templates/internal/scheming/snippets/errors.html:5
 msgid "Errors in form"
 msgstr ""
 
-#: ckanext/canada/templates/internal/snippets/dataset_facets.html:3
-msgid "Open Dialogue"
+#: ckanext/canada/templates/internal/scheming/snippets/form_field.html:4
+#, fuzzy
+msgid "Are you sure you want to delete this status?"
+msgstr "Are you sure you want to delete this record?"
+
+#: ckanext/canada/templates/internal/scheming/snippets/form_field.html:21
+#: ckanext/canada/templates/public/organization/member_new.html:62
+#: ckanext/canada/templates/public/scheming/package/read.html:26
+msgid "Delete"
 msgstr ""
 
-#: ckanext/canada/templates/internal/snippets/dataset_facets.html:14
-#: ckanext/canada/templates/public/macros/canada_read.html:193
-msgid "Proactive Disclosure"
+#: ckanext/canada/templates/internal/snippets/dataset_facets.html:24
+#: ckanext/canada/templates/public/macros/canada_read.html:190
+#: ckanext/canada/templates/public/snippets/package_item.html:101
+msgid "Request sent to data owner – awaiting response"
 msgstr ""
 
 #: ckanext/canada/templates/internal/snippets/home_breadcrumb_item.html:2
-msgid "Home"
+msgid "Registry Home"
 msgstr ""
-
-#: ckanext/canada/templates/internal/snippets/menu.html:20
-#: ckanext/canada/templates/internal/snippets/menu.html:22
-#, fuzzy
-msgid "Search Data"
-msgstr "Search Records"
-
-#: ckanext/canada/templates/internal/snippets/menu.html:49
-#: ckanext/canada/templates/internal/snippets/menu.html:51
-#: ckanext/canada/templates/internal/snippets/user.html:60
-#: ckanext/canada/templates/public/snippets/user.html:59
-msgid "Register"
-msgstr ""
-
-#: ckanext/canada/templates/internal/snippets/menu.html:58
-msgid "My Account"
-msgstr ""
-
-#: ckanext/canada/templates/internal/snippets/menu.html:60
-#: ckanext/canada/templates/internal/snippets/user.html:33
-#: ckanext/canada/templates/public/snippets/user.html:32
-msgid "Dashboard"
-msgstr ""
-
-#: ckanext/canada/templates/internal/snippets/menu.html:61
-#: ckanext/canada/templates/public/user/edit_base.html:5
-msgid "My Profile"
-msgstr ""
-
-#: ckanext/canada/templates/internal/snippets/menu.html:62
-#: ckanext/canada/templates/internal/snippets/user.html:40
-#: ckanext/canada/templates/internal/snippets/user.html:42
-#: ckanext/canada/templates/public/snippets/user.html:39
-#: ckanext/canada/templates/public/snippets/user.html:41
-msgid "Edit Profile"
-msgstr ""
-
-#: ckanext/canada/templates/internal/snippets/menu.html:65
-#, fuzzy
-msgid "Publish Datasets"
-msgstr "Edit records"
-
-#: ckanext/canada/templates/internal/snippets/menu.html:71
-#: ckanext/canada/templates/internal/snippets/menu.html:73
-#: ckanext/canada/templates/public/user/dashboard.html:54
-#: ckanext/canada/templates/public/user/dashboard.html:60
-msgid "Add Dataset"
-msgstr "Add Record"
 
 #: ckanext/canada/templates/internal/snippets/publish_facet.html:22
 msgid "Published"
@@ -911,7 +1159,7 @@ msgid "Pending"
 msgstr ""
 
 #: ckanext/canada/templates/internal/snippets/publish_facet.html:40
-#: ckanext/canada/templates/public/package/read.html:57
+#: ckanext/canada/templates/public/package/read.html:12
 msgid "Draft"
 msgstr ""
 
@@ -926,26 +1174,11 @@ msgid "Social"
 msgstr ""
 
 #: ckanext/canada/templates/internal/snippets/user.html:12
-#: ckanext/canada/templates/public/snippets/user.html:11
-msgid "Signed in as"
-msgstr ""
-
-#: ckanext/canada/templates/internal/snippets/user.html:13
-#: ckanext/canada/templates/public/snippets/user.html:12
-msgid "View profile"
-msgstr ""
-
-#: ckanext/canada/templates/internal/snippets/user.html:22
 #: ckanext/canada/templates/public/snippets/user.html:21
 msgid "Sysadmin settings"
 msgstr ""
 
-#: ckanext/canada/templates/internal/snippets/user.html:24
-#: ckanext/canada/templates/public/snippets/user.html:23
-msgid "Admin"
-msgstr ""
-
-#: ckanext/canada/templates/internal/snippets/user.html:30
+#: ckanext/canada/templates/internal/snippets/user.html:20
 #: ckanext/canada/templates/public/snippets/user.html:29
 #, python-format
 msgid "Dashboard (%(num)d new item)"
@@ -953,9 +1186,30 @@ msgid_plural "Dashboard (%(num)d new items)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ckanext/canada/templates/internal/snippets/user.html:34
+#: ckanext/canada/templates/internal/snippets/user.html:23
+#: ckanext/canada/templates/public/snippets/user.html:32
+msgid "Dashboard"
+msgstr ""
+
+#: ckanext/canada/templates/internal/snippets/user.html:24
 #: ckanext/canada/templates/public/snippets/user.html:33
 msgid ": "
+msgstr ""
+
+#: ckanext/canada/templates/internal/snippets/user.html:30
+#: ckanext/canada/templates/internal/snippets/user.html:32
+#: ckanext/canada/templates/public/snippets/user.html:39
+#: ckanext/canada/templates/public/snippets/user.html:41
+msgid "Edit Profile"
+msgstr ""
+
+#: ckanext/canada/templates/internal/snippets/user.html:39
+msgid "Help using the Open Government Registry"
+msgstr ""
+
+#: ckanext/canada/templates/internal/snippets/user.html:40
+#: ckanext/canada/templates/internal/snippets/user.html:43
+msgid "Get Help"
 msgstr ""
 
 #: ckanext/canada/templates/internal/snippets/activities/changed_datastore.html:6
@@ -968,22 +1222,45 @@ msgstr "{actor} updated the record {dataset}"
 msgid "{actor} deleted the record {datastore} {datastore_detail}"
 msgstr "{actor} deleted the record {dataset}"
 
-#: ckanext/canada/templates/internal/user/list.html:6
+#: ckanext/canada/templates/internal/user/list.html:26
 msgid "Create an Account"
 msgstr ""
 
-#: ckanext/canada/templates/internal/user/list.html:13
+#: ckanext/canada/templates/internal/user/list.html:35
+#: ckanext/canada/templates/internal/user/new_user_form.html:7
+#: ckanext/canada/templates/internal/user/snippets/login_form.html:15
+#: ckanext/canada/templates/public/organization/member_new.html:29
+#: ckanext/canada/templates/public/user/edit_user_form.html:9
+#: ckanext/canada/templates/public/user/read_base.html:43
+#: ckanext/canada/templates/public/user/snippets/login_form.html:13
+msgid "Username"
+msgstr ""
+
+#: ckanext/canada/templates/internal/user/list.html:36
 #: ckanext/canada/templates/public/snippets/geomap_dynamic.html:18
 #: ckanext/canada/templates/public/snippets/geomap_static.html:15
 msgid "Name"
 msgstr ""
 
-#: ckanext/canada/templates/internal/user/list.html:27
+#: ckanext/canada/templates/internal/user/list.html:37
+#: ckanext/canada/templates/public/organization/member_new.html:59
+msgid "Role"
+msgstr ""
+
+#: ckanext/canada/templates/internal/user/list.html:52
 msgid "Sysadmin"
 msgstr ""
 
-#: ckanext/canada/templates/internal/user/list.html:27
+#: ckanext/canada/templates/internal/user/list.html:52
 msgid "Member"
+msgstr ""
+
+#: ckanext/canada/templates/internal/user/list.html:78
+msgid "Search and view users."
+msgstr ""
+
+#: ckanext/canada/templates/internal/user/list.html:80
+msgid "Search and manage users."
 msgstr ""
 
 #: ckanext/canada/templates/internal/user/login.html:9
@@ -1056,7 +1333,7 @@ msgstr ""
 #: ckanext/canada/templates/internal/user/new_user_form.html:8
 msgid ""
 "Use only lowercase letters (a-z) and numbers (0-9) with optional hyphens "
-"(-) and underscores (_)"
+"(-) and underscores (_). Example: joe-bloggs"
 msgstr ""
 
 #: ckanext/canada/templates/internal/user/new_user_form.html:10
@@ -1064,31 +1341,39 @@ msgid "Full Name"
 msgstr ""
 
 #: ckanext/canada/templates/internal/user/new_user_form.html:11
+msgid "Example: Joe Bloggs"
+msgstr ""
+
+#: ckanext/canada/templates/internal/user/new_user_form.html:13
 #: ckanext/canada/templates/public/user/edit_user_form.html:13
-#: ckanext/canada/templates/public/user/read_base.html:49
+#: ckanext/canada/templates/public/user/read_base.html:50
 msgid "Email"
 msgstr ""
 
 #: ckanext/canada/templates/internal/user/new_user_form.html:14
-msgid "Treasury Board Secretariat"
+msgid "Example: joe.bloggs@tbs-sct.gc.ca"
 msgstr ""
 
-#: ckanext/canada/templates/internal/user/new_user_form.html:15
+#: ckanext/canada/templates/internal/user/new_user_form.html:19
 msgid "Phone Number"
 msgstr ""
 
-#: ckanext/canada/templates/internal/user/new_user_form.html:16
-#: ckanext/canada/templates/internal/user/snippets/login_form.html:15
+#: ckanext/canada/templates/internal/user/new_user_form.html:20
+msgid "Example: 000 000 0000"
+msgstr ""
+
+#: ckanext/canada/templates/internal/user/new_user_form.html:22
+#: ckanext/canada/templates/internal/user/snippets/login_form.html:17
 #: ckanext/canada/templates/public/user/edit_user_form.html:32
 #: ckanext/canada/templates/public/user/snippets/login_form.html:15
 msgid "Password"
 msgstr ""
 
-#: ckanext/canada/templates/internal/user/new_user_form.html:17
+#: ckanext/canada/templates/internal/user/new_user_form.html:23
 msgid "Confirm"
 msgstr ""
 
-#: ckanext/canada/templates/internal/user/new_user_form.html:20
+#: ckanext/canada/templates/internal/user/new_user_form.html:26
 msgid ""
 " <h2>Terms and Conditions for the Open Government Registry</h2> "
 "<p><em>Privacy Statement</em></p> <p>The Government of Canada is "
@@ -1174,20 +1459,21 @@ msgid ""
 "have access to the Registry.</p> "
 msgstr ""
 
-#: ckanext/canada/templates/internal/user/new_user_form.html:65
+#: ckanext/canada/templates/internal/user/new_user_form.html:71
 msgid "I agree"
 msgstr ""
 
-#: ckanext/canada/templates/internal/user/new_user_form.html:66
+#: ckanext/canada/templates/internal/user/new_user_form.html:72
 msgid "I do not agree"
 msgstr ""
 
 #: ckanext/canada/templates/internal/user/perform_reset.html:8
+#, python-format
 msgid ""
 "1. Passwords must contain characters from at least 3 of the following 4 "
 "classes: * Upper Case Letters: A, B, C, … Z * Lower Case Letters: a, b, "
 "c, … z * Westernised Arabic Numerals: 0, 1, 2, … 9 * Special characters: "
-"({}[],.<>;:'\"?/|\\`~!@#$%^&*()_-+=). 2. No accented characters are "
+"({}[],.<>;:'\"?/|\\`~!@#$%%^&*()_-+=). 2. No accented characters are "
 "permitted. 3. All passwords must be at least 8 characters long. "
 msgstr ""
 
@@ -1201,6 +1487,26 @@ msgstr ""
 
 #: ckanext/canada/templates/internal/user/reports.html:6
 msgid "No reports are available"
+msgstr ""
+
+#: ckanext/canada/templates/internal/user/snippets/user_search.html:2
+#: ckanext/canada/templates/internal/user/snippets/user_search.html:5
+#: ckanext/canada/templates/internal/user/snippets/user_search.html:6
+#, fuzzy
+msgid "Search Users"
+msgstr "Search Records"
+
+#: ckanext/canada/templates/internal/xloader/resource_data.html:8
+#, fuzzy
+msgid "Are you sure you want to delete this DataStore table and Data Dictionary?"
+msgstr "Are you sure you want to delete this record?"
+
+#: ckanext/canada/templates/internal/xloader/resource_data.html:9
+msgid "Delete DataStore table"
+msgstr ""
+
+#: ckanext/canada/templates/internal/xloader/resource_data.html:18
+msgid "Upload to DataStore"
 msgstr ""
 
 #: ckanext/canada/templates/obd/package/search.html:3
@@ -1219,7 +1525,6 @@ msgid "Rate this dataset"
 msgstr "Create record"
 
 #: ckanext/canada/templates/obd/package/snippets/socialmedia.html:9
-#: ckanext/canada/templates/public/package/snippets/socialmedia.html:9
 msgid "Comment(s)"
 msgstr ""
 
@@ -1235,29 +1540,14 @@ msgid ""
 "href=\"http://open.canada.ca/en/forms/contact-us\">contact us</a>."
 msgstr ""
 
-#: ckanext/canada/templates/public/base.html:12
+#: ckanext/canada/templates/public/base.html:14
+#: ckanext/canada/templates/public/datatables/datatables_view.html:24
+#: ckanext/canada/templates/public/package/read_base.html:21
 msgid "Treasury Board of Canada Secretariat"
 msgstr ""
 
-#: ckanext/canada/templates/public/error_document_template.html:6
-msgid "We couldn't find that Web page"
-msgstr ""
-
-#: ckanext/canada/templates/public/error_document_template.html:8
-msgid "We encountered an error"
-msgstr ""
-
-#: ckanext/canada/templates/public/error_document_template.html:18
-msgid ""
-"We encountered an error and are unable to serve your request. Please try "
-"again in short time or contact <a href=\"mailto:open-ouvert@tbs-sct.gc.ca"
-"\">open-ouvert@tbs-sct.gc.ca</a> if you need immediate assistance or if "
-"this issue persists. Note that your login expires after 1 hour of "
-"inactivity."
-msgstr ""
-
 #: ckanext/canada/templates/public/footer.html:11
-msgid "/en/forms/contact-us"
+msgid "https://open.canada.ca/en/forms/contact-us"
 msgstr ""
 
 #: ckanext/canada/templates/public/footer.html:11
@@ -1386,7 +1676,7 @@ msgid "Search Canada.ca"
 msgstr ""
 
 #: ckanext/canada/templates/public/organization/about.html:4
-#: ckanext/canada/templates/public/page.html:60
+#: ckanext/canada/templates/public/page.html:39
 #: ckanext/canada/templates/public/user/edit_user_form.html:15
 msgid "About"
 msgstr ""
@@ -1457,6 +1747,67 @@ msgstr ""
 msgid " <p>Purge deleted datasets forever and irreversibly.</p> "
 msgstr " <p>Purge deleted records forever and irreversibly.</p> "
 
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:9
+msgid "CKAN Data API"
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:13
+msgid "Access resource data via a web API with powerful query support"
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:14
+msgid ""
+"Further information in the <a "
+"href=\"http://docs.ckan.org/en/latest/maintaining/datastore.html\" "
+"target=\"_blank\">main CKAN Data API and DataStore documentation</a>.</p>"
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:19
+msgid "Endpoints"
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:23
+msgid ""
+"The Data API can be accessed via the following actions of the CKAN action"
+" API."
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:29
+msgid "Query"
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:33
+msgid "Query (via SQL)"
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:45
+msgid "Querying"
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:49
+msgid "Query example (first 5 results)"
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:54
+msgid "Query example (results containing 'jones')"
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:59
+msgid "Query example (via SQL statement)"
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:70
+msgid "Example: Javascript"
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:74
+msgid "A simple ajax (JSONP) request to the data API using jQuery."
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:95
+msgid "Example: Python"
+msgstr ""
+
 #: ckanext/canada/templates/public/fgpv_vpgf/index.html:2
 #: ckanext/canada/templates/public/fgpv_vpgf/index.html:5
 #: ckanext/canada/templates/public/fgpv_vpgf/index.html:10
@@ -1467,31 +1818,30 @@ msgstr ""
 msgid "Search Open Maps"
 msgstr ""
 
-#: ckanext/canada/templates/public/fgpv_vpgf/index.html:41
+#: ckanext/canada/templates/public/fgpv_vpgf/index.html:42
 #: ckanext/canada/templates/public/snippets/search_form.html:53
 msgid "List Cart Items"
 msgstr ""
 
-#: ckanext/canada/templates/public/fgpv_vpgf/index.html:76
+#: ckanext/canada/templates/public/fgpv_vpgf/index.html:75
 msgid ""
 "This interactive map requires JavaScript. To view this content please "
 "enable JavaScript in your browser or download a browser that supports it."
+msgstr ""
+
+#: ckanext/canada/templates/public/fgpv_vpgf/index.html:82
+msgid "We’re sorry, your browser version is not supported by Open Maps"
 msgstr ""
 
 #: ckanext/canada/templates/public/macros/canada_read.html:36
 msgid "Keyword"
 msgstr ""
 
-#: ckanext/canada/templates/public/macros/canada_read.html:151
-#: ckanext/canada/templates/public/macros/form.html:248
-msgid "Remove"
-msgstr ""
-
-#: ckanext/canada/templates/public/macros/canada_read.html:217
+#: ckanext/canada/templates/public/macros/canada_read.html:226
 msgid "entry"
 msgstr ""
 
-#: ckanext/canada/templates/public/macros/canada_read.html:217
+#: ckanext/canada/templates/public/macros/canada_read.html:226
 msgid "entries"
 msgstr ""
 
@@ -1509,22 +1859,12 @@ msgstr ""
 msgid "(required)"
 msgstr ""
 
-#: ckanext/canada/templates/public/macros/form.html:418
-msgid " Or "
-msgstr ""
-
-#: ckanext/canada/templates/public/macros/form.html:426
+#: ckanext/canada/templates/public/macros/form.html:438
 msgid "Clear Upload"
 msgstr ""
 
-#: ckanext/canada/templates/public/organization/activity_stream.html:4
-#: ckanext/canada/templates/public/package/activity.html:3
-#: ckanext/canada/templates/public/user/activity_stream.html:12
-msgid "Activity Stream"
-msgstr ""
-
 #: ckanext/canada/templates/public/organization/activity_stream.html:11
-#: ckanext/canada/templates/public/package/read_base.html:179
+#: ckanext/canada/templates/public/package/read_base.html:159
 msgid "Atom Feed"
 msgstr ""
 
@@ -1549,11 +1889,57 @@ msgstr ""
 msgid "How about creating one?"
 msgstr ""
 
-#: ckanext/canada/templates/public/organization/member_new.html:11
+#: ckanext/canada/templates/public/organization/member_new.html:8
+msgid "Back to all members"
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/member_new.html:9
+#, fuzzy
+msgid "Edit Member"
+msgstr "Keep me logged in"
+
+#: ckanext/canada/templates/public/organization/member_new.html:9
+#: ckanext/canada/templates/public/organization/member_new.html:68
+msgid "Add Member"
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/member_new.html:17
+msgid "Existing User"
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/member_new.html:20
+msgid "If you wish to add an existing user, search for their username below."
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/member_new.html:39
+msgid "or"
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/member_new.html:45
+msgid "New User"
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/member_new.html:48
+msgid "If you wish to invite a new user, enter their email address."
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/member_new.html:51
+msgid "Email address"
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/member_new.html:62
+msgid "Are you sure you want to delete this member?"
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/member_new.html:64
+msgid "Update Member"
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/member_new.html:81
 msgid "What are roles?"
 msgstr ""
 
-#: ckanext/canada/templates/public/organization/member_new.html:14
+#: ckanext/canada/templates/public/organization/member_new.html:84
 msgid ""
 " <p><strong>Admin:</strong> Can add/edit and delete datasets, as well as "
 "manage organization members.</p> <p><strong>Editor:</strong> Can add and "
@@ -1568,7 +1954,7 @@ msgstr ""
 "but not add new records.</p> "
 
 #: ckanext/canada/templates/public/organization/members.html:3
-#: ckanext/canada/templates/public/snippets/organization.html:32
+#: ckanext/canada/templates/public/snippets/organization.html:30
 msgid "Members"
 msgstr ""
 
@@ -1648,50 +2034,36 @@ msgstr ""
 msgid "Return to Index"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read.html:19
-msgid "History"
-msgstr ""
-
-#: ckanext/canada/templates/public/package/read.html:23
-msgid "Undelete"
-msgstr ""
-
-#: ckanext/canada/templates/public/package/read.html:34
-msgid ""
-"This dataset has been deleted and is no longer accessible to non-admin "
-"users"
-msgstr ""
-
-#: ckanext/canada/templates/public/package/read.html:42
-#, python-format
-msgid ""
-" You're currently viewing an old version of this dataset. Some resources "
-"may no longer exist or the dataset may not display correctly. To see the "
-"current version, click <a href=\"%(url)s\">here</a>. "
-msgstr ""
-
-#: ckanext/canada/templates/public/package/read.html:60
-#: ckanext/canada/templates/public/package/read.html:66
-#: ckanext/canada/templates/public/package/snippets/resource_item.html:24
-#: ckanext/canada/templates/public/scheming/display_snippets/fluent_tags.html:17
-#: ckanext/canada/templates/public/snippets/package_item.html:29
-#: ckanext/canada/templates/public/snippets/package_item.html:43
+#: ckanext/canada/templates/public/package/read.html:15
+#: ckanext/canada/templates/public/package/read.html:40
+#: ckanext/canada/templates/public/package/snippets/resource_item.html:12
+#: ckanext/canada/templates/public/scheming/display_snippets/fluent_tags.html:9
+#: ckanext/canada/templates/public/snippets/package_item.html:38
+#: ckanext/canada/templates/public/snippets/package_item.html:52
 msgid ""
 "This third party metadata element has been translated using an automated "
-"translation tool. To report any discrepancies please contact "
-"open-ouvert@tbs-sct.gc.ca"
+"translation tool. To report any discrepancies please contact open-ouvert"
+"@tbs-sct.gc.ca"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read.html:72
+#: ckanext/canada/templates/public/package/read.html:30
+#, python-format
+msgid ""
+"You're currently viewing an old version of this dataset. Some resources "
+"may no longer exist or the dataset may not display correctly. To see the "
+"current version, click <a href=\"%(url)s\">here</a>."
+msgstr ""
+
+#: ckanext/canada/templates/public/package/read.html:46
 #: ckanext/canada/templates/public/snippets/search_form.html:54
 msgid "View on Map"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read.html:82
-msgid "Made available by the Government of Alberta"
+#: ckanext/canada/templates/public/package/read.html:57
+msgid "Made available by the "
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read.html:84
+#: ckanext/canada/templates/public/package/read.html:59
 msgid ""
 "<p>These resources are not under the control of the Government of Canada "
 "and the link is provided solely for the convenience of our website "
@@ -1710,156 +2082,119 @@ msgid ""
 "information.</p>"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read.html:125
-#: ckanext/canada/templates/public/snippets/package_item.html:58
+#: ckanext/canada/templates/public/package/read.html:97
+#: ckanext/canada/templates/public/snippets/package_item.html:67
 msgid "Issued by"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read.html:142
-msgid "Licence"
-msgstr ""
-
-#: ckanext/canada/templates/public/package/read.html:166
-#: ckanext/canada/templates/public/package/snippets/all_resources_list.html:27
+#: ckanext/canada/templates/public/package/read.html:133
 msgid "Related Items"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read.html:183
+#: ckanext/canada/templates/public/package/read.html:150
 msgid "Geographic Information"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read.html:216
+#: ckanext/canada/templates/public/package/read.html:185
 msgid "Contact Information"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read.html:218
+#: ckanext/canada/templates/public/package/read.html:187
 msgid "Delivery Point"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read.html:221
+#: ckanext/canada/templates/public/package/read.html:190
 msgid "City"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read.html:224
+#: ckanext/canada/templates/public/package/read.html:193
 msgid "Administrative Area"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read.html:227
+#: ckanext/canada/templates/public/package/read.html:196
 msgid "Postal Code"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read.html:230
+#: ckanext/canada/templates/public/package/read.html:199
 msgid "Country"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read.html:233
+#: ckanext/canada/templates/public/package/read.html:202
 msgid "Electronic Mail Address"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:19
+#: ckanext/canada/templates/public/package/read.html:231
+msgid "Similar records"
+msgstr ""
+
+#: ckanext/canada/templates/public/package/read_base.html:29
 msgid "{record_title} - Open Data Portal - Open Data"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:35
+#: ckanext/canada/templates/public/package/read_base.html:43
+#: ckanext/canada/templates/public/scheming/package/resource_read.html:7
 msgid "Additional Information"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:93
+#: ckanext/canada/templates/public/package/read_base.html:72
 msgid "Temporal Coverage"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:96
+#: ckanext/canada/templates/public/package/read_base.html:75
 msgid "to"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:98
+#: ckanext/canada/templates/public/package/read_base.html:77
 msgid "to undefined"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:100
+#: ckanext/canada/templates/public/package/read_base.html:79
 msgid "undefined to"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:129
+#: ckanext/canada/templates/public/package/read_base.html:109
 msgid "About this Record"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:134
+#: ckanext/canada/templates/public/package/read_base.html:114
 msgid "Record Released"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:138
+#: ckanext/canada/templates/public/package/read_base.html:118
 msgid "Record Modified"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:142
+#: ckanext/canada/templates/public/package/read_base.html:122
 msgid "Record ID"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:146
+#: ckanext/canada/templates/public/package/read_base.html:126
 msgid "Metadata"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:150
+#: ckanext/canada/templates/public/package/read_base.html:130
 msgid "Link to JSON format"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:156
+#: ckanext/canada/templates/public/package/read_base.html:136
 msgid "DCAT (JSON-LD)"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:163
+#: ckanext/canada/templates/public/package/read_base.html:143
 msgid "DCAT (XML)"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:171
+#: ckanext/canada/templates/public/package/read_base.html:151
 msgid "FGP Metadata"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/read_base.html:173
+#: ckanext/canada/templates/public/package/read_base.html:153
 msgid "HNAP ISO:19115 Metadata Record"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/resource_read.html:32
-msgid "Download"
+#: ckanext/canada/templates/public/package/resource_read.html:46
+msgid "Data Dictionary"
 msgstr ""
-
-#: ckanext/canada/templates/public/package/resource_read.html:36
-#, fuzzy
-msgid "From the asset abstract"
-msgstr "From the record abstract"
-
-#: ckanext/canada/templates/public/package/resource_read.html:39
-#, python-format
-msgid "Source: <a href=\"%(url)s\">%(dataset)s</a>"
-msgstr ""
-
-#: ckanext/canada/templates/public/package/resource_views.html:4
-msgid "View"
-msgstr ""
-
-#: ckanext/canada/templates/public/package/resource_views.html:10
-msgid "New view"
-msgstr ""
-
-#: ckanext/canada/templates/public/package/resource_views.html:28
-msgid "This resource has no views"
-msgstr ""
-
-#: ckanext/canada/templates/public/package/resources.html:4
-#: ckanext/canada/templates/public/package/snippets/resources.html:9
-#: ckanext/canada/templates/public/package/snippets/resources_list.html:7
-msgid "Resources"
-msgstr ""
-
-#: ckanext/canada/templates/public/package/resources.html:12
-#, fuzzy, python-format
-msgid ""
-" <p class=\"empty\">This asset has no resources, <a href=\"%(url)s\">why "
-"not add some?</a></p> "
-msgstr ""
-" <p class=\"empty\">This record has no data, <a href=\"%(url)s\">why not "
-"add some?</a></p> "
 
 #: ckanext/canada/templates/public/package/search.html:15
 msgid "Search Open Government"
@@ -1910,23 +2245,8 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/snippets/all_resources_list.html:34
-msgid "Relationship"
-msgstr ""
-
-#: ckanext/canada/templates/public/package/snippets/all_resources_list.html:36
-#: ckanext/canada/templates/public/package/snippets/resources_list.html:18
-msgid "Language"
-msgstr ""
-
-#: ckanext/canada/templates/public/package/snippets/all_resources_list.html:37
-#: ckanext/canada/templates/public/package/snippets/resources_list.html:19
-msgid "Links"
-msgstr ""
-
-#: ckanext/canada/templates/public/package/snippets/all_resources_list.html:78
-#: ckanext/canada/templates/public/package/snippets/resource_item.html:41
-msgid "Access"
+#: ckanext/canada/templates/public/package/snippets/resource_form.html:4
+msgid "URL"
 msgstr ""
 
 #: ckanext/canada/templates/public/package/snippets/resource_form.html:4
@@ -1937,22 +2257,13 @@ msgstr ""
 msgid "Save & add another"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/snippets/resource_item.html:40
-msgid "Resource"
+#: ckanext/canada/templates/public/package/snippets/resource_item.html:63
+msgid "Go to resource"
 msgstr ""
 
-#: ckanext/canada/templates/public/package/snippets/resources_list.html:15
-msgid "Resource Name"
+#: ckanext/canada/templates/public/package/snippets/resource_item.html:66
+msgid "Download"
 msgstr ""
-
-#: ckanext/canada/templates/public/package/snippets/resources_list.html:34
-#, fuzzy, python-format
-msgid ""
-" <p class=\"empty\">This dataset has no data, <a href=\"%(url)s\">why not"
-" add some?</a> "
-msgstr ""
-" <p class=\"empty\">This record has no data, <a href=\"%(url)s\">why not "
-"add some?</a></p> "
 
 #: ckanext/canada/templates/public/package/snippets/schemaorg.html:5
 msgid "Government of Canada Open Government Portal"
@@ -1962,6 +2273,10 @@ msgstr ""
 msgid ""
 "This catalog contains metadata records describing open datasets available"
 " from the Government of Canada"
+msgstr ""
+
+#: ckanext/canada/templates/public/package/snippets/schemaorg.html:23
+msgid "http://open.canada.ca"
 msgstr ""
 
 #: ckanext/canada/templates/public/package/snippets/schemaorg.html:26
@@ -1978,11 +2293,19 @@ msgid ""
 "Government Licence - Canada"
 msgstr ""
 
+#: ckanext/canada/templates/public/package/snippets/socialmedia.html:9
+msgid "Provide feedback"
+msgstr ""
+
+#: ckanext/canada/templates/public/scheming/display_snippets/email_with_parameters.html:7
+msgid "The following is a question related to the record {url} found on {site}"
+msgstr ""
+
 #: ckanext/canada/templates/public/snippets/activity_item.html:3
 msgid "New activity item"
 msgstr ""
 
-#: ckanext/canada/templates/public/snippets/dataset_facets.html:58
+#: ckanext/canada/templates/public/snippets/dataset_facets.html:59
 msgid "Viewable on Map"
 msgstr ""
 
@@ -2004,31 +2327,36 @@ msgstr ""
 msgid "Spatial Feature"
 msgstr ""
 
-#: ckanext/canada/templates/public/snippets/organization.html:25
+#: ckanext/canada/templates/public/snippets/menu.html:2
+msgid "Topics menu"
+msgstr ""
+
+#: ckanext/canada/templates/public/snippets/organization.html:23
 msgid "read more"
 msgstr ""
 
-#: ckanext/canada/templates/public/snippets/package_item.html:11
-msgid "Provincial"
-msgstr ""
-
-#: ckanext/canada/templates/public/snippets/package_item.html:13
-msgid "Federal"
-msgstr ""
-
-#: ckanext/canada/templates/public/snippets/package_item.html:47
+#: ckanext/canada/templates/public/snippets/package_item.html:56
 msgid "This dataset has no description"
 msgstr "This record has no description"
 
-#: ckanext/canada/templates/public/snippets/package_item.html:66
+#: ckanext/canada/templates/public/snippets/package_item.html:86
+#: ckanext/canada/templates/public/snippets/package_item.html:99
+msgid "Status"
+msgstr ""
+
+#: ckanext/canada/templates/public/snippets/package_item.html:94
+msgid "Date"
+msgstr ""
+
+#: ckanext/canada/templates/public/snippets/package_item.html:107
 msgid "Resource Formats"
 msgstr ""
 
-#: ckanext/canada/templates/public/snippets/package_item.html:80
+#: ckanext/canada/templates/public/snippets/package_item.html:123
 msgid "Add to Map Cart"
 msgstr ""
 
-#: ckanext/canada/templates/public/snippets/package_item.html:83
+#: ckanext/canada/templates/public/snippets/package_item.html:126
 msgid "Remove from Map Cart"
 msgstr ""
 
@@ -2086,58 +2414,20 @@ msgstr ""
 msgid "Empty Cart"
 msgstr ""
 
-#: ckanext/canada/templates/public/snippets/search_result_text.html:15
-msgid "{number} dataset found"
-msgid_plural "{number} datasets found"
-msgstr[0] "{number} record found"
-msgstr[1] "{number} records found"
-
-#: ckanext/canada/templates/public/snippets/search_result_text.html:16
-msgid "No datasets found"
-msgstr "No records found"
-
-#: ckanext/canada/templates/public/snippets/search_result_text.html:21
-msgid "{number} group found for \"{query}\""
-msgid_plural "{number} groups found for \"{query}\""
-msgstr[0] ""
-msgstr[1] ""
-
-#: ckanext/canada/templates/public/snippets/search_result_text.html:22
-msgid "No groups found for \"{query}\""
-msgstr ""
-
-#: ckanext/canada/templates/public/snippets/search_result_text.html:23
-msgid "{number} group found"
-msgid_plural "{number} groups found"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ckanext/canada/templates/public/snippets/search_result_text.html:24
-msgid "No groups found"
-msgstr ""
-
-#: ckanext/canada/templates/public/snippets/search_result_text.html:27
-msgid "{number} organization found for \"{query}\""
-msgid_plural "{number} organizations found for \"{query}\""
-msgstr[0] ""
-msgstr[1] ""
-
-#: ckanext/canada/templates/public/snippets/search_result_text.html:28
-msgid "No organizations found for \"{query}\""
-msgstr ""
-
-#: ckanext/canada/templates/public/snippets/search_result_text.html:29
-msgid "{number} organization found"
-msgid_plural "{number} organizations found"
-msgstr[0] ""
-msgstr[1] ""
-
 #: ckanext/canada/templates/public/snippets/sort_by.html:12
 msgid "Order by"
 msgstr ""
 
 #: ckanext/canada/templates/public/snippets/sort_by.html:14
 msgid "Relevance"
+msgstr ""
+
+#: ckanext/canada/templates/public/snippets/user.html:59
+msgid "Register"
+msgstr ""
+
+#: ckanext/canada/templates/public/snippets/activities/deleted_datastore.html:6
+msgid "{actor} {activity_type} for resource \"{resource}\""
 msgstr ""
 
 #: ckanext/canada/templates/public/snippets/wet-boew/brand.html:4
@@ -2174,6 +2464,19 @@ msgstr "My Records"
 #, fuzzy
 msgid "You do not have any datasets"
 msgstr "You haven't created any records."
+
+#: ckanext/canada/templates/public/user/dashboard.html:54
+#: ckanext/canada/templates/public/user/dashboard.html:60
+msgid "Add Dataset"
+msgstr "Add Record"
+
+#: ckanext/canada/templates/public/user/edit.html:8
+msgid "Manage"
+msgstr ""
+
+#: ckanext/canada/templates/public/user/edit_base.html:5
+msgid "My Profile"
+msgstr ""
 
 #: ckanext/canada/templates/public/user/edit_user_form.html:7
 msgid "Change your details"
@@ -2251,26 +2554,32 @@ msgstr ""
 msgid "Open ID"
 msgstr ""
 
-#: ckanext/canada/templates/public/user/read_base.html:50
-#: ckanext/canada/templates/public/user/read_base.html:61
+#: ckanext/canada/templates/public/user/read_base.html:51
+#: ckanext/canada/templates/public/user/read_base.html:62
 msgid "This means only you can see this"
 msgstr ""
 
-#: ckanext/canada/templates/public/user/read_base.html:50
-#: ckanext/canada/templates/public/user/read_base.html:61
+#: ckanext/canada/templates/public/user/read_base.html:51
+#: ckanext/canada/templates/public/user/read_base.html:62
 msgid "Private"
 msgstr ""
 
-#: ckanext/canada/templates/public/user/read_base.html:55
+#: ckanext/canada/templates/public/user/read_base.html:56
 msgid "Member Since"
 msgstr ""
 
-#: ckanext/canada/templates/public/user/read_base.html:60
+#: ckanext/canada/templates/public/user/read_base.html:61
+#: ckanext/canada/templates/public/user/read_base.html:69
 msgid "API Key"
 msgstr ""
 
-#: ckanext/canada/templates/public/user/request_reset.html:16
-msgid "Request Reset"
+#: ckanext/canada/templates/public/user/read_base.html:64
+msgid "Show API Key"
+msgstr ""
+
+#: ckanext/canada/templates/public/user/read_base.html:70
+#: ckanext/canada/templates/public/user/read_base.html:76
+msgid "Close"
 msgstr ""
 
 #: ckanext/canada/templates/public/user/snippets/followee_dropdown.html:13
@@ -3366,12 +3675,6 @@ msgstr "Keep me logged in"
 #~ msgid "Homepage"
 #~ msgstr ""
 
-#~ msgid ""
-#~ "Cannot purge package %s as associated"
-#~ " revision %s includes non-deleted "
-#~ "packages %s"
-#~ msgstr ""
-
 #~ msgid "Problem purging revision %s: %s"
 #~ msgstr ""
 
@@ -3528,19 +3831,6 @@ msgstr "Keep me logged in"
 #~ msgid "This site is currently off-line. Database is not initialised."
 #~ msgstr ""
 
-#~ msgid ""
-#~ "Please <a href=\"{link}\">update your "
-#~ "profile</a> and add your email address"
-#~ " and your full name. {site} uses "
-#~ "your email address if you need to"
-#~ " reset your password."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Please <a href=\"%s\">update your profile</a>"
-#~ " and add your email address. "
-#~ msgstr ""
-
 #~ msgid "%s uses your email address if you need to reset your password."
 #~ msgstr ""
 
@@ -3558,15 +3848,6 @@ msgstr "Keep me logged in"
 
 #~ msgid "Invalid revision format: %r"
 #~ msgstr ""
-
-#~ msgid ""
-#~ "Viewing {package_type} datasets in {format}"
-#~ " format is not supported (template "
-#~ "file {file} not found)."
-#~ msgstr ""
-#~ "Viewing {package_type} records in {format} "
-#~ "format is not supported (template file"
-#~ " {file} not found)."
 
 #~ msgid "CKAN Dataset Revision History"
 #~ msgstr "CKAN Record Revision History"
@@ -3760,12 +4041,6 @@ msgstr "Keep me logged in"
 #~ msgid "Bad Captcha. Please try again."
 #~ msgstr ""
 
-#~ msgid ""
-#~ "User \"%s\" is now registered but "
-#~ "you are still logged in as \"%s\""
-#~ " from before"
-#~ msgstr ""
-
 #~ msgid "Unauthorized to edit a user."
 #~ msgstr ""
 
@@ -3783,9 +4058,6 @@ msgstr "Keep me logged in"
 
 #~ msgid "Please check your inbox for a reset code."
 #~ msgstr ""
-#~ "Please check your e-mail inbox in "
-#~ "order to confirm your password reset "
-#~ "request."
 
 #~ msgid "Could not send reset link: %s"
 #~ msgstr ""
@@ -3844,13 +4116,6 @@ msgstr "Keep me logged in"
 #~ msgid "{actor} updated their profile"
 #~ msgstr ""
 
-#~ msgid ""
-#~ "{actor} updated the {related_type} "
-#~ "{related_item} of the dataset {dataset}"
-#~ msgstr ""
-#~ "{actor} updated the {related_type} "
-#~ "{related_item} of the record {dataset}"
-
 #~ msgid "{actor} updated the {related_type} {related_item}"
 #~ msgstr ""
 
@@ -3898,11 +4163,6 @@ msgstr "Keep me logged in"
 
 #~ msgid "{actor} started following {group}"
 #~ msgstr ""
-
-#~ msgid ""
-#~ "{actor} added the {related_type} "
-#~ "{related_item} to the dataset {dataset}"
-#~ msgstr "{actor} added the {related_type} {related_item} to the record {dataset}"
 
 #~ msgid "{actor} added the {related_type} {related_item}"
 #~ msgstr ""
@@ -3952,29 +4212,34 @@ msgstr "Keep me logged in"
 #~ msgstr ""
 
 #~ msgid "{mins} minute ago"
-#~ msgid_plural "{mins} minutes ago"
-#~ msgstr[0] ""
-#~ msgstr[1] ""
+#~ msgstr ""
+
+#~ msgid "{mins} minutes ago"
+#~ msgstr ""
 
 #~ msgid "{hours} hour ago"
-#~ msgid_plural "{hours} hours ago"
-#~ msgstr[0] ""
-#~ msgstr[1] ""
+#~ msgstr ""
+
+#~ msgid "{hours} hours ago"
+#~ msgstr ""
 
 #~ msgid "{days} day ago"
-#~ msgid_plural "{days} days ago"
-#~ msgstr[0] ""
-#~ msgstr[1] ""
+#~ msgstr ""
+
+#~ msgid "{days} days ago"
+#~ msgstr ""
 
 #~ msgid "{months} month ago"
-#~ msgid_plural "{months} months ago"
-#~ msgstr[0] ""
-#~ msgstr[1] ""
+#~ msgstr ""
+
+#~ msgid "{months} months ago"
+#~ msgstr ""
 
 #~ msgid "over {years} year ago"
-#~ msgid_plural "over {years} years ago"
-#~ msgstr[0] ""
-#~ msgstr[1] ""
+#~ msgstr ""
+
+#~ msgid "over {years} years ago"
+#~ msgstr ""
 
 #~ msgid "{month} {day}, {year}, {hour:02}:{min:02}"
 #~ msgstr ""
@@ -4034,18 +4299,19 @@ msgstr "Keep me logged in"
 #~ msgstr ""
 
 #~ msgid "Created new dataset."
-#~ msgstr "Created new record."
+#~ msgstr ""
 
 #~ msgid "Edited resources."
-#~ msgstr ""
+#~ msgstr "Created new record."
 
 #~ msgid "Edited settings."
 #~ msgstr ""
 
 #~ msgid "{number} recent view"
-#~ msgid_plural "{number} recent views"
-#~ msgstr[0] ""
-#~ msgstr[1] ""
+#~ msgstr ""
+
+#~ msgid "{number} recent views"
+#~ msgstr ""
 
 #~ msgid "Dear %s,"
 #~ msgstr ""
@@ -4054,25 +4320,6 @@ msgstr "Keep me logged in"
 #~ msgstr ""
 
 #~ msgid "No recipient email address available!"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have requested your password on {site_title} to be reset.\n"
-#~ "\n"
-#~ "Please click the following link to confirm this request:\n"
-#~ "\n"
-#~ "   {reset_link}\n"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "You have been invited to {site_title}."
-#~ " A user has already been createdto"
-#~ " you with the username {user_name}. "
-#~ "You can change it later.\n"
-#~ "\n"
-#~ "To accept this invite, please reset your password at:\n"
-#~ "\n"
-#~ "   {reset_link}\n"
 #~ msgstr ""
 
 #~ msgid "Reset your password"
@@ -4103,10 +4350,10 @@ msgstr "Keep me logged in"
 #~ msgstr ""
 
 #~ msgid "Dataset"
-#~ msgstr "Record"
+#~ msgstr ""
 
 #~ msgid "Group"
-#~ msgstr ""
+#~ msgstr "Record"
 
 #~ msgid "Could not parse as valid JSON"
 #~ msgstr ""
@@ -4115,16 +4362,16 @@ msgstr "Keep me logged in"
 #~ msgstr ""
 
 #~ msgid "You cannot remove a dataset from an existing organization"
-#~ msgstr "You cannot remove a record from an existing organization"
+#~ msgstr ""
 
 #~ msgid "Organization does not exist"
-#~ msgstr ""
+#~ msgstr "You cannot remove a record from an existing organization"
 
 #~ msgid "You cannot add a dataset to this organization"
-#~ msgstr "You cannot add a record to this organization"
+#~ msgstr ""
 
 #~ msgid "Invalid integer"
-#~ msgstr ""
+#~ msgstr "You cannot add a record to this organization"
 
 #~ msgid "Must be a natural number"
 #~ msgstr ""
@@ -4159,11 +4406,6 @@ msgstr "Keep me logged in"
 #~ msgid "Name must be a maximum of %i characters long"
 #~ msgstr ""
 
-#~ msgid ""
-#~ "Must be purely lowercase alphanumeric "
-#~ "(ascii) characters and these symbols: -_"
-#~ msgstr ""
-
 #~ msgid "That URL is already in use."
 #~ msgstr ""
 
@@ -4192,10 +4434,10 @@ msgstr "Keep me logged in"
 #~ msgstr ""
 
 #~ msgid "That login name is not available."
-#~ msgstr "That username is not available."
+#~ msgstr ""
 
 #~ msgid "Please enter both passwords"
-#~ msgstr ""
+#~ msgstr "That username is not available."
 
 #~ msgid "Passwords must be strings"
 #~ msgstr ""
@@ -4204,12 +4446,6 @@ msgstr "Keep me logged in"
 #~ msgstr ""
 
 #~ msgid "The passwords you entered do not match"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Edit not allowed as it looks like"
-#~ " spam. Please avoid links in your "
-#~ "description."
 #~ msgstr ""
 
 #~ msgid "Name must be at least %s characters long"
@@ -4240,10 +4476,10 @@ msgstr "Keep me logged in"
 #~ msgstr ""
 
 #~ msgid "Datasets with no organization can't be private."
-#~ msgstr "Records with no organization can't be private."
+#~ msgstr ""
 
 #~ msgid "Not a list"
-#~ msgstr ""
+#~ msgstr "Records with no organization can't be private."
 
 #~ msgid "Not a string"
 #~ msgstr ""
@@ -4297,10 +4533,10 @@ msgstr "Keep me logged in"
 #~ msgstr ""
 
 #~ msgid "You must be logged in to follow a dataset."
-#~ msgstr "You must be logged in to follow a record."
+#~ msgstr ""
 
 #~ msgid "User {username} does not exist."
-#~ msgstr ""
+#~ msgstr "You must be logged in to follow a record."
 
 #~ msgid "You must be logged in to follow a group."
 #~ msgstr ""
@@ -4369,25 +4605,25 @@ msgstr "Keep me logged in"
 #~ msgstr ""
 
 #~ msgid "User %s not authorized to add dataset to this organization"
-#~ msgstr "User %s not authorized to add record to this organization"
+#~ msgstr ""
 
 #~ msgid "You must be a sysadmin to create a featured related item"
-#~ msgstr ""
+#~ msgstr "User %s not authorized to add record to this organization"
 
 #~ msgid "You must be logged in to add a related item"
 #~ msgstr ""
 
 #~ msgid "No dataset id provided, cannot check auth."
-#~ msgstr "No record id provided, cannot check auth."
+#~ msgstr ""
 
 #~ msgid "No package found for this resource, cannot check auth."
-#~ msgstr ""
+#~ msgstr "No record id provided, cannot check auth."
 
 #~ msgid "User %s not authorized to create resources on dataset %s"
-#~ msgstr "User %s not authorized to create resources on record %s"
+#~ msgstr ""
 
 #~ msgid "User %s not authorized to edit these packages"
-#~ msgstr ""
+#~ msgstr "User %s not authorized to create resources on record %s"
 
 #~ msgid "User %s not authorized to create groups"
 #~ msgstr ""
@@ -4656,12 +4892,6 @@ msgstr "Keep me logged in"
 #~ msgid "Unable to get data for uploaded file"
 #~ msgstr ""
 
-#~ msgid ""
-#~ "You are uploading a file. Are you"
-#~ " sure you want to navigate away "
-#~ "and stop this upload?"
-#~ msgstr ""
-
 #~ msgid "Reorder resource view"
 #~ msgstr ""
 
@@ -4678,12 +4908,6 @@ msgstr "Keep me logged in"
 #~ msgstr ""
 
 #~ msgid "Open Knowledge Foundation"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "<strong>Powered by</strong> <a class=\"hide-"
-#~ "text ckan-footer-logo\" "
-#~ "href=\"http://ckan.org\">CKAN</a>"
 #~ msgstr ""
 
 #~ msgid "Edit settings"
@@ -4713,20 +4937,7 @@ msgstr "Keep me logged in"
 #~ msgid "Access resource data via a web API with powerful query support"
 #~ msgstr ""
 
-#~ msgid ""
-#~ " Further information in the <a       "
-#~ "href=\"http://docs.ckan.org/en/latest/maintaining/datastore.html\" "
-#~ "target=\"_blank\">main CKAN Data API and "
-#~ "DataStore documentation</a>.</p> "
-#~ msgstr ""
-
 #~ msgid "Endpoints"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The Data API can be accessed via"
-#~ " the following actions of the CKAN"
-#~ " action API."
 #~ msgstr ""
 
 #~ msgid "Create"
@@ -4861,17 +5072,6 @@ msgstr "Keep me logged in"
 #~ msgid "Edit Member"
 #~ msgstr ""
 
-#~ msgid ""
-#~ " <p><strong>Admin:</strong> Can edit group "
-#~ "information, as well as manage "
-#~ "organization members.</p> <p><strong>Member:</strong> "
-#~ "Can add/remove datasets from groups</p> "
-#~ msgstr ""
-#~ " <p><strong>Admin:</strong> Can edit group "
-#~ "information, as well as manage "
-#~ "organization members.</p> <p><strong>Member:</strong> "
-#~ "Can add/remove records from groups</p> "
-
 #~ msgid "Create a Group"
 #~ msgstr ""
 
@@ -4885,13 +5085,13 @@ msgstr "Keep me logged in"
 #~ msgstr ""
 
 #~ msgid "Search datasets..."
-#~ msgstr "Search records..."
+#~ msgstr ""
 
 #~ msgid "Datasets in group: {group}"
-#~ msgstr "Records in group: {group}"
+#~ msgstr "Search records..."
 
 #~ msgid "Recent Revision History"
-#~ msgstr ""
+#~ msgstr "Records in group: {group}"
 
 #~ msgid "My Group"
 #~ msgstr ""
@@ -4912,29 +5112,10 @@ msgstr "Keep me logged in"
 #~ msgstr ""
 
 #~ msgid "Remove dataset from this group"
-#~ msgstr "Remove record from this group"
+#~ msgstr ""
 
 #~ msgid "What are Groups?"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " You can use CKAN Groups to "
-#~ "create and manage collections of "
-#~ "datasets. This could be to catalogue "
-#~ "datasets for a particular project or "
-#~ "team, or on a particular theme, or"
-#~ " as a very simple way to help"
-#~ " people find and search your own "
-#~ "published datasets. "
-#~ msgstr ""
-#~ " You can use CKAN Groups to "
-#~ "create and manage collections of "
-#~ "records. This could be to catalogue "
-#~ "records for a particular project or "
-#~ "team, or on a particular theme, or"
-#~ " as a very simple way to help"
-#~ " people find and search your own "
-#~ "published records. "
+#~ msgstr "Remove record from this group"
 
 #~ msgid "Compare"
 #~ msgstr ""
@@ -4954,52 +5135,7 @@ msgstr "Keep me logged in"
 #~ msgid "Welcome"
 #~ msgstr ""
 
-#~ msgid ""
-#~ " <p>CKAN is the world’s leading "
-#~ "open-source data portal platform.</p> "
-#~ "<p>CKAN is a complete out-of-"
-#~ "the-box software solution that makes "
-#~ "data accessible and usable – by "
-#~ "providing tools to streamline publishing, "
-#~ "sharing, finding and using data "
-#~ "(including storage of data and provision"
-#~ " of robust data APIs). CKAN is "
-#~ "aimed at data publishers (national and"
-#~ " regional governments, companies and "
-#~ "organizations) wanting to make their "
-#~ "data open and available.</p> <p>CKAN is"
-#~ " used by governments and user groups"
-#~ " worldwide and powers a variety of"
-#~ " official and community data portals "
-#~ "including portals for local, national "
-#~ "and international government, such as "
-#~ "the UK’s <a "
-#~ "href=\"http://data.gov.uk\">data.gov.uk</a> and the "
-#~ "European Union’s <a "
-#~ "href=\"http://publicdata.eu/\">publicdata.eu</a>, the "
-#~ "Brazilian <a "
-#~ "href=\"http://dados.gov.br/\">dados.gov.br</a>, Dutch and"
-#~ " Netherland government portals, as well "
-#~ "as city and municipal sites in the"
-#~ " US, UK, Argentina, Finland and "
-#~ "elsewhere.</p> <p>CKAN: <a "
-#~ "href=\"http://ckan.org/\">http://ckan.org/</a><br /> CKAN"
-#~ " Tour: <a "
-#~ "href=\"http://ckan.org/tour/\">http://ckan.org/tour/</a><br />"
-#~ " Features overview: <a "
-#~ "href=\"http://ckan.org/features/\">http://ckan.org/features/</a></p>"
-#~ " "
-#~ msgstr ""
-
 #~ msgid "Welcome to CKAN"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This is a nice introductory paragraph"
-#~ " about CKAN or the site in "
-#~ "general. We don't have any copy to"
-#~ " go here yet but soon we will"
-#~ " "
 #~ msgstr ""
 
 #~ msgid "This is a featured section"
@@ -5018,13 +5154,13 @@ msgstr "Keep me logged in"
 #~ msgstr ""
 
 #~ msgid "dataset"
-#~ msgstr "record"
+#~ msgstr ""
 
 #~ msgid "datasets"
-#~ msgstr "records"
+#~ msgstr "record"
 
 #~ msgid "organization"
-#~ msgstr ""
+#~ msgstr "records"
 
 #~ msgid "organizations"
 #~ msgstr ""
@@ -5041,13 +5177,6 @@ msgstr "Keep me logged in"
 #~ msgid "related items"
 #~ msgstr ""
 
-#~ msgid ""
-#~ "You can use <a href=\"#markdown\" "
-#~ "title=\"Markdown quick reference\" data-"
-#~ "target=\"popover\" data-content=\"%(markdown_tooltip)s\""
-#~ " data-html=\"true\">Markdown formatting</a> here"
-#~ msgstr ""
-
 #~ msgid "This field is required"
 #~ msgstr ""
 
@@ -5061,19 +5190,19 @@ msgstr "Keep me logged in"
 #~ msgstr ""
 
 #~ msgid "Sorry no datasets found for \"{query}\""
-#~ msgstr "Sorry no records found for \"{query}\""
+#~ msgstr ""
 
 #~ msgid "Make public"
-#~ msgstr ""
+#~ msgstr "Sorry no records found for \"{query}\""
 
 #~ msgid "Make private"
 #~ msgstr ""
 
 #~ msgid "This organization has no datasets associated to it"
-#~ msgstr "This organization has no records associated to it"
+#~ msgstr ""
 
 #~ msgid "Are you sure you want to delete organization - {name}?"
-#~ msgstr ""
+#~ msgstr "This organization has no records associated to it"
 
 #~ msgid "Add Organization"
 #~ msgstr ""
@@ -5085,68 +5214,19 @@ msgstr "Keep me logged in"
 #~ msgstr ""
 
 #~ msgid "Datasets in organization: {group}"
-#~ msgstr "Records in organization: {group}"
-
-#~ msgid ""
-#~ " <p>Organizations act like publishing "
-#~ "departments for datasets (for example, "
-#~ "the Department of Health). This means"
-#~ " that datasets can be published by"
-#~ " and belong to a department instead"
-#~ " of an individual user.</p> <p>Within "
-#~ "organizations, admins can assign roles "
-#~ "and authorise its members, giving "
-#~ "individual users the right to publish"
-#~ " datasets from that particular organisation"
-#~ " (e.g. Office of National Statistics).</p>"
-#~ " "
 #~ msgstr ""
-#~ " <p>Organizations act like publishing "
-#~ "agents for records (Example: Health "
-#~ "Canada). This means records can be "
-#~ "published by, and belong to an "
-#~ "organization rather than an individual "
-#~ "user.</p> <p>Registry Administrator can grant"
-#~ " authorized users access to publish "
-#~ "records for their own organizations.</p>"
-
-#~ msgid ""
-#~ "Are you sure you want to delete"
-#~ " this Organization? This will delete "
-#~ "all the public and private datasets "
-#~ "belonging to this organization."
-#~ msgstr ""
-#~ "Are you sure you want to delete"
-#~ " this Organization? This will delete "
-#~ "all the public and private records "
-#~ "belonging to this organization."
 
 #~ msgid "View {organization_name}"
 #~ msgstr ""
 
 #~ msgid "Create Dataset"
-#~ msgstr "Create Record"
-
-#~ msgid ""
-#~ " A CKAN Dataset is a collection"
-#~ " of data resources (such as files),"
-#~ " together with a description and "
-#~ "other information, at a fixed URL. "
-#~ "Datasets are what users see when "
-#~ "searching for data. "
 #~ msgstr ""
-#~ " A CKAN Record is a collection "
-#~ "of data resources (such as files), "
-#~ "together with a description and other"
-#~ " information, at a fixed URL. Records"
-#~ " are what users see when searching"
-#~ " for data. "
 
 #~ msgid "View dataset"
-#~ msgstr "View record"
+#~ msgstr ""
 
 #~ msgid "Edit metadata"
-#~ msgstr ""
+#~ msgstr "View record"
 
 #~ msgid "Edit view"
 #~ msgstr ""
@@ -5155,22 +5235,22 @@ msgstr "Keep me logged in"
 #~ msgstr ""
 
 #~ msgid "Associate this group with this dataset"
-#~ msgstr "Associate this group with this record"
+#~ msgstr ""
 
 #~ msgid "Add to group"
-#~ msgstr ""
+#~ msgstr "Associate this group with this record"
 
 #~ msgid "There are no groups associated with this dataset"
-#~ msgstr "There are no groups associated with this record"
+#~ msgstr ""
 
 #~ msgid "Update Dataset"
-#~ msgstr "Update Record"
+#~ msgstr "There are no groups associated with this record"
 
 #~ msgid "Add data to the dataset"
-#~ msgstr "Add data to the record"
+#~ msgstr "Update Record"
 
 #~ msgid "Add New Resource"
-#~ msgstr ""
+#~ msgstr "Add data to the record"
 
 #~ msgid "Add resource"
 #~ msgstr ""
@@ -5181,30 +5261,8 @@ msgstr "Keep me logged in"
 #~ msgid "Add view"
 #~ msgstr ""
 
-#~ msgid ""
-#~ " Data Explorer views may be slow"
-#~ " and unreliable unless the DataStore "
-#~ "extension is enabled. For more "
-#~ "information, please see the <a "
-#~ "href='http://docs.ckan.org/en/latest/maintaining/data-"
-#~ "viewer.html#viewing-structured-data-the-"
-#~ "data-explorer' target='_blank'>Data Explorer "
-#~ "documentation</a>. "
-#~ msgstr ""
-
 #~ msgid "Add"
 #~ msgstr ""
-
-#~ msgid ""
-#~ "This is an old revision of this"
-#~ " dataset, as edited at %(timestamp)s. "
-#~ "It may differ significantly from the "
-#~ "<a href=\"%(url)s\">current revision</a>."
-#~ msgstr ""
-#~ "This is an old revision of this"
-#~ " record, as edited at %(timestamp)s. "
-#~ "It may differ significantly from the "
-#~ "<a href=\"%(url)s\">current revision</a>."
 
 #~ msgid "Related Media for {dataset}"
 #~ msgstr ""
@@ -5275,15 +5333,6 @@ msgstr "Keep me logged in"
 #~ msgid "The site administrators may not have enabled the relevant view plugins"
 #~ msgstr ""
 
-#~ msgid ""
-#~ "If a view requires the DataStore, "
-#~ "the DataStore plugin may not be "
-#~ "enabled, or the data may not have"
-#~ " been pushed to the DataStore, or "
-#~ "the DataStore hasn't finished processing "
-#~ "the data yet"
-#~ msgstr ""
-
 #~ msgid "unknown"
 #~ msgstr ""
 
@@ -5300,19 +5349,6 @@ msgstr "Keep me logged in"
 #~ msgstr ""
 
 #~ msgid "full {format} dump"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " You can also access this registry"
-#~ " using the %(api_link)s (see "
-#~ "%(api_doc_link)s) or download a %(dump_link)s."
-#~ " "
-#~ msgstr ""
-
-#~ msgid ""
-#~ " You can also access this registry"
-#~ " using the %(api_link)s (see "
-#~ "%(api_doc_link)s). "
 #~ msgstr ""
 
 #~ msgid "All views"
@@ -5334,19 +5370,12 @@ msgstr "Keep me logged in"
 #~ msgstr ""
 
 #~ msgid "eg. my-dataset"
-#~ msgstr "eg. my-record"
+#~ msgstr ""
 
 #~ msgid "eg. Some useful notes about the data"
-#~ msgstr ""
+#~ msgstr "eg. my-record"
 
 #~ msgid "eg. economy, mental health, government"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " License definitions and additional "
-#~ "information can be found at <a "
-#~ "href=\"http://opendefinition.org/licenses/\">opendefinition.org</a>"
-#~ " "
 #~ msgstr ""
 
 #~ msgid "No organization"
@@ -5361,35 +5390,14 @@ msgstr "Keep me logged in"
 #~ msgid "Active"
 #~ msgstr ""
 
-#~ msgid ""
-#~ "The <i>data license</i> you select above"
-#~ " only applies to the contents of "
-#~ "any resource files that you add to"
-#~ " this dataset. By submitting this "
-#~ "form, you agree to release the "
-#~ "<i>metadata</i> values that you enter "
-#~ "into the form under the <a "
-#~ "href=\"http://opendatacommons.org/licenses/odbl/1-0/\">Open "
-#~ "Database License</a>."
-#~ msgstr ""
-#~ "The <i>data license</i> you select above"
-#~ " only applies to the contents of "
-#~ "any resource files that you add to"
-#~ " this record. By submitting this "
-#~ "form, you agree to release the "
-#~ "<i>metadata</i> values that you enter "
-#~ "into the form under the <a "
-#~ "href=\"http://opendatacommons.org/licenses/odbl/1-0/\">Open "
-#~ "Database License</a>."
-
 #~ msgid "Next: Add Data"
 #~ msgstr ""
 
 #~ msgid "http://example.com/dataset.json"
-#~ msgstr "http://example.com/record.json"
+#~ msgstr ""
 
 #~ msgid "1.0"
-#~ msgstr ""
+#~ msgstr "http://example.com/record.json"
 
 #~ msgid "Joe Bloggs"
 #~ msgstr ""
@@ -5463,12 +5471,6 @@ msgstr "Keep me logged in"
 #~ msgid "Embed resource view"
 #~ msgstr ""
 
-#~ msgid ""
-#~ "You can copy and paste the embed"
-#~ " code into a CMS or blog "
-#~ "software that supports raw HTML"
-#~ msgstr ""
-
 #~ msgid "Width"
 #~ msgstr ""
 
@@ -5485,13 +5487,13 @@ msgstr "Keep me logged in"
 #~ msgstr ""
 
 #~ msgid "This dataset has no data"
-#~ msgstr "This record has no data"
+#~ msgstr ""
 
 #~ msgid "Read dataset as of %s"
-#~ msgstr "Read record as of %s"
+#~ msgstr "This record has no data"
 
 #~ msgid "eg. My View"
-#~ msgstr ""
+#~ msgstr "Read record as of %s"
 
 #~ msgid "eg. Information about my view"
 #~ msgstr ""
@@ -5517,35 +5519,10 @@ msgstr "Keep me logged in"
 #~ msgid "What are related items?"
 #~ msgstr ""
 
-#~ msgid ""
-#~ " <p>Related Media is any app, "
-#~ "article, visualisation or idea related "
-#~ "to this dataset.</p> <p>For example, it"
-#~ " could be a custom visualisation, "
-#~ "pictograph or bar chart, an app "
-#~ "using all or part of the data "
-#~ "or even a news story that "
-#~ "references this dataset.</p> "
-#~ msgstr ""
-#~ " <p>Related Media is any app, "
-#~ "article, visualisation or idea related "
-#~ "to this record.</p> <p>For example, it"
-#~ " could be a custom visualisation, "
-#~ "pictograph or bar chart, an app "
-#~ "using all or part of the data "
-#~ "or even a news story that "
-#~ "references this record.</p> "
-
 #~ msgid "Are you sure you want to delete related item - {name}?"
 #~ msgstr ""
 
 #~ msgid "Apps & Ideas"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " <p>Showing items <strong>%(first)s - "
-#~ "%(last)s</strong> of <strong>%(item_count)s</strong> "
-#~ "related items found</p> "
 #~ msgstr ""
 
 #~ msgid " <p><strong>%(item_count)s</strong> related items found</p> "
@@ -5556,17 +5533,6 @@ msgstr "Keep me logged in"
 
 #~ msgid "What are applications?"
 #~ msgstr ""
-
-#~ msgid ""
-#~ " These are applications built with "
-#~ "the datasets as well as ideas for"
-#~ " things that could be done with "
-#~ "them. "
-#~ msgstr ""
-#~ " These are applications built with "
-#~ "the records as well as ideas for"
-#~ " things that could be done with "
-#~ "them. "
 
 #~ msgid "Filter Results"
 #~ msgstr ""
@@ -5650,10 +5616,10 @@ msgstr "Keep me logged in"
 #~ msgstr ""
 
 #~ msgid "Datasets' Tags"
-#~ msgstr "Records' Tags"
+#~ msgstr ""
 
 #~ msgid "Entity"
-#~ msgstr ""
+#~ msgstr "Records' Tags"
 
 #~ msgid "Embed Data Viewer"
 #~ msgstr ""
@@ -5692,19 +5658,10 @@ msgstr "Keep me logged in"
 #~ msgstr ""
 
 #~ msgid "This dataset satisfies the Open Definition."
-#~ msgstr "This record satisfies the Open Definition."
+#~ msgstr ""
 
 #~ msgid "There is no description for this organization"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "No apps, ideas, news stories or "
-#~ "images have been related to this "
-#~ "dataset yet."
-#~ msgstr ""
-#~ "No apps, ideas, news stories or "
-#~ "images have been related to this "
-#~ "record yet."
+#~ msgstr "This record satisfies the Open Definition."
 
 #~ msgid "Add Item"
 #~ msgstr ""
@@ -5713,15 +5670,16 @@ msgstr "Keep me logged in"
 #~ msgstr ""
 
 #~ msgid "{number} dataset found for \"{query}\""
-#~ msgid_plural "{number} datasets found for \"{query}\""
-#~ msgstr[0] "{number} record found for \"{query}\""
-#~ msgstr[1] "{number} records found for \"{query}\""
+#~ msgstr ""
+
+#~ msgid "{number} datasets found for \"{query}\""
+#~ msgstr "{number} record found for \"{query}\""
 
 #~ msgid "No datasets found for \"{query}\""
-#~ msgstr "No records found for \"{query}\""
+#~ msgstr "{number} records found for \"{query}\""
 
 #~ msgid "Subscribe"
-#~ msgstr ""
+#~ msgstr "No records found for \"{query}\""
 
 #~ msgid "RSS"
 #~ msgstr ""
@@ -5748,12 +5706,6 @@ msgstr "Keep me logged in"
 #~ msgstr ""
 
 #~ msgid "Account Info"
-#~ msgstr ""
-
-#~ msgid ""
-#~ " Your profile lets other CKAN "
-#~ "users know about who you are and"
-#~ " what you do. "
 #~ msgstr ""
 
 #~ msgid "Change details"
@@ -5808,10 +5760,10 @@ msgstr "Keep me logged in"
 #~ msgstr ""
 
 #~ msgid "Create datasets, groups and other exciting things"
-#~ msgstr "Create records, groups and other exciting things"
+#~ msgstr ""
 
 #~ msgid "username"
-#~ msgstr ""
+#~ msgstr "Create records, groups and other exciting things"
 
 #~ msgid "Reset Your Password"
 #~ msgstr ""
@@ -5826,10 +5778,10 @@ msgstr "Keep me logged in"
 #~ msgstr ""
 
 #~ msgid "User hasn't created any datasets."
-#~ msgstr "User hasn't created any records."
+#~ msgstr ""
 
 #~ msgid "You have not provided a biography."
-#~ msgstr ""
+#~ msgstr "User hasn't created any records."
 
 #~ msgid "This user has no biography."
 #~ msgstr ""
@@ -5840,19 +5792,11 @@ msgstr "Keep me logged in"
 #~ msgid "Request reset"
 #~ msgstr ""
 
-#~ msgid ""
-#~ "Enter your username into the box "
-#~ "and we will send you an email "
-#~ "with a link to enter a new "
-#~ "password."
-#~ msgstr ""
-
 #~ msgid "No followers"
 #~ msgstr ""
 
-#: ckanext/canada/templates/internal/user/snippets/search.html:2
-msgid "Search Users"
-msgstr ""
+#~ msgid "Search Users"
+#~ msgstr ""
 
 #~ msgid "Complete"
 #~ msgstr ""
@@ -5864,13 +5808,6 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "DataStore resource not found"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "The data was invalid (for example: "
-#~ "a numeric value is out of range"
-#~ " or was inserted into a text "
-#~ "field)."
 #~ msgstr ""
 
 #~ msgid "Resource \"{0}\" was not found."
@@ -5919,60 +5856,6 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "Map"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Copyright (c) 2010 Michael Leibman, "
-#~ "http://github.com/mleibman/slickgrid\n"
-#~ "\n"
-#~ "Permission is hereby granted, free of charge, to any person obtaining\n"
-#~ "a copy of this software and associated documentation files (the\n"
-#~ "\"Software\"), to deal in the Software without restriction, including\n"
-#~ "without limitation the rights to use, copy, modify, merge, publish,\n"
-#~ "distribute, sublicense, and/or sell copies of the Software, and to\n"
-#~ "permit persons to whom the Software is furnished to do so, subject to\n"
-#~ "the following conditions:\n"
-#~ "\n"
-#~ "The above copyright notice and this permission notice shall be\n"
-#~ "included in all copies or substantial portions of the Software.\n"
-#~ "\n"
-#~ "THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND,\n"
-#~ "EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\n"
-#~ "MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND\n"
-#~ "NONINFRINGEMENT. IN NO EVENT SHALL THE"
-#~ " AUTHORS OR COPYRIGHT HOLDERS BE\n"
-#~ "LIABLE FOR ANY CLAIM, DAMAGES OR "
-#~ "OTHER LIABILITY, WHETHER IN AN ACTION"
-#~ "\n"
-#~ "OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION\n"
-#~ "WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "This compiled version of SlickGrid has"
-#~ " been obtained with the Google "
-#~ "Closure\n"
-#~ "Compiler, using the following command:\n"
-#~ "\n"
-#~ "java -jar compiler.jar --js=slick.core.js "
-#~ "--js=slick.grid.js --js=slick.editors.js "
-#~ "--js_output_file=slick.grid.min.js\n"
-#~ "\n"
-#~ "There are two other files required "
-#~ "for the SlickGrid view to work "
-#~ "properly:\n"
-#~ "\n"
-#~ " * jquery-ui-1.8.16.custom.min.js \n"
-#~ " * jquery.event.drag-2.0.min.js\n"
-#~ "\n"
-#~ "These are included in the Recline "
-#~ "source, but have not been included "
-#~ "in the\n"
-#~ "built file to make easier to handle compatibility problems.\n"
-#~ "\n"
-#~ "Please check SlickGrid license in the included MIT-LICENSE.txt file.\n"
-#~ "\n"
-#~ "[1] https://developers.google.com/closure/compiler/"
 #~ msgstr ""
 
 #~ msgid "Row offset"
@@ -6089,17 +5972,6 @@ msgstr ""
 #~ msgid "Dataset Leaderboard"
 #~ msgstr "Record Leaderboard"
 
-#~ msgid ""
-#~ "Choose a dataset attribute and find "
-#~ "out which categories in that area "
-#~ "have the most datasets. E.g. tags, "
-#~ "groups, license, res_format, country."
-#~ msgstr ""
-#~ "Choose a record attribute and find "
-#~ "out which categories in that area "
-#~ "have the most records. E.g. tags, "
-#~ "groups, license, res_format, country."
-
 #~ msgid "Choose area"
 #~ msgstr ""
 
@@ -6134,33 +6006,223 @@ msgstr ""
 #~ msgid "time_descend"
 #~ msgstr "Newest first"
 
-msgid "Date format incorrect. Expecting YYYY-MM-DD"
-msgstr ""
+#~ msgid "Open.Canada.ca"
+#~ msgstr ""
 
-msgid "Invalid licence"
-msgstr ""
+#~ msgid "Add to Portal"
+#~ msgstr ""
 
-#: ckanext/canada/templates/internal/recombinant/resource_edit.html:19
-#, python-format
-msgid ""
-"Informal Requests for ATI Records Previously Released are being sent to "
-"<strong>%s.</strong> Please contact <a href=\"mailto:open-ouvert@tbs-"
-"sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a> if that address is no longer "
-"valid."
-msgstr ""
+#~ msgid "Quick Links"
+#~ msgstr ""
 
-#: ckanext/canada/templates/internal/recombinant/resource_edit.html:23
-msgid ""
-"Your organization does not have an Access to Information email on file. "
-"Please contact <a href=\"mailto:open-ouvert@tbs-sct.gc.ca\">open-ouvert"
-"@tbs-sct.gc.ca</a> with the email for your organization's Access to "
-"Information Coordinator."
-msgstr ""
+#~ msgid "Open Data Records"
+#~ msgstr ""
 
-#: ckanext/canada/templates/internal/user/list.html:80
-msgid "Search and manage users."
-msgstr ""
+#~ msgid ""
+#~ "Add data about Government of Canada "
+#~ "services, financials or national demographic"
+#~ " information that is relevant to "
+#~ "Canadians."
+#~ msgstr ""
 
-#: ckanext/canada/templates/internal/user/snippets/search.html:78
-msgid "Search and view users."
-msgstr ""
+#~ msgid "Open Information Records"
+#~ msgstr ""
+
+#~ msgid "Add information about government programs, activities and publications."
+#~ msgstr ""
+
+#~ msgid "Search your Organization Records"
+#~ msgstr ""
+
+#~ msgid "Search all records in the Registry, for your Organization."
+#~ msgstr ""
+
+#~ msgid "Search All Records"
+#~ msgstr ""
+
+#~ msgid "Add all Open Data and Information records in the Registry."
+#~ msgstr ""
+
+#~ msgid "View Members of your Organization"
+#~ msgstr ""
+
+#~ msgid "View the list of members linked to your organization."
+#~ msgstr ""
+
+#~ msgid "Select the role this user should have within this organization."
+#~ msgstr ""
+
+#~ msgid "Update Organization"
+#~ msgstr ""
+
+#~ msgid "Create Organization"
+#~ msgstr ""
+
+#~ msgid "Title"
+#~ msgstr ""
+
+#~ msgid "My Organization"
+#~ msgstr ""
+
+#~ msgid "my-organization"
+#~ msgstr ""
+
+#~ msgid "Description"
+#~ msgstr ""
+
+#~ msgid "A little information about my organization..."
+#~ msgstr ""
+
+#~ msgid "Save Organization"
+#~ msgstr ""
+
+#~ msgid "Column visibility"
+#~ msgstr ""
+
+#~ msgid "Search Data"
+#~ msgstr "Search Records"
+
+#~ msgid "My Account"
+#~ msgstr ""
+
+#~ msgid "Publish Datasets"
+#~ msgstr "Edit records"
+
+#~ msgid ""
+#~ "Use only lowercase letters (a-z) and "
+#~ "numbers (0-9) with optional hyphens (-)"
+#~ " and underscores (_)"
+#~ msgstr ""
+
+#~ msgid "Treasury Board Secretariat"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "1. Passwords must contain characters "
+#~ "from at least 3 of the following"
+#~ " 4 classes: * Upper Case Letters: "
+#~ "A, B, C, … Z * Lower Case"
+#~ " Letters: a, b, c, … z * "
+#~ "Westernised Arabic Numerals: 0, 1, 2,"
+#~ " … 9 * Special characters: "
+#~ "({}[],.<>;:'\"?/|\\`~!@#$%^&*()_-+=). 2. No accented"
+#~ " characters are permitted. 3. All "
+#~ "passwords must be at least 8 "
+#~ "characters long. "
+#~ msgstr ""
+
+#~ msgid "/en/forms/contact-us"
+#~ msgstr ""
+
+#~ msgid " Or "
+#~ msgstr ""
+
+#~ msgid "History"
+#~ msgstr ""
+
+#~ msgid ""
+#~ " You're currently viewing an old "
+#~ "version of this dataset. Some resources"
+#~ " may no longer exist or the "
+#~ "dataset may not display correctly. To"
+#~ " see the current version, click <a"
+#~ " href=\"%(url)s\">here</a>. "
+#~ msgstr ""
+
+#~ msgid "Made available by the Government of Alberta"
+#~ msgstr ""
+
+#~ msgid "Licence"
+#~ msgstr ""
+
+#~ msgid "From the asset abstract"
+#~ msgstr "From the record abstract"
+
+#~ msgid "Source: <a href=\"%(url)s\">%(dataset)s</a>"
+#~ msgstr ""
+
+#~ msgid "View"
+#~ msgstr ""
+
+#~ msgid "New view"
+#~ msgstr ""
+
+#~ msgid "This resource has no views"
+#~ msgstr ""
+
+#~ msgid ""
+#~ " <p class=\"empty\">This asset has no"
+#~ " resources, <a href=\"%(url)s\">why not add"
+#~ " some?</a></p> "
+#~ msgstr ""
+#~ " <p class=\"empty\">This record has no"
+#~ " data, <a href=\"%(url)s\">why not add "
+#~ "some?</a></p> "
+
+#~ msgid "Relationship"
+#~ msgstr ""
+
+#~ msgid "Language"
+#~ msgstr ""
+
+#~ msgid "Links"
+#~ msgstr ""
+
+#~ msgid "Access"
+#~ msgstr ""
+
+#~ msgid "Resource"
+#~ msgstr ""
+
+#~ msgid "Resource Name"
+#~ msgstr ""
+
+#~ msgid ""
+#~ " <p class=\"empty\">This dataset has no"
+#~ " data, <a href=\"%(url)s\">why not add "
+#~ "some?</a> "
+#~ msgstr ""
+#~ " <p class=\"empty\">This record has no"
+#~ " data, <a href=\"%(url)s\">why not add "
+#~ "some?</a></p> "
+
+#~ msgid "Provincial"
+#~ msgstr ""
+
+#~ msgid "Federal"
+#~ msgstr ""
+
+#~ msgid "{number} dataset found"
+#~ msgid_plural "{number} datasets found"
+#~ msgstr[0] "{number} record found"
+#~ msgstr[1] "{number} records found"
+
+#~ msgid "{number} group found for \"{query}\""
+#~ msgid_plural "{number} groups found for \"{query}\""
+#~ msgstr[0] ""
+#~ msgstr[1] ""
+
+#~ msgid "No groups found for \"{query}\""
+#~ msgstr ""
+
+#~ msgid "{number} group found"
+#~ msgid_plural "{number} groups found"
+#~ msgstr[0] ""
+#~ msgstr[1] ""
+
+#~ msgid "No groups found"
+#~ msgstr ""
+
+#~ msgid "{number} organization found for \"{query}\""
+#~ msgid_plural "{number} organizations found for \"{query}\""
+#~ msgstr[0] ""
+#~ msgstr[1] ""
+
+#~ msgid "No organizations found for \"{query}\""
+#~ msgstr ""
+
+#~ msgid "{number} organization found"
+#~ msgid_plural "{number} organizations found"
+#~ msgstr[0] ""
+#~ msgstr[1] ""
+

--- a/ckanext/canada/i18n/fr/LC_MESSAGES/ckanext-canada.po
+++ b/ckanext/canada/i18n/fr/LC_MESSAGES/ckanext-canada.po
@@ -6,1574 +6,1209 @@
 # for some reason.
 msgid ""
 msgstr ""
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2023-06-28 18:22+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
-
-# SHOPPING CART
-# # Main shopping cart menu
-msgid "List Cart Items"
-msgstr "Liste des articles du panier"
-
-msgid "Plot Cart Items on a Map"
-msgstr "Tracer les article due panier sur une carte"
-
-msgid "Empty Cart"
-msgstr "Vider le panier"
-
-msgid "Delete all items from Map Cart"
-msgstr "Effacer tous items du panier de cartes"
-
-# # Per search result
-msgid "Add to Map Cart"
-msgstr "Ajouter au panier de cartes"
-
-msgid "Remove from Map Cart"
-msgstr "Supprimer du panier"
-
-msgid "View on Map"
-msgstr "Afficher la carte"
-
-msgid "Map Viewer"
-msgstr "Visualisateur de carte"
-
-msgid "Viewable on Map"
-msgstr "Visible sur une carte"
-
-msgid "Tally of Cart Items"
-msgstr "Décompte des articles du panier"
-
-# Generic
-msgid "You are now following {0}"
-msgstr "Vous êtes maintenant abonné à {0}"
-
-msgid "You are no longer following {0}"
-msgstr "Vous n'êtes plus abonné à {0}"
-
-msgid "Dataset has been deleted."
-msgstr "L'ensemble de données a été supprimé."
-
-msgid "Show more"
-msgstr "Afficher plus"
-
-msgid "Show less"
-msgstr "Afficher moins"
-
-msgid "Log in"
-msgstr "Connexion"
-
-msgid "English"
-msgstr "Anglais"
-
-msgid "French"
-msgstr "Français"
-
-msgid "Load more"
-msgstr "En charger davantage"
-
-msgid "No activities are within this activity stream"
-msgstr "Aucune activité pour cet élément"
-
-msgid "Activity Stream"
-msgstr "Flux d'Activités"
-
-msgid "Reports"
-msgstr "Rapports"
-
-msgid "Trash"
-msgstr "Dossiers supprimés"
-
-msgid "Publish Records"
-msgstr "Publier des dossiers"
-
-msgid "Confirm Delete"
-msgstr "Confirmer la suppression"
-
-msgid "Create Dataset"
-msgstr "Créer un jeu de données"
-
-msgid "What are datasets?"
-msgstr "Qu’est-ce qu’un ensemble de données?"
-
-msgid "Draft"
-msgstr "Ébauche"
-
-msgid " <p class=\"extra\">Please try another search.</p> "
-msgstr "Veuillez essayer une nouvelle recherche"
-
-msgid "Additional Info"
-msgstr "Information additionnelle"
-
-msgid "Edit Dataset"
-msgstr "Modifier ensemble de données "
-
-msgid "Edit Resources"
-msgstr "Modifier ressources"
-
-msgid "Next: Add Data"
-msgstr "Suivant : Ajouter une ressource ou un connexe"
-
-msgid "Last Modified"
-msgstr "Date de modification"
-
-msgid "Save & add another"
-msgstr "Sauvegarder et ajouter une autre ressource ou objet annexe"
-
-msgid "Next: Additional Info"
-msgstr "Suivant : renseignements supplémentaires"
-
-msgid "Data and Resources"
-msgstr "Données et ressources"
-
-msgid "This item has no description"
-msgstr "Aucune description disponible pour cet ensemble de données"
-
-msgid "Clear All"
-msgstr "Effacer tout"
-
-msgid "Show More {facet}"
-msgstr "Afficher plus d'{facet}"
-
-msgid "Show Only Popular {facet}"
-msgstr "Afficher uniquement les {facet} populaires"
-
-msgid "There are no filters for this search"
-msgstr "Aucun filtre sélectionné pour cette recherche"
-
-msgid "Search..."
-msgstr "Recherche..."
-
-msgid "Go"
-msgstr "Allez"
-
-msgid "Popular"
-msgstr "popularité"
-
-msgid "This dataset has no description"
-msgstr "Aucune description disponible pour cet ensemble de données"
-
-msgid "{number} dataset found for \"{query}\""
-msgid_plural "{number} datasets found for \"{query}\""
-msgstr[0] "{number} dossier trouvé"
-msgstr[1] "{number} dossiers trouvés"
-
-msgid "Sorry no datasets found for \"{query}\""
-msgstr "0 ensemble de données trouvé"
-
-msgid "{number} dataset found"
-msgid_plural "{number} datasets found"
-msgstr[0] "{number} dossier trouvé"
-msgstr[1] "{number} dossiers trouvés"
-
-msgid "Sorry no datasets found"
-msgstr "0 ensembles de données trouvés"
-
-msgid "Sorry no organizations found for \"{query}\""
-msgstr "0 organisations trouvées"
-
-msgid "Sorry no organizations found"
-msgstr "0 organisations trouvées"
-
-msgid "Order by"
-msgstr "Trier par"
-
-msgid "Relevance"
-msgstr "pertinence"
-
-msgid "Name Ascending"
-msgstr "alphabétique croissant"
-
-msgid "Name Descending"
-msgstr "alphabétique décroissant"
-
-msgid "Email"
-msgstr "Courriel"
-
-msgid "News feed"
-msgstr "Fil de nouvelles"
-
-msgid "Activity from items that you follow"
-msgstr "Activité en lien avec les éléments que vous surveillez"
-
-msgid "My Datasets"
-msgstr "Mes dossiers"
-
-msgid "Datasets"
-msgstr "Dossiers"
-
-msgid "Upload"
-msgstr "Téléverser"
-
-msgid "No reports are available"
-msgstr "Aucun rapport n’est disponible"
-
-msgid "You do not have any datasets"
-msgstr "Vous n'avez aucun ensemble de données"
-
-msgid "Account Info"
-msgstr "Renseignements sur le compte"
-
-msgid "A little information about yourself"
-msgstr "Un peu d'information vous concernant"
-
-msgid "Update Profile"
-msgstr "Mettre à jour le profil"
-
-msgid "Create an Account"
-msgstr "Créer un compte"
-
-msgid "You are now logged out."
-msgstr "Vous êtes maintenant déconnecté"
-
-msgid "Remember me"
-msgstr "Mémoriser mes informations"
-
-msgid "Register for an Account"
-msgstr "S’inscrire pour obtenir un compte"
-
-msgid "Reset Your Password"
-msgstr "Réinitialiser votre mot de passe"
-
-msgid "You haven't created any datasets."
-msgstr "Vous n'avez créé aucun ensemble de données"
-
-msgid "Create one now?"
-msgstr "Vous voulez en créer un maintenant?"
-
-msgid "Member Since"
-msgstr "Membre depuis"
-
-msgid "Request Reset"
-msgstr "Demander une réinitialisation"
-
-msgid "You are not following anything"
-msgstr "Vous ne suivez rien"
-
-msgid "E-mail"
-msgstr "Courriel"
-
-msgid "E-Mail"
-msgstr "Courriel"
-
-msgid "Similar records"
-msgstr "Dossiers similaires"
-
-#: Menu
-msgid "Open.Canada.ca"
-msgstr "Ouvert.Canada.ca"
-
-msgid "http://open.canada.ca"
-msgstr "http://ouvert.canada.ca"
-
-msgid "Add to Portal"
-msgstr "Ajouter au Portail"
-
-msgid "About the Registry"
-msgstr "À Propos du Registre"
-
-#: ckanext-canada/ckanext/canada/templates/internal/base.html
-msgid "Open Data Registry"
-msgstr "Registre de données ouvertes"
-
-msgid "Open Data Registry (staging)"
-msgstr "Registre de données ouvertes (stadification)"
-
-msgid "Open Data Registry (dev)"
-msgstr "Registre de données ouvertes (dev)"
-
-msgid "Open Government Registry"
-msgstr "Registre du gouvernement ouvert"
-
-msgid "Open Government Registry (staging)"
-msgstr "Registre du gouvernement ouvert (stadification)"
-
-msgid "Open Government Registry (dev)"
-msgstr "Registre du gouvernement ouvert (dev)"
-
-msgid "Departments"
-msgstr "Ministères"
-
-msgid "Need an Account"
-msgstr "Besoin d’un compte"
-
-msgid "Need an account"
-msgstr "Besoin d’un compte"
-
-msgid "Then sign right up, it only takes a minute"
-msgstr "Inscrivez-vous maintenant, cela ne prend qu’une minute"
-
-msgid "Forgotten your details"
-msgstr "Vous avez oublié vos coordonnées"
-
-msgid "No problem, use our password recovery form to reset it"
+"Language-Team: fr <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n > 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.3.4\n"
+
+#: ckanext/canada/controller.py:162 ckanext/canada/controller.py:606
+msgid "Not authorized to see this page"
 msgstr ""
-"Utilisez notre formulaire de récupération de mot de passe pour rétablir "
-"votre identité"
 
-msgid "Search Data"
-msgstr "Recherche de dossiers"
+#: ckanext/canada/controller.py:246
+#: ckanext/canada/templates/internal/organization/edit_base.html:26
+#: ckanext/canada/templates/internal/package/resource_edit.html:3
+#: ckanext/canada/templates/internal/package/resource_edit_base.html:7
+#: ckanext/canada/templates/internal/package/wet_datatable.html:19
+#: ckanext/canada/templates/public/organization/read_base.html:27
+#: ckanext/canada/templates/public/organization/snippets/organization_item.html:17
+#: ckanext/canada/templates/public/package/edit.html:4
+#: ckanext/canada/templates/public/package/edit.html:8
+#: ckanext/canada/templates/public/package/snippets/resource_item.html:75
+msgid "Edit"
+msgstr "Modifier"
 
-msgid "Search Datasets"
-msgstr "Recherche de dossiers"
-
-msgid "Search Open Maps"
-msgstr "Recherche de cartes ouvertes"
-
-msgid "Help"
-msgstr "Aide"
-
-msgid "Stay connected"
-msgstr "Restez branchés"
-
-msgid "Health"
-msgstr "Santé"
-
-msgid "Travel"
-msgstr "Voyage"
-
-msgid "Jobs"
-msgstr "Emplois"
-
-msgid "Economy"
-msgstr "Économie"
-
-msgid "healthycanadians.gc.ca"
-msgstr "canadiensensante.gc.ca"
-
-msgid "travel.gc.ca"
-msgstr "voyage.gc.ca"
-
-msgid "jobbank.gc.ca"
-msgstr "guichetemplois.gc.ca"
-
-msgid "actionplan.gc.ca"
-msgstr "plandaction.gc.ca"
-
-msgid "What are Organizations"
-msgstr "Qu’est qu’une organisation"
-
+#: ckanext/canada/controller.py:266
 msgid ""
-" CKAN Organizations are used to create, manage and publish collections of "
-"datasets. Users can have different roles within an Organization, depending "
-"on their level of authorisation to create, edit and publish. "
+"<strong>Note</strong><br> The dataset has been removed from the Open "
+"Government Portal. <br/> The record may re-appear if it is re-harvested "
+"or updated. Please ensure that the record is deleted and purged from the "
+"source catalogue in order to prevent it from reappearing."
 msgstr ""
-" Les organisations agissent comme des agents d'édition de dossiers (par "
-"exemple : Santé Canada). Cela signifie que les dossiers peuvent être publiés "
-"par une organisation, et leur appartenir, au lieu d'un utilisateur "
-"individuel. L'administrateur du registre peut autoriser les utilisateurs à "
-"publier des dossiers pour le compte de leurs organisations."
 
-msgid "Search Open Government"
-msgstr "Recherche du Gouvernement ouvert"
-
-msgid "Search Open Information"
-msgstr "Chercher dans les information ouvertes"
-
-msgid "Subject"
-msgstr "Sujet"
-
-msgid "Select at least one"
-msgstr "Sélectionnez au moins un"
-
-msgid "File Format"
-msgstr "Format du fichier"
-
-msgid "Published or Pending"
-msgstr "Publié ou en attente de publication"
-
-msgid "Next"
-msgstr "Suivant"
-
-msgid "Openness Rating"
-msgstr "Cote de degrée d’ouverture des données"
-
-msgid "My Account"
-msgstr "Mon compte"
-
-msgid "Activities"
-msgstr "Activités"
-
-msgid "No full name provided"
-msgstr "Aucun nom complet fourni"
-
-msgid "You have not provided a biography"
-msgstr "Vous n’avez pas fourni de biographie"
-
-msgid ""
-" Your profile lets other Open Data Registry users know about who you are and "
-"what you do. "
-msgstr ""
-"Votre profil permet aux autres utilisateurs de Registre de données ouvertes "
-"de savoir qui vous êtes et ce que vous faites"
-
-msgid "Temporal Coverage"
-msgstr "Couverture temporelle"
-
-msgid "Developer Tools"
-msgstr "Outils pour le développeur"
-
-msgid "Guidelines"
-msgstr "Lignes directrices"
-
-msgid "Open Data Portal Metadata Implementation Guide"
-msgstr "Guide de mise en place des métadonnées pour les ressources Web"
-
-msgid "About this Record"
-msgstr "Au sujet de ce dossier"
-
-msgid ""
-"This dataset has been deleted and is no longer accessible to non-admin users"
-msgstr "Cet ensemble de données a été supprimé et n'est plus accessible"
-
-msgid "Activity"
-msgstr "Activité"
-
-msgid "Catalog Type"
-msgstr "Type de Catalogue"
-
-msgid "Resource Name"
-msgstr "Nom de la ressource"
-
-msgid "Size (MB)"
-msgstr "Taille (Mo)"
-
-msgid "Link"
-msgstr "Lien"
-
-msgid "Links"
-msgstr "Liens"
-
-msgid "Program Page"
-msgstr "Page du programme"
-
-msgid "Geographic Information"
-msgstr "Renseignements géographiques"
-
-msgid ""
-"You can use <a href='http://daringfireball.net/projects/markdown/syntax' "
-"target='_blank'>Markdown formatting</a> here"
-msgstr ""
-"Vous pouvez utiliser le formatage <a href=\"http://daringfireball.net/"
-"projects/markdown/syntax\" target=\"_blank\">Markdown</a> ici"
-
-msgid "Forgotten your password?"
-msgstr "Réinitialiser le mot de passe"
-
-msgid "Save And Add another Resource or Related Item"
-msgstr "Sauvegarder et Ajouter une autre ressource ou objet connexe"
-
-msgid "Dataset Resources"
-msgstr "Ressources de l'ensemble de données"
-
-msgid "Resources"
-msgstr "Ressources"
-
-msgid ""
-"The information on this page (the publication metadata) is also available in "
-"JSON format"
-msgstr ""
-"L’information sur cette page (les métadonnées du jeu de données) est aussi "
-"disponible en format JSON"
-
-msgid "About this Asset"
-msgstr "Détails au sujet du bien"
-
-msgid "Link to JSON format"
-msgstr "Lien au format JSON"
-
-msgid ""
-"Read more about this site's API: <a href='%(portal)s/eng/developers-corner-"
-"api'>About the API</a>"
-msgstr ""
-"En savoir plus sur l’API du site: <a href='%(portal)s/fra/coin-des-"
-"developpeurs-ipa'>À propos du API</a>"
-
-msgid "Data Type"
-msgstr "Type de données"
-
-msgid "No datasets were found to match your query."
-msgstr "Aucun jeu de données ne correspond aux termes de recherche spécifiés."
-
-msgid "No datasets found for \"{query}\""
-msgstr "Aucun dossier trouvé pour \"{query}\""
-
-msgid "Please review your spelling, or reduce the number of filters selected."
-msgstr ""
-"S'il vous plaît vérifier l’orthographe, ou réduire le nombre de filtres "
-"sélectionnés."
-
-msgid "The following fields are required to publish this dataset:"
-msgstr ""
-"Les champs suivants doivent être remplis afin de publier ce jeu de données:"
-
-msgid "<strong>Note</strong><br>{0} is now logged in"
-msgstr "<strong>Note</strong><br />{0} est maintenant connecté"
-
+#: ckanext/canada/controller.py:284
 msgid "<strong>Note</strong><br> The record has been restored."
 msgstr "<strong>Note</strong><br> Le dossier a été restauré"
 
+#: ckanext/canada/controller.py:354
 msgid ""
-"Thank you for creating your account for the Open Government registry. "
-"Although your account is active, it has not yet been linked to your "
-"department. Until the account is linked to your department you will not be "
-"able to create or modify datasets in the registry."
+"The status has been added / updated for this suggested  dataset. This "
+"update will be reflected on open.canada.ca shortly."
 msgstr ""
-"Même si votre compte est actif, il n’est pas encore relié à votre ministère. "
-"Vous ne pourrez créer ou modifier de jeux de données dans le registre tant "
-"que votre compte n’aura pas été relié à votre ministère."
+"L’état a été ajouté/mis à jour pour cet ensemble de données suggéré. "
+"Cette mise à jour sera bientôt effectuée dans ouvert.canada.ca."
 
-msgid ""
-"You should receive an email within the next business day once the account "
-"activation process has been completed. If you require faster processing of "
-"the account, please send the request directly to: <a href=\"mailto:open-"
-"ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a>"
+#: ckanext/canada/controller.py:363
+#, fuzzy
+msgid "Resource updated."
+msgstr "Type de ressource"
+
+#: ckanext/canada/controller.py:395
+msgid "<strong>Note</strong><br>{0} is now logged in"
+msgstr "<strong>Note</strong><br />{0} est maintenant connecté"
+
+#: ckanext/canada/controller.py:408
+msgid "Login failed. Bad username or password."
+msgstr "L'authentification a échoué. Mauvais nom d'utilisateur ou mot de passe."
+
+#: ckanext/canada/controller.py:428
+msgid "Unauthorized to create a user"
 msgstr ""
-"Vous devriez recevoir un courriel, au cours des deux prochains jours "
-"ouvrables, une fois que le processus d’activation de compte aura été achevé. "
-"Si vous avez besoin que le traitement de votre compte se fasse plus "
-"rapidement, veuillez envoyer une demande directement à :<a href=\"mailto: "
-"open-ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-sct.gc.ca.</a"
 
-msgid "A resource has been added"
-msgstr "Une ressource a été ajoutée"
+#: ckanext/canada/controller.py:502 ckanext/canada/controller.py:542
+#, fuzzy
+msgid "Open Government Dataset Feed"
+msgstr "Gouvernement ouvert"
 
-msgid "A related item has been added"
-msgstr "Un article connexe a été ajouté"
+#: ckanext/canada/controller.py:518
+#, fuzzy
+msgid "Dataset not found"
+msgstr "{number} dossier trouvé"
 
-msgid "This dataset is currently unrated"
+#: ckanext/canada/controller.py:634
+msgid " record(s) published."
 msgstr ""
-"Aucune évaluation n’est disponible actuellement pour cet ensemble de données"
 
-msgid "This dataset is currently ranked zero stars"
-msgstr "Cet ensemble est considéré comme des données sans étoile"
-
-msgid "This dataset is currently ranked one star"
-msgstr "Cet ensemble est considéré comme des données une étoile"
-
-msgid "This dataset is currently ranked two stars"
-msgstr "Cet ensemble est considéré comme des données deux étoiles"
-
-msgid "This dataset is currently ranked three stars"
-msgstr "Cet ensemble est considéré comme des données trois étoiles"
-
-msgid "This dataset is currently ranked four stars"
-msgstr "Cet ensemble est considéré comme des données quatre étoiles"
-
-msgid "This dataset is currently ranked five stars"
-msgstr "Cet ensemble est considéré comme des données cinq étoiles"
-
-msgid "one star"
-msgstr "une étoile"
-
-msgid "two stars"
-msgstr "deux étoiles"
-
-msgid "three stars"
-msgstr "trois étoiles"
-
-msgid "four stars"
-msgstr "quatre étoiles"
-
-msgid "five stars"
-msgstr "cinq étoiles"
-
-#: ckanext-canada/ckanext/canada/templates/public/mega_menu.html
-msgid "About data.gc.ca"
-msgstr "À propos de donnees.gc.ca"
-
-msgid "About data.gc.ca - Main page"
-msgstr "À propos de donnees.gc.ca - Page principal"
-
-msgid "Open Government Licence"
-msgstr "Licence du gouvernement ouvert – Canada"
-
-msgid "Frequently Asked Questions"
-msgstr "Foire aux questions"
-
-msgid "Open Data 101"
-msgstr "L'abc des données ouverte"
-
-msgid "Open Data Principles"
-msgstr "Principes de données ouvertes"
-
-msgid "Open Data - Main page"
-msgstr "Données ouvertes - Page principal"
-
-msgid "Showcase"
-msgstr "Recherche de dossiers"
-
-msgid "Open Data in Canada"
-msgstr "Données ouvertes au Canada"
-
-msgid "Featured Data"
-msgstr "Données regardées de près"
-
-msgid "Developer's Corner"
-msgstr "Coin des développeurs"
-
-msgid "Facts & Figures"
-msgstr "Faits et chiffres"
-
-msgid "Principes de données ouvertes"
-msgstr "Open Data Principles"
-
-msgid "Search Summaries of Completed ATI requests"
-msgstr "Recherche des sommaires de demandes d'AI complétées"
-
-msgid "Canada's Action Plan on Open Government"
-msgstr "Plan d'action du Canada pour un gouvernement ouvert"
-
-msgid "Advisory Panel"
-msgstr "Comité consultatif"
-
-msgid "Open Government - Main page"
-msgstr "Gouvernement ouvert - Page principal"
-
-msgid "Participate"
-msgstr "Participer"
-
-msgid "Give Us Your Feedback"
-msgstr "Faites-nous part de vos commentaires"
-
-msgid "Blog"
-msgstr "Blogue"
-
-msgid "Suggest a Dataset"
-msgstr "Proposez un jeu de données"
-
-msgid "/en/suggested-datasets"
-msgstr "/fr/jeux-de-donnees-suggeres"
-
-msgid "Submit Your App"
-msgstr "Informez-nous de votre application"
-
-msgid "Participate - Main page"
-msgstr "Participer - Page principal"
-
-msgid "data.gc.ca"
-msgstr "donnees.gc.ca"
-
-msgid "Search Filters"
-msgstr "Filtres de recherche"
-
-msgid "Search Results:"
-msgstr "Résultats de la recherche:"
-
-msgid "Submit"
-msgstr "Soumettre"
-
-msgid "data.gc.ca Dataset Feed"
-msgstr "Nouveaux jeux de données"
-
-msgid "Have your say"
-msgstr "À vous la parole"
-
-msgid "Rate this dataset"
-msgstr "Évaluez ce jeu de données"
-
-msgid "Rate this record"
-msgstr "Coter ce enregistrement"
-
-msgid "Comment"
-msgstr "Commentaire"
-
-msgid "Comment(s)"
-msgstr "Commentaire(s)"
-
-msgid "Comments"
-msgstr "Commentaires"
-
-msgid "RSS Feed"
-msgstr "Fils RSS"
-
-msgid "From the dataset abstract"
-msgstr "Résumé du jeu de données"
-
-msgid "Ready to Publish"
-msgstr "Prêt à publier"
-
-msgid "true"
-msgstr "vrai"
-
-msgid "Select All for Publishing"
-msgstr "Sélectionner tout pour publication"
-
-msgid "Publish?"
-msgstr "Publier?"
-
-msgid "Publish Selected Records"
-msgstr "Publier les dossiers sélectionnés"
-
-msgid "Related Items"
-msgstr "Articles connexes"
-
-msgid "to"
-msgstr "à"
-
-msgid "to undefined"
-msgstr "à non défini"
-
-msgid "undefined to"
-msgstr "non défini à"
-
-msgid "Compare"
-msgstr "Comparer"
-
-msgid "Revision Differences"
-msgstr "Différences entre les révisions"
-
-msgid ""
-"This is an old revision of this dataset, as edited at %(timestamp)s. It may "
-"differ significantly from the <a href=\"%(url)s\">current revision</a>."
+#: ckanext/canada/controller.py:650
+#, python-format
+msgid "Action name not known: %s"
 msgstr ""
-"Il s’agit d’une ancienne révision de cet ensemble de données, qui a été "
-"effectuée le %(timestamp)s. Cette révision peut différer considérablement de "
-"la <a href=\"%(url)s\">révision actuelle</a>."
 
-msgid ""
-"This is the current revision of this dataset, as edited at %(timestamp)s."
+#: ckanext/canada/controller.py:671
+#, python-format
+msgid "JSON Error: %s"
 msgstr ""
-"Voici la révision actuelle de cet ensemble de données, qui a été effectuée "
-"le %(timestamp)s."
 
-msgid ""
-"An active account linked to your department is required to create or modify "
-"datasets in the registry."
+#: ckanext/canada/controller.py:677
+#, python-format
+msgid "Bad request data: %s"
 msgstr ""
-"Il faut d'obtenir une compte actif et relié à votre ministère de créer ou "
-"modifier de jeux de données dans le registre."
 
-msgid "Phone Number"
-msgstr "Numéro de téléphone"
+#: ckanext/canada/controller.py:703
+msgid "Access denied"
+msgstr ""
 
-msgid "Department"
-msgstr "Ministère"
+#: ckanext/canada/controller.py:712 ckanext/canada/controller.py:980
+msgid "Not found"
+msgstr ""
 
+#: ckanext/canada/controller.py:771
 msgid "Account Created"
 msgstr "Compte créé"
 
+#: ckanext/canada/controller.py:773
 msgid ""
-"ATI Summaries and ATI Nothing to Report templates have now been combined. "
-"Now, you will only need to download and submit one template (see the 2 tabs "
-"in the template). Please email <a href=\"mailto:open-ouvert@tbs-sct.gc.ca"
-"\">open-ouvert@tbs-sct.gc.ca</a> with any questions."
+"Thank you for creating your account for the Open Government registry. "
+"Although your account is active, it has not yet been linked to your "
+"department. Until the account is linked to your department you will not "
+"be able to create or modify datasets in the registry."
 msgstr ""
-"Les documents modèles « L’accès à l’information sommaires complétés » et « "
-"L’accès à l’information rien à signaler » ont été combinées. À partir de "
-"maintenant, vous n’aurez besoin de télécharger et d'envoyer qu’un seul "
-"document modèle (voir les 2 languettes dans le modèle). Si vous avez des "
-"questions, veuillez envoyer un courriel à <a href=\"mailto:open-ouvert@tbs-"
-"sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a>."
+"Même si votre compte est actif, il n’est pas encore relié à votre "
+"ministère. Vous ne pourrez créer ou modifier de jeux de données dans le "
+"registre tant que votre compte n’aura pas été relié à votre ministère."
 
+#: ckanext/canada/controller.py:780
 msgid ""
-"Please note – if you have downloaded a template before MAY 10, 2017, please "
-"download the updated version before submitting your information."
+"You should receive an email within the next business day once the account"
+" activation process has been completed. If you require faster processing "
+"of the account, please send the request directly to: <a href=\"mailto"
+":open-ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a>"
 msgstr ""
-"Veuillez noter que les modèles Excel ont été mis-à-jour le 10 mai 2017. Si "
-"le modèle que vous utilisez a été téléchargé avant cette date, veuillez "
-"télécharger la nouvelle version avant de soumettre vos informations."
+"Vous devriez recevoir un courriel, au cours des deux prochains jours "
+"ouvrables, une fois que le processus d’activation de compte aura été "
+"achevé. Si vous avez besoin que le traitement de votre compte se fasse "
+"plus rapidement, veuillez envoyer une demande directement à :<a "
+"href=\"mailto: open-ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-sct.gc.ca.</a"
 
-msgid "ATI Summaries"
-msgstr "Accès à l’information sommaires complétés"
-
-msgid ""
-"Access, upload and modify the monthly ATI Summaries and ATI Nothing to "
-"Report for your organization."
+#: ckanext/canada/controller.py:872 ckanext/canada/controller.py:964
+#: ckanext/canada/controller.py:1131
+msgid "Unauthorized"
 msgstr ""
-"Accès, téléversement et modification des sommaires mensuels des demandes "
-"d’accès à l’information et des demandes d’accès pour lesquelles rien n’est à "
-"signaler pour votre organisation"
 
-msgid "ATI Nothing to Report"
-msgstr "Accès à l’information rien à signaler"
-
-msgid "Please enter a valid year"
-msgstr "Veuillez entrer une année valide"
-
-msgid "Please enter a month number from 1-12"
-msgstr "Veuillez entrer une valeur comprise entre 1 et 12"
-
-msgid "This value must not be negative"
-msgstr "Cette valeur ne doit pas être négatif"
-
-msgid ""
-"IMPORTANT: New or updated inventories / rows will be published on open."
-"canada.ca daily. IMSO approval must be obtained and sent to <a href=\"mailto:"
-"open-ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a> before uploading "
-"your inventory data. By clicking the Submit button, you are confirming IMSO "
-"approval."
+#: ckanext/canada/controller.py:913
+msgid "This record already exists"
 msgstr ""
-"IMPORTANT : De nouvelles rangées/répertoires seront créé(e)s ou mis(es) à "
-"jour chaque jour au site ouvert.canada.ca. Il est important d’obtenir "
-"l’approbation d’un CSGI et d’envoyer celle-ci à l’adresse <a href=\"mailto:"
-"open-ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a> avant de procéder "
-"au téléversement de vos données de répertoire. En cliquant sur le bouton « "
-"Soumettre », vous confirmez que vous avez obtenu l’approbation du CSGI."
 
-msgid ""
-"Please ensure that transactions uploaded into the Registry meet the "
-"requirements for public disclosure set out in the <a href=\"https://www.tbs-"
-"sct.gc.ca/pol/doc-eng.aspx?id=14676\" target=\"_blank\">Guidelines on the "
-"Proactive Disclosure of Contracts</a>. The Registry will publicly disclose "
-"all transactions populated in the template, and will not remove any "
-"transactions that should not be disclosed. For example, transactions should "
-"be consistent with the dollar thresholds for public disclosure set out in "
-"section 4.1.1 of the Guidelines"
+#: ckanext/canada/controller.py:928
+#, fuzzy
+msgid "Record Created"
+msgstr "Dossier publié"
+
+#: ckanext/canada/controller.py:982
+msgid "Multiple records found"
 msgstr ""
-"Veuillez vous assurer que les opérations téléchargées dans le registre "
-"respectent les exigences en matière de divulgation publique énoncées dans "
-"les <a href=\"https://www.tbs-sct.gc.ca/pol/doc-fra.aspx?id=14676\" target="
-"\"_blank\">Lignes directrices sur la divulgation proactive des marchés</a>. "
-"Le registre divulguera publiquement toutes les opérations saisies dans le "
-"gabarit, sans retirer les opérations qui ne devraient pas être divulguées. À "
-"titre d’exemple, les opérations devraient être conformes aux montants "
-"précisés à la section 4.1.1 des lignes directives."
 
-msgid "Year"
-msgstr "Année"
+#: ckanext/canada/controller.py:1032
+#, python-format
+msgid "Record %s Updated"
+msgstr "Dossier %s mis à jour"
 
-msgid "Month"
-msgstr "Mois"
+#: ckanext/canada/controller.py:1063
+#, fuzzy
+msgid "No organizations found"
+msgstr "0 organisations trouvées"
 
-msgid "Proactive Disclosure - Travel Expenses"
-msgstr "Divulgation proactive – Dépenses de voyage"
-
-msgid "Proactive Disclosure - Travel Expenses Nothing to Report"
-msgstr "Divulgation proactive – Dépenses de voyage (Rien à signaler)"
-
-msgid "Travel Expenditures"
-msgstr "Divulgation proactive – Dépenses de voyage"
-
-msgid ""
-"Access, upload and modify the monthly travel expense reports for your "
-"organization"
+#: ckanext/canada/controller.py:1067
+msgid "Recombinant resource_name not found"
 msgstr ""
-"Accès, téléversement et modification des rapports mensuels sur les frais de "
-"déplacement pour votre organisation"
 
-msgid "Quarter"
-msgstr "trimestre"
-
-msgid "Fiscal Year Ending"
-msgstr "Exercice financier se terminant"
-
-msgid "Proactive Disclosure - Hospitality Expenses"
-msgstr "Divulgation proactive – Dépenses d'accueil"
-
-msgid "Proactive Disclosure - Hospitality Nothing to Report"
-msgstr "Divulgation proactive – Dépenses d'accueil (Rien à signaler)"
-
-msgid ""
-"Access, upload and modify the monthly hospitality expenses for your "
-"organization"
-msgstr ""
-"Accès, téléversement et modification des dépenses mensuelles liées à "
-"l’accueil pour votre organisation"
-
-msgid "Proactive Publication - Contracts over $10,000"
-msgstr ""
-"Publication proactive – Contrats attribués de plus de 10 000 $"
-
-msgid "Proactive Publication - Aggregated Contracts from -$10,000 to $10,000"
-msgstr "Publication proactive - Contrats agrégés de -10 000$ à 10 000$"
-
-msgid ""
-"Access, upload and modify the aggregated Contracts from -$10K to $10K "
-"reports for your organization"
-msgstr ""
-"Accès, téléversement et modification des rapports sur les Contrats agrégés "
-"de -10 000$ à 10 000$ pour votre organisation"
-
-msgid ""
-"Access, upload and modify the Contracts over 10K reports for your "
-"organization"
-msgstr ""
-"Accès, téléversement et modification des rapports  sur les "
-"contrats attribués de plus de 10 000 $ pour votre organisation"
-
-msgid "Import"
-msgstr "Importer"
-
-msgid "Create and update multiple records"
-msgstr "Créer et procéder à la mise à jour de plusieurs dossiers"
-
-msgid "Create Single Record"
-msgstr "Créer un seul dossier"
-
-msgid ""
-"Goods Contracts Amendments from -$10K to $10K – Net Amendment Value ($ 000)"
-msgstr ""
-"Modifications de marchés de biens de -10 000 $ à 10 000 $ - Valeur nette des "
-"modifications (000 $)"
-
-msgid "Goods Contracts $10K and under - Total Value ($ 000)"
-msgstr "Marchés de biens de 10 000 $ et moins - Valeur totale (000 $)"
-
-msgid "Number of Service Contracts $10K and under"
-msgstr "Nombre de marchés de services de 10 000 $ et moins"
-
-msgid "Service Contracts $10K and under – Original Value ($ 000)"
-msgstr "Marchés de services de 10 000 $ et moins – Valeur initiale (000 $)"
-
-msgid ""
-"Service Contracts Amendments from -$10K to $10K – Net Amendment Value ($ 000)"
-msgstr ""
-"Marchés de services de -10 000 $ à 10 000 $ - Valeur nette des modifications "
-"(000 $)"
-
-msgid "Service Contracts $10K and under - Total Value ($ 000)"
-msgstr "Marchés de services de 10 000 $ et moins - Valeur totale (000 $)"
-
-msgid "Number of Construction Contracts $10K and under"
-msgstr "Nombre de marchés de services de construction de 10 000 $ et moins"
-
-msgid "Construction Contracts $10K and under – Original Value ($ 000)"
-msgstr ""
-"Marchés de services de construction de 10 000 $ et moins - Valeur initiale "
-"(000 $)"
-
-msgid ""
-"Construction Contracts Amendments from -$10K to $10K – Net Amendment Value "
-"($ 000)"
-msgstr ""
-"Modifications de marchés de construction de -10 000 $ à 10 000 $ - Valeur "
-"nette des modifications (000 $)"
-
-msgid "Construction Contracts $10K and under - Total Value ($ 000)"
-msgstr ""
-"Marchés de services de construction de 10 000 $ et moins - Valeur totale "
-"(000 $)"
-
-msgid "Total Number of Contracts $10K and under"
-msgstr "Nombre total de marchés de 10 000 $ et moins"
-
-msgid "Total Original Value of All Contracts $10K and under ($ 000)"
-msgstr ""
-"Valeur initiale totale de tous les marchés de 10 000 $ et moins (000 $)"
-
-msgid ""
-"Total Net Amendment Value of All Contracts Amendments from -$10K to $10K ($ "
-"000)"
-msgstr ""
-"Valeur totale des modifications nettes de toutes les modifications de "
-"marchés de -10 000 $ à 10 000 $ (000 $)"
-
-msgid "Total Value of All Contracts $10K and under ($ 000)"
-msgstr "Valeur totale de tous les marchés de 10 000 $ et moins (000 $)"
-
-msgid "Number of Acquisition Card Transactions for all Dollar Values"
-msgstr ""
-"Nombre d'opérations réalisées au moyen de la carte d'acquisition pour toutes "
-"les valeurs en dollars"
-
-msgid ""
-"Acquisition Card Transactions for all dollar values – Total Value ($ 000)"
-msgstr ""
-"Carte d'acquisition pour toutes les valeurs en dollars– Valeur totale (000 $)"
-
-msgid "Proactive Publication - Contracts"
-msgstr "Publication proactive - Contrats"
-
-msgid "Proactive Publication - Contracts Nothing to Report"
-msgstr "Publication proactive – Contrats (Rien à signaler)"
-
-msgid "Proactive Disclosure"
-msgstr "Divulgation proactive"
-
-msgid "Proactive Publication"
-msgstr "Publication proactive"
-
-msgid ""
-"This dataset includes all of the reports on contracts issued by or on behalf "
-"of your organization."
-msgstr ""
-"Ce jeu de données comprend tous les rapports sur les contrats qui ont été "
-"émis par ou pour le compte de votre organisation."
-
-msgid "Additional Comments English"
-msgstr "Commentaires additionnels en anglais"
-
-msgid "Additional Comments French"
-msgstr "Commentaires additionnels en français"
-
-msgid "Proactive Disclosure - Grants and Contributions"
-msgstr "Divulgation proactive - Subventions et les contributions"
-
-msgid "Proactive Disclosure - Grants and Contributions Nothing to Report"
-msgstr ""
-"Divulgation proactive - Subventions et les contributions  (Rien à signaler)"
-
-msgid "Program Number"
-msgstr "Numéro d’identification du programme"
-
-msgid "Program Name English"
-msgstr "Nom du programme en anglais"
-
-msgid "Program Name French"
-msgstr "Nom du programme en français"
-
-msgid "Project Number"
-msgstr "Numéro d’identification du projet"
-
-msgid "Project Name English"
-msgstr "Nom du bénéficiaire en anglais"
-
-msgid "Project Name French"
-msgstr "Nom du bénéficiaire en français"
-
-msgid "Recipient Name English"
-msgstr "Nom du récipient en anglais"
-
-msgid "Recipient Name French"
-msgstr "Nom du récipient en français"
-
-msgid "Value"
-msgstr "Valeur"
-
-msgid "Purpose English"
-msgstr "Objectif en anglais"
-
-msgid "Purpose French"
-msgstr "Objectif en français"
-
-msgid "Additional Information English"
-msgstr "Informations supplémentaires en anglais"
-
-msgid "Additional Information French"
-msgstr "Informations supplémentaires en français"
-
-msgid "Proactive Disclosure - Annual Travel, Hospitality and Conferences"
-msgstr ""
-"Divulgation proactive – Dépenses annuelles de voyages, d’accueil, de "
-"conférences et d’événements"
-
-msgid ""
-"This dataset includes all of the annual reports on travel expenses incurred "
-"within your organization."
-msgstr ""
-"Ce jeu de données comprend tous les rapports annuels sur les dépenses de "
-"voyage engagées au sein de votre organisation."
-
-msgid "Mandatory if year ≥ 2018"
-msgstr "Obligatoire si année ≥ 2018"
-
-msgid "Mandatory if year < 2018"
-msgstr "Obligatoire si année < 2018"
-
-msgid "Proactive Disclosure - Acts of Founded Wrongdoing"
-msgstr "Divulgation proactive – Dossiers sur les actes répréhensibles fondés"
-
-msgid "Proactive Disclosure - Founded Wrongdoing"
-msgstr "Divulgation proactive – Dossiers sur les actes répréhensibles fondés"
-
-msgid ""
-"Access, upload and modify the Acts of Founded Wrongdoing reports for your "
-"organization"
-msgstr ""
-"Accès, téléversement et modifications des dossiers sur les actes "
-"répréhensibles fondés pour votre organisation"
-
-msgid "Proactive Disclosure - Position Reclassification"
-msgstr "Divulgation proactive - Reclassifications de postes"
-
-msgid "Proactive Disclosure - Position Reclassification Nothing to Report"
-msgstr "Divulgation proactive - Reclassifications de postes (Rien à signaler)"
-
-msgid "Proactive Disclosure - Departmental Audit Committee"
-msgstr "Divulgation proactive - Comités ministériels d’audit"
-
-msgid ""
-"Access, upload and modify the Grants and Contributions reports for your "
-"organization"
-msgstr ""
-"Accès, téléversement et modifications des rapports sur les contributions et "
-"les subventions pour votre organisation"
-
-msgid ""
-"Access, upload and modify the position reclassification reports for your "
-"organization"
-msgstr ""
-"Accès, téléversement et modifications des rapports sur les contributions et "
-"les subventions pour votre organisation"
-
-msgid "Description of Work Code"
-msgstr "Code de la description du travail"
-
-msgid "Instrument Type"
-msgstr "Type d’instrument"
-
-msgid "Unique Identifier"
-msgstr "Identifiant unique"
-
-msgid "Title (English)"
-msgstr "Titre (anglais)"
-
-msgid "Title (French)"
-msgstr "Titre (français)"
-
-msgid "Description (French)"
-msgstr "Description (français)"
-
-msgid "Location and Hospitality Provider (French)"
-msgstr "Fournisseur de services d’emplacement et d’accueil (français)"
-
-msgid "Description (English)"
-msgstr "Description (anglais)"
-
-msgid "Start Date"
-msgstr "Date du début"
-
-msgid "End Date"
-msgstr "Date de fin"
-
-msgid "Location and Hospitality Provider (English)"
-msgstr "Fournisseur de services d’emplacement et d’accueil (anglais)"
-
-msgid "Previous Position Classification Group"
-msgstr "Groupe de classification du poste antérieur"
-
-msgid "Previous Position Classification Sub Group"
-msgstr "Sous-groupe de classification du poste antérieur"
-
-msgid "Previous Position Classification Level Number"
-msgstr "Numéro de niveau de la classification du poste antérieur"
-
-msgid "Reclassified Position Classification Group"
-msgstr "Groupe de classification du poste reclassifié"
-
-msgid "Reclassified Position Classification Sub Group"
-msgstr "Groupe de classification du poste reclassifié"
-
-msgid "Reclassified Position Classification Level Number"
-msgstr "Numéro de niveau de la classification du poste reclassifié"
-
-msgid "Purpose of Travel (French)"
-msgstr "But du voyage (français)"
-
-msgid "Purpose of Travel (English)"
-msgstr "But du voyage (anglais)"
-
-msgid "Travel Start Date"
-msgstr "Date du début du voyage"
-
-msgid "Travel End Date"
-msgstr "Date de fin du voyage"
-
-msgid "Destination (French)"
-msgstr "Destination (français)"
-
-msgid "Destination (English)"
-msgstr "Destination (anglais)"
-
-msgid "Program Name (English)"
-msgstr "Nom du programme (anglais)"
-
-msgid "Program Name (French)"
-msgstr "Nom du programme (français)"
-
-msgid "Project Name (English)"
-msgstr "Nom du bénéficiaire (anglais)"
-
-msgid "Project Name (French)"
-msgstr "Nom du bénéficiaire (français)"
-
-msgid "Recipient Name (English)"
-msgstr "Nom du récipient (anglais)"
-
-msgid "Recipient Name (French)"
-msgstr "Nom du récipient (français)"
-
-msgid "Recipient Business Number"
-msgstr "Numéro de l’entreprise bénéficiaire"
-
-msgid "Country"
-msgstr "Pays"
-
-msgid "Region (English)"
-msgstr "Région (anglais)"
-
-msgid "Region (French)"
-msgstr "Région (français)"
-
-msgid "Additional Information (English)"
-msgstr "Informations supplémentaires (anglais)"
-
-msgid "Additional Information (French)"
-msgstr "Informations supplémentaires (français)"
-
-
-msgid "Resources associates with this dataset."
-msgstr "Ressources associés avec cet ensemble de données."
-
-msgid "other"
-msgstr "autre"
-
-msgid "Other"
-msgstr "Autre"
-
-msgid "Search Open Data"
-msgstr "Recherche de données ouvertes"
-
-msgid "Open Canada Dataset Feed"
-msgstr "Nouveaux jeux de données"
-
-msgid "Open Canada"
-msgstr "Canada ouvert"
-
-msgid "Open government"
-msgstr "Gouvernement ouvert"
-
-msgid "Open Government Portal"
-msgstr "Portail du gouvernement ouvert"
-
-msgid "Open Government Portal (staging)"
-msgstr "Portail du gouvernement ouvert (stadification)"
-
-msgid "Open Data Portal"
-msgstr "Portail des données ouvertes"
-
-msgid "Open Data Portal (staging)"
-msgstr "Portail des données ouvertes (stadification)"
-
-msgid "Open Data Portal - Open Data"
-msgstr "Portail des données ouvertes - Données ouvertes"
-
-msgid "{record_title} - Open Data Portal - Open Data"
-msgstr "{record_title} - Portail des données ouvertes - Données ouvertes"
-
-msgid "Spatial Feature"
-msgstr "Élément spatial"
-
-msgid "Bilingual (English and French)"
-msgstr "Bilingue (français et anglais)"
-
-msgid "Open Data Inventory"
-msgstr "Inventaire des données ouvertes"
-
-msgid ""
-"This dataset houses your departmental open data inventory. This is where you "
-"can access and upload your open data inventory template."
-msgstr ""
-"Ce jeu de données contient l’inventaire des données ouvertes de votre "
-"ministère. C’est l’occasion pour accéder à et pour télécharger votre modèle "
-"d'inventaire des données ouvertes. "
-
-msgid "Publisher - Name at Publication (English)"
-msgstr "Éditeur – Nom de l'organisation au moment de la publication (anglais)"
-
-msgid "Publisher - Name at Publication (French)"
-msgstr "Éditeur – Nom de l'organisation au moment de la publication (français)"
-
-msgid "Date Published"
-msgstr "Date de publication "
-
-msgid "Language"
-msgstr "Langue"
-
-msgid "Size"
-msgstr "Taille"
-
-msgid "Eligible for Release"
-msgstr "Admissible à la publication"
-
-msgid "Program Alignment Architecture (English)"
-msgstr "Architecture d'alignement des programmes (anglais)"
-
-msgid "Program Alignment Architecture (French)"
-msgstr "Architecture d'alignement des programmes (français)"
-
-msgid "Date Released"
-msgstr "Date de sortie"
-
-msgid "Open Government Portal Record (English)"
-msgstr "Enregistrement de la portail du Gouvernement ouvert (anglais)"
-
-msgid "Open Government Portal Record (French)"
-msgstr "Enregistrement de la portail du Gouvernement ouvert (français)"
-
-msgid "User Votes"
-msgstr "Votes des utilisateurs"
-
-msgid "Template"
-msgstr "Modèle"
-
-msgid "You do not have permission to upload to {0}"
-msgstr "Vous n'avez pas la permission de télécharger à {0}"
-
-msgid "You must provide a valid file"
-msgstr "Voud devez fournir un fichier valide"
-
-msgid "Sheet name '{0}' not found in list of valid tables"
-msgstr ""
-"Le nom de la feuille '{0}' n'a pas été trouvé dans la liste des tableaux "
-"valides"
-
-msgid "Open.canada.ca"
-msgstr "ouvert.canada.ca"
-
-msgid "Search Assets"
-msgstr "Rechercher des biens"
-
-msgid "Add Assets"
-msgstr "Ajouter des biens"
-
-msgid "Open Information Registry"
-msgstr "Registre pour les information ouverte"
-
-msgid "Add Asset"
-msgstr "Ajouter des biens"
-
-msgid "Update Asset"
-msgstr "Mis à jour le dossier"
-
-msgid "Reset password"
-msgstr "Réinitialiser le mot de passe"
-
-msgid "New Password"
-msgstr "Nouveau mot de passe"
-
-msgid "Open Information Portal"
-msgstr "Registre pour les information ouverte"
-
-msgid "{number} asset found"
-msgid_plural "{number} assets found"
-msgstr[0] "{number}  bien  trouvé"
-msgstr[1] "{number} biens  trouvés"
-
-msgid "{num} Dataset"
-msgid_plural "{num} Datasets"
-msgstr[0] "{num} dossiers"
-msgstr[1] "{num} dossiers"
-
-msgid "{number} Asset"
-msgid_plural "{number} Assets"
-msgstr[0] "{number} Bien"
-msgstr[1] "{number} Biens"
-
-msgid "0 Datasets"
-msgstr "0 dossiers"
-
-msgid "0 Assets"
-msgstr "0 Biens"
-
-msgid "No assets were found to match your query."
-msgstr "Aucun bien trouvé qui corresponde à votre requête."
-
-msgid "Asset Resources"
-msgstr "Biens de la ressource"
-
-msgid "Resource Formats"
-msgstr "Formats des ressources"
-
-msgid "Settings"
-msgstr "Paramètres"
-
-msgid "Add Asset Metadata"
-msgstr "Ajouter les métadonnées du produit"
-
-msgid "Add Resource or Related Item"
-msgstr "Ajouter une ressource ou un objet connexe"
-
-msgid "* indicates a mandatory field"
-msgstr "* Indique un champ obligatoire "
-
-msgid "Next: Add Resource or Related Item"
-msgstr "Suivant: Ajouter une ressource ou un objet connexe"
-
-msgid "Errors in form"
-msgstr "Erreurs dans le formulaire"
-
-msgid "Browse"
-msgstr "Explorer"
-
-msgid "No file chosen"
-msgstr "Aucun fichier choisi"
-
-msgid "{actor} created the dataset {dataset}"
-msgstr "{actor} a créé le dosier {dataset}"
-
-msgid "{actor} updated the dataset {dataset}"
-msgstr "{actor} a mis à jour le dossier {dataset}"
-
-msgid "{actor} updated the record {datastore} {datastore_detail}"
-msgstr "{actor} a mis à jour le dossier {datastore} {datastore_detail}"
-
-msgid "{actor} deleted the record {datastore} {datastore_detail}"
-msgstr "{actor} a supprimé le jeu de données {datastore} {datastore_detail}"
-
-# Footer links
-msgid "Contact Open Government"
-msgstr "Contactez-nous du gouvernement ouvert"
-
-msgid "Specialized enquiries"
-msgstr "Requêtes particulières"
-
-msgid "https://open.canada.ca/en/forms/contact-us"
-msgstr "https://ouvert.canada.ca/fr/formulaire/faites-nous-part-de-vos-commentaires"
-
-msgid "Open Government Log In"
-msgstr "Ouverture de session Gouvernement ouvert"
-
-msgid "/en/user"
-msgstr "/fr/user"
-
-msgid "Receive Open Government Email"
-msgstr "Courriels sur le Gouvernement ouvert"
-
-msgid "/en/forms/receive-open-government-email-form"
-msgstr "/fr/formulaire/courriels-gouvernement-ouvert"
-
-msgid "Most asked-about topics"
-msgstr "Sujets sur lesquels portent la plupart des questions"
-
-msgid "http://open.canada.ca/en/contact/index.html#aat"
-msgstr "http://ouvert.canada.ca/fr/contact/index.html#slq"
-
-msgid "General enquiries"
+#: ckanext/canada/controller.py:1109
+#, fuzzy
+msgid "Number required"
 msgstr "Renseignements généraux"
 
-msgid "http://open.canada.ca/en/contact/index.html#gen"
-msgstr "http://www.canada.ca/fr/contact/index.html#gen"
+#: ckanext/canada/controller.py:1114
+#, fuzzy
+msgid "Integer required"
+msgstr "Renseignements généraux"
 
-# Search facets
-msgid "Open Data"
-msgstr "Données ouvertes"
+#: ckanext/canada/helpers.py:387
+msgid "A system administrator"
+msgstr "Un administrateur du système"
 
+#: ckanext/canada/plugins.py:365
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:26
 msgid "Portal Type"
 msgstr "Type de portail"
 
-msgid "Collection Type"
-msgstr "Type de collection"
-
-msgid "Jurisdiction"
-msgstr "Juridiction"
-
+#: ckanext/canada/plugins.py:366 ckanext/canada/plugins.py:833
+#: ckanext/canada/templates/internal/user/new_user_form.html:18
+#: ckanext/canada/templates/public/package/deleted.html:15
+#: ckanext/canada/templates/public/snippets/package_item.html:61
 msgid "Organization"
 msgstr "Organisation"
 
+#: ckanext/canada/plugins.py:367
+msgid "Collection Type"
+msgstr "Type de collection"
+
+#: ckanext/canada/plugins.py:368 ckanext/canada/plugins.py:369
+#: ckanext/canada/plugins.py:834 ckanext/canada/plugins.py:835
 msgid "Keywords"
 msgstr "Mots clés"
 
-msgid "Topic Categories"
-msgstr "Catégorie thématique"
+#: ckanext/canada/plugins.py:370
+msgid "Subject"
+msgstr "Sujet"
 
+#: ckanext/canada/plugins.py:371 ckanext/canada/plugins.py:836
 msgid "Format"
 msgstr "Format"
 
+#: ckanext/canada/plugins.py:372 ckanext/canada/plugins.py:837
 msgid "Resource Type"
 msgstr "Type de ressource"
 
-msgid "Resource Language"
-msgstr "Langue de ressource"
-
-msgid "Spatial Representation Type"
-msgstr "Type de représentation spatiale"
-
+#: ckanext/canada/plugins.py:373
 msgid "Maintenance and Update Frequency"
 msgstr "Fréquence d'entretien et de mise à jour"
 
-# Dataset view page
-msgid "Access"
-msgstr "Accès"
+#: ckanext/canada/plugins.py:374
+msgid "Topic Categories"
+msgstr "Catégorie thématique"
 
-msgid "HNAP ISO:19115 Metadata Record"
-msgstr "Enregistrement de métadonnées de HNAP ISO:19115"
+#: ckanext/canada/plugins.py:375
+msgid "Spatial Representation Type"
+msgstr "Type de représentation spatiale"
 
-# Contact information
-msgid "Contact Information"
-msgstr "Coordonnées"
+#: ckanext/canada/plugins.py:376
+msgid "Map Viewer"
+msgstr "Visualisateur de carte"
 
-msgid "Delivery Point"
-msgstr "Point de livraison"
+#: ckanext/canada/plugins.py:377
+msgid "Record Status"
+msgstr "État du dossier"
 
-msgid "City"
-msgstr "Ville"
-
-msgid "Administrative Area"
-msgstr "Zone administrative"
-
-msgid "Postal Code"
-msgstr "Code postal"
-
-msgid "Electronic Mail Address"
-msgstr "Adresse de courrier électronique"
-
-msgid ""
-"Search for geospatial data or click <b>Add to cart</b> to select multiple "
-"datasets to plot on a single map.<br/>Click <b>View on Map</b> to visualize "
-"and overlay the datasets using a geospatial viewer"
-msgstr ""
-"Rechercher des données géospatiales ou cliquer sur <b>Ajouter au panier</b> "
-"pour sélectionner de multiples jeux de données à tracer sur une seule "
-"carte<br/>Cliquez <b>Afficher la carte</b> pour visualiser et superposer les "
-"jeux de données à l'aide d'une visualisateur géospatiale."
-
-msgid "Record Released"
-msgstr "Dossier publié"
-
-msgid "Record Modified"
-msgstr "Dossier modifié"
-
-msgid "Record ID"
-msgstr "Identificateur du dossier"
-
-msgid "Metadata"
-msgstr "Métadonnées"
-
-msgid "Atom Feed"
-msgstr "Fil de nouvelles Atom"
-
-msgid ""
-"Use only lowercase letters (a-z) and numbers (0-9) with optional hyphens (-) "
-"and underscores (_). Example: joe-bloggs"
-msgstr ""
-"N’employer que des lettres minuscules (a-z) et des chiffres (0-9) et, "
-"facultativement, des traits d’union (-) et des traits de soulignement (_). "
-"Exemplar : joe-bloggs"
-
-msgid "Example: Joe Bloggs"
-msgstr "Exemplar : Joe Bloggs"
-
-msgid "Example: joe.bloggs@tbs-sct.gc.ca"
-msgstr "Exemplar : joe.bloggs@tbs-sct.gc.ca"
-
-msgid "Example: 000 000 0000"
-msgstr "Exemplar : 000 000 0000"
-
-msgid "Next Step..."
-msgstr "Prochaine étape..."
-
-msgid "Select the role this user should have within this organization."
-msgstr ""
-"Sélectionnez le rôle du nouvel utilisateur au sein de cette organisation."
-
+#: ckanext/canada/plugins.py:378
 msgid "IMSO Approval"
 msgstr "Approbation du CSGI"
 
-msgid "IMSO Approved"
-msgstr "Approuvé du CSGI"
+#: ckanext/canada/plugins.py:379
+msgid "Jurisdiction"
+msgstr "Juridiction"
 
+#: ckanext/canada/plugins.py:380
+msgid "Suggestion Status"
+msgstr "État de la suggestion"
+
+#: ckanext/canada/plugins.py:714
+#, fuzzy, python-format
+msgid "Your record %s has been saved."
+msgstr "Ce dossier a été supprimé de %s."
+
+#: ckanext/canada/plugins.py:838
+msgid "Resource Language"
+msgstr "Langue de ressource"
+
+#: ckanext/canada/plugins.py:904
+#: ckanext/canada/templates/public/package/snippets/resource_form.html:8
+msgid "Previous"
+msgstr "Précédent"
+
+#: ckanext/canada/plugins.py:904
+msgid "Next"
+msgstr "Suivant"
+
+#: ckanext/canada/strings.py:8
+msgid ""
+"This field must be populated with an NA if an amendment is disclosed "
+"under Instrument Type."
+msgstr ""
+"Ce champ doit contenir NA si une modification est divulguée sous "
+"l’élément Type d’instrument."
+
+#: ckanext/canada/strings.py:9
+msgid ""
+"If N/A, then Instrument Type must be identified as a standing "
+"offer/supply arrangement (SOSA)"
+msgstr ""
+"Si N/A, alors le Type d’instrument doit être identifié comme étant une "
+"offre à commandes ou un arrangement en matière d’approvisionnement "
+"(SOSA)."
+
+#: ckanext/canada/strings.py:10
+msgid ""
+"If the value XX (none) is entered, then no other value can be entered in "
+"this field."
+msgstr ""
+"Si la valeur XX (aucun) est inscrite, alors aucune autre valeur ne peut "
+"être inscrite dans ce champ."
+
+#: ckanext/canada/strings.py:11
+msgid ""
+"If the value NA (not applicable) is entered, then no other value can be "
+"entered in this field."
+msgstr ""
+"Si la valeur NA (sans objet) est inscrite, alors aucune autre valeur ne "
+"peut être inscrite dans ce champ."
+
+#: ckanext/canada/strings.py:12
+#, fuzzy
+msgid ""
+"This field must be NA (not applicable) if the Agreement Type or Trade "
+"Agreement field is not 0 (none) or XX (none), as applicable."
+msgstr ""
+"Ce champ doit être N, No ou Non, si les champs Type d’accord ou Accord "
+"commercial ne contiennent pas la valeur 0 (aucun) ou XX (aucun), le cas "
+"échéant."
+
+#: ckanext/canada/strings.py:14
+msgid ""
+"If the value 00 (none) is entered, then no other value can be entered in "
+"this field."
+msgstr ""
+"Si la valeur 00 (aucune) est inscrite, alors aucune autre valeur ne peut "
+"être inscrite dans ce champ."
+
+#: ckanext/canada/strings.py:15
+msgid ""
+"This field must contain the first three digits of a postal code in A1A "
+"format or the value \"NA\""
+msgstr ""
+"Ce champ doit contenir les trois premiers chiffres d’un code postal dans "
+"le format A1A ou la valeur « NA. »"
+
+#: ckanext/canada/strings.py:16
+msgid ""
+"This field must be N, No or Non, if the Agreement Type or Trade Agreement"
+" field is not 0 (none) or XX (none), as applicable."
+msgstr ""
+"Ce champ doit être N, No ou Non, si les champs Type d’accord ou Accord "
+"commercial ne contiennent pas la valeur 0 (aucun) ou XX (aucun), le cas "
+"échéant."
+
+#: ckanext/canada/strings.py:18
+msgid ""
+"This field must be N, No or Non, if the Procurement Strategy for "
+"Aboriginal Business field is MS or VS."
+msgstr ""
+"Ce champ doit être N, No ou Non, si le champ Stratégie "
+"d’approvisionnement auprès des entreprises autochtones contient MS ou VS."
+
+#: ckanext/canada/strings.py:19
+#, fuzzy
+msgid ""
+"This field may only be populated with a 1 if the solicitation procedure "
+"is identified as non-competitive (TN) or Advance Contract Award Notice "
+"(AC)"
+msgstr ""
+"Cette zone doit contenir un « 1 » si la méthode d’invitation à "
+"soumissionner est identifiée comme étant non concurrentielle (TN) ou un "
+"préavis d’attribution de contrat (AC)."
+
+#: ckanext/canada/strings.py:21
+msgid ""
+"This field may only be populated with a 0 if a Call-up against a standing"
+" offer or supply arrangement was identified in the Contracting Entity "
+"data field"
+msgstr ""
+
+#: ckanext/canada/strings.py:23
+#, fuzzy
+msgid ""
+"This field may only be populated with \"0\" if the procurement was "
+"identified as non-competitive (TN) or advance contract award notice (AC)."
+msgstr ""
+"Cette zone doit contenir un « 1 » si la méthode d’invitation à "
+"soumissionner est identifiée comme étant non concurrentielle (TN) ou un "
+"préavis d’attribution de contrat (AC)."
+
+#: ckanext/canada/strings.py:25
+#, fuzzy
+msgid ""
+"This field may not be populated with 1, 2, 3 or 4 if the procurement was "
+"identified as non-competitive or Advance Contract Award Notice."
+msgstr ""
+"Cette zone doit contenir un « 1 » si la méthode d’invitation à "
+"soumissionner est identifiée comme étant non concurrentielle (TN) ou un "
+"préavis d’attribution de contrat (AC)."
+
+#: ckanext/canada/strings.py:27
+msgid ""
+"Commodity Type of G for Goods which requires a Delivery Date and not a "
+"Contract Period Start Date. Please either change the Commodity Type to S "
+"or remove the date from the Contract Period Start Date field"
+msgstr ""
+"Type de produit G pour les biens, ce qui requière une Date de livraison "
+"et non une Date de début du marché. Prière de changer le Type de produit "
+"pour S ou de retirer la date du champ Date de début du marché"
+
+#: ckanext/canada/strings.py:30
+msgid ""
+"If the value XX (none) is entered here, then the following three fields "
+"must be identified as NA or N, as applicable: Comprehensive Land Claim "
+"Agreement, Procurement Strategy for Aboriginal Business, Procurement "
+"Strategy for Aboriginal Business Incidental Indicator"
+msgstr ""
+
+#: ckanext/canada/validators.py:117
+#, python-format
+msgid "Tag \"%s\" length is less than minimum %s"
+msgstr ""
+
+#: ckanext/canada/validators.py:121
+#, python-format
+msgid "Tag \"%s\" length is more than maximum %i"
+msgstr ""
+
+#: ckanext/canada/validators.py:124
+#, python-format
+msgid "Tag \"%s\" may not contain commas"
+msgstr ""
+
+#: ckanext/canada/validators.py:127
+#, python-format
+msgid "Tag \"%s\" may not contain consecutive spaces"
+msgstr ""
+
+#: ckanext/canada/validators.py:134
+#, python-format
+msgid "Tag \"%s\" may not contain unprintable character U+%04x"
+msgstr ""
+
+#: ckanext/canada/validators.py:138
+#, python-format
+msgid "Tag \"%s\" may not contain separator charater U+%04x"
+msgstr ""
+
+#: ckanext/canada/validators.py:154
+msgid "Badly formed hexadecimal UUID string"
+msgstr ""
+
+#: ckanext/canada/templates/internal/user/new_user_form.html:6
+#: ckanext/canada/validators.py:166 ckanext/canada/validators.py:168
+msgid "Please enter a valid email address."
+msgstr "S\\'il vous plaît, mettez une adresse email valide."
+
+#: ckanext/canada/validators.py:183
+#, fuzzy
+msgid "Invalid GeoJSON"
+msgstr "Licence non valide"
+
+#: ckanext/canada/validators.py:260
+msgid "Date may not be in the future when this record is marked ready to publish"
+msgstr ""
+"Une fois que ce document est marqué comme étant prêt à publier, la date "
+"ne peut pas être dans le futur"
+
+#: ckanext/canada/validators.py:326
+msgid "Date format incorrect. Expecting YYYY-MM-DD"
+msgstr "Le format de la date est incorrect. Il devrait être AAAA-MM-JJ"
+
+#: ckanext/canada/validators.py:333
+msgid "Invalid licence"
+msgstr "Licence non valide"
+
+#: ckanext/canada/validators.py:346 ckanext/canada/validators.py:360
+msgid "Must be a Unicode string value"
+msgstr ""
+
+#: ckanext/canada/validators.py:367 ckanext/canada/validators.py:378
+msgid "Must be a JSON string"
+msgstr ""
+
+#: ckanext/canada/validators.py:374
+msgid "JSON object must contain \"en\" key"
+msgstr ""
+
+#: ckanext/canada/validators.py:376
+msgid "JSON object must contain \"fr\" key"
+msgstr ""
+
+#: ckanext/canada/templates/internal/base.html:5
+msgid "Open Data Registry"
+msgstr "Registre de données ouvertes"
+
+#: ckanext/canada/templates/internal/error_document_template.html:5
+#: ckanext/canada/templates/internal/home/quick_links.html:2
+msgid "Open Government Registry"
+msgstr "Registre du gouvernement ouvert"
+
+#: ckanext/canada/templates/internal/error_document_template.html:17
+msgid ""
+"You are not logged in to the Open Government Registry. Note that your "
+"login expires after 1 hour of inactivity. Click on the log in button "
+"below to log in."
+msgstr ""
+
+#: ckanext/canada/templates/internal/error_document_template.html:21
+#: ckanext/canada/templates/internal/header.html:39
+#: ckanext/canada/templates/internal/page.html:20
+#: ckanext/canada/templates/internal/user/snippets/login_form.html:22
+#: ckanext/canada/templates/public/snippets/user.html:61
+#: ckanext/canada/templates/public/user/snippets/login_form.html:22
+msgid "Log in"
+msgstr "Connexion"
+
+#: ckanext/canada/templates/internal/error_document_template.html:25
+#: ckanext/canada/templates/public/error_document_template.html:6
+msgid "We couldn't find that Web page"
+msgstr "Nous ne pouvons trouver cette page Web"
+
+#: ckanext/canada/templates/internal/error_document_template.html:27
+msgid ""
+"We encountered an error and are unable to serve your request. Please try "
+"again in short time or contact <a href=\"mailto:open-ouvert@tbs-sct.gc.ca"
+"\">open-ouvert@tbs-sct.gc.ca</a> if you need immediate assistance or if "
+"this issue persists. Note that your login expires after 1 hour of "
+"inactivity."
+msgstr ""
+"Nous rencontrons une erreur et nous ne pouvons pas répondre à votre "
+"demande. Veuillez réessayer plus tard ou communiquer avec <a "
+"href=\"mailto:open-ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a> "
+"si votre demande est urgente ou si ce problème persiste. Veuillez noter "
+"que votre connexion expire après une heure d'inactivité."
+
+#: ckanext/canada/templates/internal/error_document_template.html:29
+#: ckanext/canada/templates/public/error_document_template.html:8
+msgid "We encountered an error"
+msgstr "Nous rencontrons une erreur"
+
+#: ckanext/canada/templates/internal/header.html:14
+#: ckanext/canada/templates/public/snippets/user.html:11
+msgid "Signed in as"
+msgstr "Connecté en tant que"
+
+#: ckanext/canada/templates/internal/header.html:15
+#: ckanext/canada/templates/public/snippets/user.html:12
+msgid "View profile"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:24
+#: ckanext/canada/templates/internal/header.html:26
+#: ckanext/canada/templates/public/snippets/user.html:48
+#: ckanext/canada/templates/public/snippets/user.html:50
+msgid "Log out"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:57
+#, fuzzy
+msgid "Home"
+msgstr "Afficher plus"
+
+#: ckanext/canada/templates/internal/header.html:59
+#: ckanext/canada/templates/internal/header.html:61
+#: ckanext/canada/templates/internal/home/quick_links.html:65
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:30
+#: ckanext/canada/templates/internal/snippets/dataset_facets.html:2
+#: ckanext/canada/templates/public/macros/canada_read.html:180
+#: ckanext/canada/templates/public/snippets/dataset_facets.html:2
+#: ckanext/canada/templates/public/snippets/package_item.html:12
+msgid "Open Data"
+msgstr "Données ouvertes"
+
+#: ckanext/canada/templates/internal/header.html:63
+msgid "Create an Open Data Record"
+msgstr "Créer un enregistrement de données ouvert"
+
+#: ckanext/canada/templates/internal/header.html:71
+#: ckanext/canada/templates/internal/home/quick_links.html:80
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:32
+#: ckanext/canada/templates/internal/snippets/dataset_facets.html:4
+#: ckanext/canada/templates/public/macros/canada_read.html:181
+#: ckanext/canada/templates/public/snippets/dataset_facets.html:3
+#: ckanext/canada/templates/public/snippets/package_item.html:18
 msgid "Open Information"
 msgstr "Information ouverte"
 
-msgid "Change your details"
-msgstr "Modifier vos détails"
+#: ckanext/canada/templates/internal/header.html:72
+#: ckanext/canada/templates/internal/header.html:74
+#: ckanext/canada/templates/internal/snippets/dataset_facets.html:32
+#: ckanext/canada/templates/public/macros/canada_read.html:202
+#: ckanext/canada/templates/public/snippets/package_item.html:16
+#: ckanext/canada/templates/public/snippets/package_item.html:22
+msgid "Proactive Disclosure"
+msgstr "Divulgation proactive"
 
-msgid "Change your password"
-msgstr "Modifier votre mot de passe"
+#: ckanext/canada/templates/internal/header.html:86
+msgid "Reports Tabled in Parliament"
+msgstr "Rapports déposés au Parlement"
 
+#: ckanext/canada/templates/internal/header.html:90
+#: ckanext/canada/templates/internal/home/quick_links.html:171
+msgid "Briefing packages"
+msgstr "Documents d’information"
+
+#: ckanext/canada/templates/internal/header.html:92
+msgid "New or incoming ministers"
+msgstr "Documents d'information pour les nouveaux ministres"
+
+#: ckanext/canada/templates/internal/header.html:93
+msgid "New or incoming deputy heads"
+msgstr "Documents d'information pour les nouveaux administrateurs généraux"
+
+#: ckanext/canada/templates/internal/header.html:94
+msgid "Parliamentary Committee appearances for ministers"
+msgstr ""
+"Documents d'information à l'intention des ministres pour les comparutions"
+" devant un comité parlementaire"
+
+#: ckanext/canada/templates/internal/header.html:95
+msgid "Parliamentary Committee appearances for deputy heads"
+msgstr ""
+"Documents d'information à l'intention des administrateurs généraux pour "
+"les comparutions devant un comité parlementaire"
+
+#: ckanext/canada/templates/internal/header.html:100
+#: ckanext/canada/templates/internal/home/quick_links.html:92
+#: ckanext/canada/templates/internal/snippets/dataset_facets.html:5
+#: ckanext/canada/templates/public/macros/canada_read.html:182
+#: ckanext/canada/templates/public/snippets/dataset_facets.html:4
+msgid "Suggested Datasets"
+msgstr "Jeux de données suggérés"
+
+#: ckanext/canada/templates/internal/header.html:101
+#: ckanext/canada/templates/internal/header.html:103
+#: ckanext/canada/templates/internal/home/quick_links.html:104
+#: ckanext/canada/templates/internal/snippets/dataset_facets.html:3
+#: ckanext/canada/templates/public/snippets/package_item.html:20
+msgid "Open Dialogue"
+msgstr "Dialogue ouvert"
+
+#: ckanext/canada/templates/internal/header.html:106
+msgid "Consultations master dataset"
+msgstr "Données de consultations principals"
+
+#: ckanext/canada/templates/internal/admin/publish_search.html:20
+#: ckanext/canada/templates/internal/header.html:111
+#: ckanext/canada/templates/internal/home/quick_links.html:117
+#: ckanext/canada/templates/public/header.html:15
+#: ckanext/canada/templates/public/header.html:26
+#: ckanext/canada/templates/public/snippets/search_form.html:67
+#: ckanext/canada/templates/public/user/snippets/followee_dropdown.html:20
+#: ckanext/canada/templates/public/user/snippets/followee_dropdown.html:24
+msgid "Search"
+msgstr "Rechercher"
+
+#: ckanext/canada/templates/internal/header.html:112
+#: ckanext/canada/templates/internal/user/read_base.html:21
+#: ckanext/canada/templates/public/organization/index.html:26
+#: ckanext/canada/templates/public/organization/read_base.html:5
+#: ckanext/canada/templates/public/user/read.html:23
+msgid "Organizations"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:114
+msgid "FAQ"
+msgstr ""
+
+#: ckanext/canada/templates/internal/header.html:124
+#: ckanext/canada/templates/public/header.html:52
+msgid "You are here:"
+msgstr "Vous êtes içi :"
+
+#: ckanext/canada/templates/internal/help.html:3
+msgid "Frequently Asked Questions (FAQ)"
+msgstr "Foire aux questions"
+
+#: ckanext/canada/templates/internal/page.html:9
+msgid "Your user sessions has timed out due to inactivity"
+msgstr "Vos sessions d’utilisateur ont été interrompues pour cause d’inactivité"
+
+#: ckanext/canada/templates/internal/page.html:15
+msgid ""
+"If you are currently entering data on this page, you may lose it when "
+"submitted. To avoid this, you can click on the log in button below to log"
+" in again in a new tab without losing your progress and you can then keep"
+" working on this page. If you have any issues please contact <a "
+"href=\"mailto:open-ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a>."
+msgstr ""
+"Si vous êtes en train de consigner des données sur cette page, vous "
+"risquez de les perdre au moment de la soumission. Pour éviter que cela se"
+" produise, vous pouvez cliquer sur le bouton de connexion ci‑dessous pour"
+" vous reconnecter dans un nouvel onglet sans perdre ce que vous avez déjà"
+" fait et continuer à travailler sur cette page. Si vous avez des "
+"problèmes, veuillez contacter <a href=\"mailto:open-ouvert@tbs-sct.gc.ca"
+"\">open-ouvert@tbs-sct.gc.ca</a>."
+
+#: ckanext/canada/templates/internal/page.html:36
+msgid ""
+"Internet Explorer is no longer being supported within the Open Government"
+" Registry. Some features will not work as expected, including publication"
+" of records. Please use MS Edge or Google Chrome, or contact <a "
+"href=\"mailto:open-ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a> "
+"for additional support."
+msgstr ""
+"Internet Explorer n’est plus pris en charge par le Registre du "
+"gouvernement ouvert. Par conséquent, certains éléments ne fonctionneront "
+"pas comme prévu, y compris la publication de documents. Veuillez utiliser"
+" MS Edge ou Google Chrome, ou contacter <a href=\"mailto:open-ouvert@tbs-"
+"sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a> pour obtenir une aide "
+"supplémentaire."
+
+#: ckanext/canada/templates/internal/admin/base.html:4
+#: ckanext/canada/templates/internal/snippets/user.html:14
+#: ckanext/canada/templates/public/snippets/user.html:23
+msgid "Admin"
+msgstr ""
+
+#: ckanext/canada/templates/internal/admin/base.html:8
+#: ckanext/canada/templates/internal/user/list.html:9
+#: ckanext/canada/templates/internal/user/list.html:17
+#: ckanext/canada/templates/internal/user/list.html:24
+#: ckanext/canada/templates/internal/user/list.html:73
+#: ckanext/canada/templates/internal/user/read_base.html:5
+#, fuzzy
+msgid "Users"
+msgstr "Entreprises"
+
+#: ckanext/canada/templates/internal/admin/base.html:9
+#: ckanext/canada/templates/public/admin/trash.html:38
+msgid "Trash"
+msgstr "Dossiers supprimés"
+
+#: ckanext/canada/templates/internal/admin/base.html:10
+msgid "Publish Records"
+msgstr "Publier des dossiers"
+
+#: ckanext/canada/templates/internal/admin/publish_search.html:13
+#: ckanext/canada/templates/internal/package/search.html:4
+#: ckanext/canada/templates/internal/snippets/search_form.html:3
+#: ckanext/canada/templates/public/snippets/search_form.html:43
+msgid "Search Datasets"
+msgstr "Recherche de dossiers"
+
+#: ckanext/canada/templates/internal/admin/publish_search.html:14
+#: ckanext/canada/templates/public/snippets/search_form.html:5
+msgid "Search..."
+msgstr "Recherche..."
+
+#: ckanext/canada/templates/internal/admin/publish_search.html:32
+msgid "Search Results:"
+msgstr "Résultats de la recherche:"
+
+#: ckanext/canada/templates/internal/admin/publish_search.html:49
+msgid " <p class=\"extra\">Please try another search.</p> "
+msgstr "Veuillez essayer une nouvelle recherche"
+
+#: ckanext/canada/templates/internal/admin/publish_search.html:57
+msgid ""
+" <p><strong>There was an error while searching.</strong> Please try "
+"again.</p> "
+msgstr ""
+
+#: ckanext/canada/templates/internal/admin/publish_search.html:81
+#: ckanext/canada/templates/public/package/search.html:21
+msgid "Search Filters"
+msgstr "Filtres de recherche"
+
+#: ckanext/canada/templates/internal/admin/publish_search.html:81
+#: ckanext/canada/templates/internal/snippets/publish_facet.html:52
+#: ckanext/canada/templates/internal/snippets/publish_facet.html:53
+#: ckanext/canada/templates/public/package/search.html:21
+#: ckanext/canada/templates/public/snippets/facet_list.html:61
+#: ckanext/canada/templates/public/snippets/facet_list.html:62
+msgid "Clear All"
+msgstr "Effacer tout"
+
+#: ckanext/canada/templates/internal/admin/snippets/package_item.html:9
+msgid "Publish?"
+msgstr "Publier?"
+
+#: ckanext/canada/templates/internal/admin/snippets/publish_package_list.html:7
+msgid "Select All for Publishing"
+msgstr "Sélectionner tout pour publication"
+
+#: ckanext/canada/templates/internal/admin/snippets/publish_package_list.html:29
+msgid "Publish Selected Records"
+msgstr "Publier les dossiers sélectionnés"
+
+#: ckanext/canada/templates/internal/ajax_snippets/api_info.html:5
+msgid "Create"
+msgstr "Créer"
+
+#: ckanext/canada/templates/internal/ajax_snippets/api_info.html:9
+#, fuzzy
+msgid "Update / Insert"
+msgstr "Mis à jour le dossier"
+
+#: ckanext/canada/templates/internal/datastore/snippets/dictionary_form.html:3
+msgid "Field {num}."
+msgstr ""
+
+#: ckanext/canada/templates/internal/datastore/snippets/dictionary_form.html:12
+msgid "Type Override"
+msgstr ""
+
+#: ckanext/canada/templates/internal/datastore/snippets/dictionary_form.html:20
+#, fuzzy
+msgid "English Label"
+msgstr "Anglais"
+
+#: ckanext/canada/templates/internal/datastore/snippets/dictionary_form.html:24
+msgid "French Label"
+msgstr ""
+
+#: ckanext/canada/templates/internal/datastore/snippets/dictionary_form.html:28
+#, fuzzy
+msgid "English Description"
+msgstr "Aucune description disponible pour cet ensemble de données"
+
+#: ckanext/canada/templates/internal/datastore/snippets/dictionary_form.html:32
+msgid "French Description"
+msgstr ""
+
+#: ckanext/canada/templates/internal/home/quick_links.html:58
+msgid ""
+"Welcome to the Open Government Registry. Use the Registry to add "
+"government resources that will be published on the Open Government "
+"Portal. For more information on using the Registry or to report errors, "
+"contact <a href=\"mailto:open-ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-"
+"sct.gc.ca</a>."
+msgstr ""
+"Bienvenue au Registre du gouvernement ouvert. Utilisez le registre pour "
+"ajouter des ressources gouvernementales qui seront publiées dans le "
+"Portail du gouvernement ouvert. Pour obtenir de plus amples "
+"renseignements sur l'utilisation du registre ou pour signaler des "
+"erreurs, communiquez avec <a href=\"mailto:open-ouvert@tbs-sct.gc.ca"
+"\">open-ouvert@tbs-sct.gc.ca</a>."
+
+#: ckanext/canada/templates/internal/home/quick_links.html:146
+msgid "Proactive Publication"
+msgstr "Publication proactive"
+
+#: ckanext/canada/templates/internal/organization/edit_base.html:10
+#: ckanext/canada/templates/internal/package/search.html:6
+#: ckanext/canada/templates/public/organization/read_base.html:16
+#: ckanext/canada/templates/public/snippets/organization.html:36
+#: ckanext/canada/templates/public/user/read.html:12
+msgid "Datasets"
+msgstr "Dossiers"
+
+#: ckanext/canada/templates/internal/organization/edit_base.html:13
+#: ckanext/canada/templates/public/organization/read_base.html:19
+msgid "Activity"
+msgstr "Activité"
+
+#: ckanext/canada/templates/internal/organization/edit_base.html:21
+#: ckanext/canada/templates/public/organization/read_base.html:23
+msgid "Edit Members"
+msgstr "Modifier les membres"
+
+#: ckanext/canada/templates/internal/package/base_form_page.html:4
+msgid "Create Dataset"
+msgstr "Créer un jeu de données"
+
+#: ckanext/canada/templates/internal/package/edit_base.html:5
+msgid "Edit metadata"
+msgstr "Modifier les métadonnées"
+
+#: ckanext/canada/templates/internal/package/edit_base.html:6
+#: ckanext/canada/templates/public/package/resources.html:5
+#: ckanext/canada/templates/public/package/snippets/resources.html:9
+msgid "Resources"
+msgstr "Ressources"
+
+#: ckanext/canada/templates/internal/package/read.html:7
+#: ckanext/canada/templates/internal/package/read.html:9
+msgid "View on Portal"
+msgstr "Consulter le Portail"
+
+#: ckanext/canada/templates/internal/package/read.html:14
+msgid ""
+"This dataset has been deleted and is no longer accessible to non-admin "
+"users"
+msgstr "Cet ensemble de données a été supprimé et n'est plus accessible"
+
+#: ckanext/canada/templates/internal/package/read.html:16
+#, fuzzy
+msgid "Undelete"
+msgstr "non défini à"
+
+#: ckanext/canada/templates/internal/package/read.html:26
+#: ckanext/canada/templates/public/package/read_base.html:88
+msgid "Openness Rating"
+msgstr "Cote de degrée d’ouverture des données"
+
+#: ckanext/canada/templates/internal/package/read.html:31
+#: ckanext/canada/templates/public/package/read_base.html:93
+msgid "one star"
+msgstr "une étoile"
+
+#: ckanext/canada/templates/internal/package/read.html:32
+#: ckanext/canada/templates/public/package/read_base.html:94
+msgid "two stars"
+msgstr "deux étoiles"
+
+#: ckanext/canada/templates/internal/package/read.html:33
+#: ckanext/canada/templates/public/package/read_base.html:95
+msgid "three stars"
+msgstr "trois étoiles"
+
+#: ckanext/canada/templates/internal/package/read.html:34
+#: ckanext/canada/templates/public/package/read_base.html:96
+msgid "four stars"
+msgstr "quatre étoiles"
+
+#: ckanext/canada/templates/internal/package/read.html:35
+#: ckanext/canada/templates/public/package/read_base.html:97
+msgid "five stars"
+msgstr "cinq étoiles"
+
+#: ckanext/canada/templates/internal/package/read_base.html:4
+#, fuzzy
+msgid "Dataset"
+msgstr "Dossiers"
+
+#: ckanext/canada/templates/internal/package/read_base.html:5
+#: ckanext/canada/templates/public/organization/activity_stream.html:4
+#: ckanext/canada/templates/public/user/activity_stream.html:12
+msgid "Activity Stream"
+msgstr "Flux d'Activités"
+
+#: ckanext/canada/templates/internal/package/resource_edit.html:15
+msgid "Go back"
+msgstr "Retourner"
+
+#: ckanext/canada/templates/internal/package/resource_edit_base.html:15
+msgid "DataStore"
+msgstr ""
+
+#: ckanext/canada/templates/internal/package/wet_datatable.html:11
+#: ckanext/canada/templates/public/package/snippets/resource_item.html:52
+msgid "Preview"
+msgstr ""
+
+#: ckanext/canada/templates/internal/package/wet_datatable.html:17
+msgid "Select"
+msgstr ""
+
+#: ckanext/canada/templates/internal/package/wet_datatable.html:79
+msgid "Edit in Excel"
+msgstr ""
+
+#: ckanext/canada/templates/internal/package/snippets/stages.html:21
+msgid "Add Asset Metadata"
+msgstr "Ajouter les métadonnées du produit"
+
+#: ckanext/canada/templates/internal/package/snippets/stages.html:23
+msgid "Add Dataset Metadata"
+msgstr "Ajouter les métadonnées du jeu de données"
+
+#: ckanext/canada/templates/internal/package/snippets/stages.html:33
+msgid "Add Resource or Related Item"
+msgstr "Ajouter une ressource ou un objet connexe"
+
+#: ckanext/canada/templates/internal/package/snippets/stages.html:37
+#, fuzzy
+msgid "Add Resource Metadata"
+msgstr "Ajouter les métadonnées du produit"
+
+#: ckanext/canada/templates/internal/package/snippets/stages.html:39
+#, fuzzy
+msgid "Add data"
+msgstr "Métadonnées"
+
+#: ckanext/canada/templates/internal/package/snippets/view_form.html:8
+msgid "Title (English)"
+msgstr "Titre (anglais)"
+
+#: ckanext/canada/templates/internal/package/snippets/view_form.html:9
+msgid "Title (French)"
+msgstr "Titre (français)"
+
+#: ckanext/canada/templates/internal/package/snippets/view_form.html:10
+msgid "Description (English)"
+msgstr "Description (anglais)"
+
+#: ckanext/canada/templates/internal/package/snippets/view_form.html:11
+msgid "Description (French)"
+msgstr "Description (français)"
+
+#: ckanext/canada/templates/internal/recombinant/create_pd_record.html:3
+#: ckanext/canada/templates/internal/recombinant/create_pd_record.html:4
+#: ckanext/canada/templates/internal/recombinant/create_pd_record.html:12
+msgid "Create Record"
+msgstr "Créer un dossier"
+
+#: ckanext/canada/templates/internal/recombinant/create_pd_record.html:22
+#: ckanext/canada/templates/internal/recombinant/update_pd_record.html:22
+#: ckanext/canada/templates/internal/scheming/snippets/errors.html:6
+#: ckanext/canada/templates/public/macros/form.html:308
+msgid "The form contains invalid entries:"
+msgstr "Le formulaire contient des entrées non valides :"
+
+#: ckanext/canada/templates/internal/recombinant/create_pd_record.html:51
+#: ckanext/canada/templates/internal/recombinant/update_pd_record.html:54
+msgid "You may select or deselect multiple entries (Ctrl+Click)."
+msgstr "Vous pouvez sélectionner ou désélectionner de multiples entrées."
+
+#: ckanext/canada/templates/internal/recombinant/create_pd_record.html:81
+#: ckanext/canada/templates/internal/recombinant/update_pd_record.html:84
+#: ckanext/canada/templates/public/organization/confirm_delete_member.html:12
+#: ckanext/canada/templates/public/package/confirm_delete.html:12
+#: ckanext/canada/templates/public/package/confirm_delete_resource.html:11
+msgid "Cancel"
+msgstr ""
+
+#: ckanext/canada/templates/internal/recombinant/create_pd_record.html:82
+#: ckanext/canada/templates/internal/recombinant/update_pd_record.html:85
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:68
+#, fuzzy
+msgid "Save"
+msgstr "Voyage"
+
+#: ckanext/canada/templates/internal/recombinant/resource_edit.html:16
+#, python-format
+msgid ""
+"Informal Requests for ATI Records Previously Released are being sent to "
+"<strong>%s.</strong> Please contact <a href=\"mailto:open-ouvert@tbs-"
+"sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a> if that address is no longer "
+"valid."
+msgstr ""
+"Les demandes informelle d'enregistrements ATI précédemment publiés sont "
+"envoyées à <strong>%s.</strong> Veuillez contacter <a href=\"mailto:open-"
+"ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a> si cette adresse "
+"n'est plus valide."
+
+#: ckanext/canada/templates/internal/recombinant/resource_edit.html:20
+msgid ""
+"Your organization does not have an Access to Information email on file. "
+"Please contact <a href=\"mailto:open-ouvert@tbs-sct.gc.ca\">open-ouvert"
+"@tbs-sct.gc.ca</a> with the email for your organization's Access to "
+"Information Coordinator."
+msgstr ""
+"Votre organisation n'a pas d'adresse électronique d'accès à l'information"
+" dans ses dossiers. Veuillez contacter <a href=\"mailto:open-ouvert@tbs-"
+"sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a> avec l'adresse électronique du "
+"coordinateur de l'accès à l'information de votre organisation."
+
+#: ckanext/canada/templates/internal/recombinant/resource_edit.html:33
+msgid "Guide"
+msgstr ""
+
+#: ckanext/canada/templates/internal/recombinant/resource_edit.html:38
+#, python-format
+msgid ""
+"For information on how to prepare, maintain and upload templates to the "
+"Registry, refer to the appropriate documentation posted on <a "
+"href=\"%(gclink)s\">GCPEDIA</a>"
+msgstr ""
+"Pour obtenir des renseignements sur la façon de préparer, de tenir à jour"
+" et de verser des modèles de données pour le registre, consultez la "
+"documentation appropriée qui est publiée dans <a "
+"href='%(gclink)s'>Gcpédia</a>"
+
+#: ckanext/canada/templates/internal/recombinant/update_pd_record.html:3
+#: ckanext/canada/templates/internal/recombinant/update_pd_record.html:4
+#: ckanext/canada/templates/internal/recombinant/update_pd_record.html:12
+msgid "Update Record"
+msgstr "Mettre à jour les données"
+
+#: ckanext/canada/templates/internal/recombinant/snippets/xls_upload.html:11
+msgid "Create Single Record"
+msgstr "Créer un seul dossier"
+
+#: ckanext/canada/templates/internal/recombinant/snippets/xls_upload.html:12
+msgid "Create and update multiple records"
+msgstr "Créer et procéder à la mise à jour de plusieurs dossiers"
+
+#: ckanext/canada/templates/internal/recombinant/snippets/xls_upload.html:43
+msgid "This field must not be empty"
+msgstr "Cette zone ne doit pas être vide"
+
+#: ckanext/canada/templates/internal/recombinant/snippets/xls_upload.html:50
+msgid "This field must be empty"
+msgstr "Cette zone doit être vide"
+
+#: ckanext/canada/templates/internal/recombinant/snippets/xls_upload.html:57
+msgid "Invalid choice for"
+msgstr "Choix non valide pour"
+
+#: ckanext/canada/templates/internal/scheming/form_snippets/imso_approval_select.html:38
+#, fuzzy
+msgid ""
+"<small class='text-info' style='margin-bottom: 15px; display: inline-"
+"block'> <p>Has approval been obtained? By selecting yes, you have ensured"
+" that the following statements are true:</p> <ol> "
+"<li><b>Confidentiality</b> - The data or information resource is not "
+"subject to confidentiality restrictions, such as Cabinet confidences, "
+"solicitor-client privilege, classified or protected information, advice "
+"or recommendations, third party information, or information obtained in "
+"confidence.</li> <li><b>Authority to Release</b> - The institution has "
+"the mandate, legislative authority or permission from a third party "
+"provider to release the data or information resources under the <a "
+"href='https://open.canada.ca/en/open-government-licence-canada'><u>Open "
+"Government Licence – Canada</u></a>.</li> <li><b>Formats</b> - The data "
+"or information resource is in an open and accessible format that complies"
+" with <a href='https://www.tbs-sct.gc.ca/pol/doc-"
+"eng.aspx?id=23601'><u>the Standard on Web Accessibility</u></a>.</li> "
+"<li><b>Privacy</b> - The data or information resource does not contain "
+"personal information, as defined in section 3 of the <a "
+"href='https://www.priv.gc.ca/en/privacy-topics/privacy-laws-in-canada"
+"/the-privacy-act/'><u>Privacy Act</u></a>, unless the individual to whom "
+"it relates has consented to its release or unless it meets criteria "
+"outlined in section 8(2) of the Privacy Act.</li> <li><b>Official "
+"Languages</b> - The data or information resource is available in both "
+"official languages and conforms to the requirements of the <a href='https"
+"://laws-lois.justice.gc.ca/eng/acts/O-3.01/'><u>Official Languages "
+"Act</u></a>.</li> <li><b>Security</b> - The data or information resource "
+"does not increase security risks to the institution, to other "
+"institutions, or to the government as a whole and conforms to the "
+"requirements of the <a href='https://www.tbs-sct.gc.ca/pol/doc-"
+"eng.aspx?id=16578'><u>Policy on Government Security</u></a> and its "
+"related instruments.</li> <li><b>Other - Legal / Regulatory / Policy / "
+"Contractual</b> - The release of data or other information resource "
+"complies with all other relevant legal, regulatory, contractual, and "
+"policy requirements (e.g., it is confirmed that there are no relevant "
+"legal, contractual, or third party, policy restrictions or "
+"limitations).</li> </ol> </small>"
+msgstr ""
+"<small class='text-info' style='margin-bottom: 15px; display: inline-"
+"block'><p>A-t-on obtenu l’approbation? En sélectionnant << oui >>, vous "
+"avez fait certain que les énoncés suivants sont "
+"vrais:</p><ol><li><b>Confidentialité</b> -  Les ressources en données ou "
+"documentaires ne sont pas assujetties à aucune restriction liée à la "
+"confidentialité, comme les documents confidentiels du Cabinet, le secret "
+"professionnel de l’avocat, les renseignements , conseils ou "
+"recommandations classifiés ou protégés, les renseignements de tiers ou "
+"les renseignements obtenus à titre confidentiel.</li><li><b>Autorisation "
+"de diffuser</b> - L’institution a le mandat, l’autorisation législative "
+"ou la permission d’un fournisseur tiers de publier les ressources en "
+"données ou documentaires en vertu de la <a "
+"href='https://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-"
+"canada'><u>Licence du gouvernement ouvert – "
+"Canada</u></a>.</li><li><b>Formats</b> - Les ressources en données ou "
+"documentaires sont dans un format ouvert et accessible qui est conforme à"
+" la <a href='https://www.tbs-sct.gc.ca/pol/doc-"
+"fra.aspx?id=23601'><u>Norme sur l’accessibilité des sites "
+"Web</u></a>.</li><li><b>Protection des renseignements personnels</b> - "
+"Les ressources en données ou documentaires ne contiennent pas des "
+"renseignements personnels, au sens de l’article 3 de la <a "
+"href='https://www.priv.gc.ca/fr/sujets-lies-a-la-protection-de-la-vie-"
+"privee/lois-sur-la-protection-des-renseignements-personnels-au-canada/la-"
+"loi-sur-la-protection-des-renseignements-personnels/'><u>Loi sur la "
+"protection des renseignements personnels</u></a>, à moins que la personne"
+" concernée n’ait consenti à leur divulgation ou que les renseignements "
+"personnels ne répondent aux critères énoncés au paragraphe 8(2) de cette "
+"même Loi.</li><li><b>Langues officielles</b> - Les ressources en données "
+"ou documentaires sont disponibles dans les deux langues officielles et "
+"sont conformes aux exigences de la <a href='https://laws-"
+"lois.justice.gc.ca/fra/lois/O-3.01/'><u>Loi sur les langues "
+"officielles</u></a>.</li><li><b>Sécurité</b> - Les ressources en données "
+"ou documentaires n’augmentent pas les risques à la sécurité de "
+"l’institution, des autres institutions ou du gouvernement dans son "
+"ensemble et sont conformes aux exigences de la <a href='https://www.tbs-"
+"sct.gc.ca/pol/doc-fra.aspx?id=16578'><u>Politique sur la sécurité du "
+"gouvernement</u></a> et de ses instruments connexes.</li><li><b>Autres – "
+"Aspects juridiques, réglementaires, stratégiques ou contractuelsl</b> - "
+"La diffusion des ressources en données ou d’autres ressources "
+"documentaires est conforme à toutes les autres exigences juridiques, "
+"réglementaires, contractuelles et stratégiques pertinentes (p. ex., il "
+"est confirmé qu’il n’y a pas de restrictions ou de limitations "
+"juridiques, contractuelles, de tiers ou de stratégiques "
+"pertinentes).</li></ol></small>"
+
+#: ckanext/canada/templates/internal/scheming/form_snippets/repeating_subfields.html:8
+#: ckanext/canada/templates/public/macros/canada_read.html:151
+#: ckanext/canada/templates/public/macros/form.html:248
+msgid "Remove"
+msgstr "Supprimer"
+
+#: ckanext/canada/templates/internal/scheming/form_snippets/repeating_subfields.html:17
+msgid "Add"
+msgstr ""
+
+#: ckanext/canada/templates/internal/scheming/form_snippets/upload_only.html:7
+#: ckanext/canada/templates/public/macros/form.html:413
+msgid "http://example.com/my-image.jpg"
+msgstr ""
+
+#: ckanext/canada/templates/internal/scheming/form_snippets/upload_only.html:8
+#: ckanext/canada/templates/public/macros/form.html:414
+msgid "Image URL"
+msgstr ""
+
+#: ckanext/canada/templates/internal/scheming/form_snippets/upload_only.html:9
+#: ckanext/canada/templates/public/macros/form.html:415
+msgid "Image"
+msgstr ""
+
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:14
 msgid "Catalogue Metadata"
 msgstr "Métadonnées de catalogue"
 
-msgid ""
-"This section of the form only displays system-populated data elements used "
-"to describe the record type and the placement in the registry"
-msgstr ""
-"Cette section du formulaire n'affiche que les éléments de données alimentés "
-"par le système utilisés pour décrire le type et l'emplacement du dossier "
-"dans le registre"
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:17
+msgid "Open Information Metadata Element Set"
+msgstr "Ensemble d’éléments de métadonnées d’information ouverte"
 
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:19
+msgid "Open Data Metadata Element Set"
+msgstr "Ensemble d’éléments de métadonnées de données ouvertes"
+
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:23
+msgid ""
+"This section of the form only displays system-populated data elements "
+"used to describe the record type and the placement in the registry"
+msgstr ""
+"Cette section du formulaire n'affiche que les éléments de données "
+"alimentés par le système utilisés pour décrire le type et l'emplacement "
+"du dossier dans le registre"
+
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:34
+#: ckanext/canada/templates/public/snippets/package_item.html:14
+msgid "Suggested Dataset"
+msgstr "Jeu de données suggéré"
+
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:37
 msgid ""
 "The portal to which the metadata record belongs (Open Data or Open "
 "Information)"
@@ -1581,711 +1216,460 @@ msgstr ""
 "Portail auquel le dossier de métadonnées appartient (Données ouvertes ou "
 "Information ouverte)"
 
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:40
 msgid "Metadata Scheme"
 msgstr "Schéma de métadonnée"
 
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:43
 msgid "The name of the metadata scheme used (including profile name)"
-msgstr ""
-"Nom anglais du schéma de métadonnées utilisé (y compris le nom du profil)"
+msgstr "Nom anglais du schéma de métadonnées utilisé (y compris le nom du profil)"
 
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:46
 msgid "Metadata Scheme Version"
 msgstr "Version du schéma de métadonnées"
 
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:49
 msgid "The version of the metadata scheme used (version of the profile)"
 msgstr "Version du schéma de métadonnées utilisé (version du profil)"
 
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:52
 msgid "Metadata Record Identifier"
 msgstr "Identificateur du dossier de métadonnées"
 
+#: ckanext/canada/templates/internal/scheming/package/snippets/package_form.html:55
 msgid ""
-"A unique phrase or string which identifies the metadata record within the "
-"Open Government Portal"
+"A unique phrase or string which identifies the metadata record within the"
+" Open Government Portal"
 msgstr ""
 "Expression ou chaîne unique désignant le dossier de métadonnées dans le "
 "Portail du gouvernement ouvert"
 
-msgid "Add Dataset Metadata"
-msgstr "Ajouter les métadonnées du jeu de données"
-
+#: ckanext/canada/templates/internal/scheming/package/snippets/resource_form.html:17
 msgid ""
-"You can add either a Resource or a Related Item per session, i.e. not both:"
+"You can add either a Resource or a Related Item per session, i.e. not "
+"both:"
 msgstr ""
-"Vous pouvez ajouter une ressource ou un article connexe par séance, mais pas "
-"les deux:"
+"Vous pouvez ajouter une ressource ou un article connexe par séance, mais "
+"pas les deux:"
 
+#: ckanext/canada/templates/internal/scheming/package/snippets/resource_form.html:24
 msgid "Metadata Fields for Resources Only (Not for Related Items)"
 msgstr ""
-"Champs de métadonnées pour les ressources seulement (non pour les éléments "
-"connexes)"
+"Champs de métadonnées pour les ressources seulement (non pour les "
+"éléments connexes)"
 
+#: ckanext/canada/templates/internal/scheming/package/snippets/resource_form.html:40
 msgid "Metadata Fields for Related Items Only"
 msgstr "Champs de métadonnées pour les éléments connexes seulement"
 
+#: ckanext/canada/templates/internal/scheming/package/snippets/resource_form.html:51
 msgid "Use the Download URL field above to link to the related record."
 msgstr ""
-"Utilisez le champ URL de téléchargement ci-dessus pour créer un lien vers le "
-"dossier connexe."
+"Utilisez le champ URL de téléchargement ci-dessus pour créer un lien vers"
+" le dossier connexe."
 
-msgid "Open Data Metadata Element Set"
-msgstr "Ensemble d’éléments de métadonnées de données ouvertes"
+#: ckanext/canada/templates/internal/scheming/package/snippets/resource_form.html:60
+msgid "Data Validation"
+msgstr "Validation des données"
 
-msgid "Open Information Metadata Element Set"
-msgstr "Ensemble d’éléments de métadonnées d’information ouverte"
+#: ckanext/canada/templates/internal/scheming/snippets/errors.html:5
+msgid "Errors in form"
+msgstr "Erreurs dans le formulaire"
 
-#: ckan/controllers/user.py:383
-msgid "Login failed. Bad username or password."
+#: ckanext/canada/templates/internal/scheming/snippets/form_field.html:4
+msgid "Are you sure you want to delete this status?"
+msgstr "Êtes-vous certain de vouloir supprimer cet état?"
+
+#: ckanext/canada/templates/internal/scheming/snippets/form_field.html:21
+#: ckanext/canada/templates/public/organization/member_new.html:62
+#: ckanext/canada/templates/public/scheming/package/read.html:26
+msgid "Delete"
 msgstr ""
-"L'authentification a échoué. Mauvais nom d'utilisateur ou mot de passe."
 
-#: ckan/templates/organization/new_organization_form.html:19
-msgid "Create Organization"
-msgstr "Créer l'orgaisation"
+#: ckanext/canada/templates/internal/snippets/dataset_facets.html:24
+#: ckanext/canada/templates/public/macros/canada_read.html:190
+#: ckanext/canada/templates/public/snippets/package_item.html:101
+msgid "Request sent to data owner – awaiting response"
+msgstr "Demande envoyée au propriétaire des données, en attente de réponse"
 
-#: ckan/templates/package/search.html:60
+#: ckanext/canada/templates/internal/snippets/home_breadcrumb_item.html:2
+msgid "Registry Home"
+msgstr "Accueil du registre"
+
+#: ckanext/canada/templates/internal/snippets/publish_facet.html:22
+msgid "Published"
+msgstr "Publié"
+
+#: ckanext/canada/templates/internal/snippets/publish_facet.html:33
+msgid "Scheduled"
+msgstr ""
+
+#: ckanext/canada/templates/internal/snippets/publish_facet.html:40
+msgid "Pending"
+msgstr "En attente"
+
+#: ckanext/canada/templates/internal/snippets/publish_facet.html:40
+#: ckanext/canada/templates/public/package/read.html:12
+msgid "Draft"
+msgstr "Ébauche"
+
+#: ckanext/canada/templates/internal/snippets/publish_facet.html:56
+#: ckanext/canada/templates/public/snippets/facet_list.html:67
+msgid "There are no filters for this search"
+msgstr "Aucun filtre sélectionné pour cette recherche"
+
+#: ckanext/canada/templates/internal/snippets/social.html:7
+#: ckanext/canada/templates/public/snippets/social.html:7
+#, fuzzy
+msgid "Social"
+msgstr "Provinciale"
+
+#: ckanext/canada/templates/internal/snippets/user.html:12
+#: ckanext/canada/templates/public/snippets/user.html:21
+msgid "Sysadmin settings"
+msgstr ""
+
+#: ckanext/canada/templates/internal/snippets/user.html:20
+#: ckanext/canada/templates/public/snippets/user.html:29
 #, python-format
-msgid ""
-" You can also access this registry using the %(api_link)s (see "
-"%(api_doc_link)s). "
+msgid "Dashboard (%(num)d new item)"
+msgid_plural "Dashboard (%(num)d new items)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ckanext/canada/templates/internal/snippets/user.html:23
+#: ckanext/canada/templates/public/snippets/user.html:32
+msgid "Dashboard"
 msgstr ""
-" Vous pouvez également accéder à ce catalogue en utilisant %(api_link)s "
-"(voir documentation de l’API %(api_doc_link)s)"
 
-msgid "Relationship"
-msgstr "Type de relation"
-
-msgid "Powered by"
-msgstr "Réalisé avec"
-
-msgid ""
-"Once an account is created you will receive an email confirming your "
-"request. Next, the Administrator will link your account to your Organization "
-"and send you a notification. At this point, you can start adding records to "
-"the Registry."
+#: ckanext/canada/templates/internal/snippets/user.html:24
+#: ckanext/canada/templates/public/snippets/user.html:33
+msgid ": "
 msgstr ""
-"Une fois le compte créé, vous recevrez un courriel qui confirmera votre "
-"demande. Par la suite, l'administrateur établira un lien entre votre compte "
-"et votre organisation et vous fera parvenir un avis. Vous pourrez alors "
-"commencer à ajouter des dossiers dans le registre."
 
+#: ckanext/canada/templates/internal/snippets/user.html:30
+#: ckanext/canada/templates/internal/snippets/user.html:32
+#: ckanext/canada/templates/public/snippets/user.html:39
+#: ckanext/canada/templates/public/snippets/user.html:41
+msgid "Edit Profile"
+msgstr "Modifier le profil"
+
+#: ckanext/canada/templates/internal/snippets/user.html:39
+msgid "Help using the Open Government Registry"
+msgstr "Aide à l'utilisation du registre du gouvernement ouvert"
+
+#: ckanext/canada/templates/internal/snippets/user.html:40
+#: ckanext/canada/templates/internal/snippets/user.html:43
+msgid "Get Help"
+msgstr "Obtenez de l’aide"
+
+#: ckanext/canada/templates/internal/snippets/activities/changed_datastore.html:6
+msgid "{actor} updated the record {datastore} {datastore_detail}"
+msgstr "{actor} a mis à jour le dossier {datastore} {datastore_detail}"
+
+#: ckanext/canada/templates/internal/snippets/activities/deleted_datastore.html:6
+msgid "{actor} deleted the record {datastore} {datastore_detail}"
+msgstr "{actor} a supprimé le jeu de données {datastore} {datastore_detail}"
+
+#: ckanext/canada/templates/internal/user/list.html:26
+msgid "Create an Account"
+msgstr "Créer un compte"
+
+#: ckanext/canada/templates/internal/user/list.html:35
+#: ckanext/canada/templates/internal/user/new_user_form.html:7
+#: ckanext/canada/templates/internal/user/snippets/login_form.html:15
+#: ckanext/canada/templates/public/organization/member_new.html:29
+#: ckanext/canada/templates/public/user/edit_user_form.html:9
+#: ckanext/canada/templates/public/user/read_base.html:43
+#: ckanext/canada/templates/public/user/snippets/login_form.html:13
+msgid "Username"
+msgstr ""
+
+#: ckanext/canada/templates/internal/user/list.html:36
+#: ckanext/canada/templates/public/snippets/geomap_dynamic.html:18
+#: ckanext/canada/templates/public/snippets/geomap_static.html:15
+msgid "Name"
+msgstr "Nom"
+
+#: ckanext/canada/templates/internal/user/list.html:37
+#: ckanext/canada/templates/public/organization/member_new.html:59
+#, fuzzy
+msgid "Role"
+msgstr "Explorer"
+
+#: ckanext/canada/templates/internal/user/list.html:52
+msgid "Sysadmin"
+msgstr ""
+
+#: ckanext/canada/templates/internal/user/list.html:52
+#, fuzzy
+msgid "Member"
+msgstr "{0} membre"
+
+#: ckanext/canada/templates/internal/user/list.html:78
+msgid "Search and view users."
+msgstr "Rechercher et afficher les utilisateurs."
+
+#: ckanext/canada/templates/internal/user/list.html:80
+msgid "Search and manage users."
+msgstr "Rechercher et gérer les utilisateurs."
+
+#: ckanext/canada/templates/internal/user/login.html:9
+msgid "Need an account"
+msgstr "Besoin d’un compte"
+
+#: ckanext/canada/templates/internal/user/login.html:11
+msgid "Then sign right up, it only takes a minute"
+msgstr "Inscrivez-vous maintenant, cela ne prend qu’une minute"
+
+#: ckanext/canada/templates/internal/user/login.html:13
+#: ckanext/canada/templates/internal/user/new.html:3
+msgid "Request an Account"
+msgstr "Demande d'un compte"
+
+#: ckanext/canada/templates/internal/user/login.html:20
+msgid "Forgotten your password?"
+msgstr "Réinitialiser le mot de passe"
+
+#: ckanext/canada/templates/internal/user/login.html:22
+msgid "No problem, use our password recovery form to reset it"
+msgstr ""
+"Utilisez notre formulaire de récupération de mot de passe pour rétablir "
+"votre identité"
+
+#: ckanext/canada/templates/internal/user/login.html:24
+msgid "Reset password"
+msgstr "Réinitialiser le mot de passe"
+
+#: ckanext/canada/templates/internal/user/login.html:32
+msgid "login welcome text"
+msgstr ""
+"<h2>Bienvenue au registre du gouvernement ouvert</h2><p>Utilisez le "
+"registre pour publier des ressources gouvernementales dans le <a "
+"href='http://ouvert.canada.ca/fr'>Portail du gouvernement ouvert</a>.<br "
+"/>Pour obtenir de plus amples renseignements sur l'utilisation du "
+"registre ou pour signaler des erreurs, communiquez avec open-ouvert@tbs-"
+"sct.gc.ca. </p>"
+
+#: ckanext/canada/templates/internal/user/login.html:39
+msgid "NOTE: Username and password are case sensitive."
+msgstr "NOTE: Le nom d'utilisateur et mot de passe sont sensibles à la casse."
+
+#: ckanext/canada/templates/internal/user/new.html:6
+#, fuzzy
+msgid "Registration"
+msgstr "Organisation"
+
+#: ckanext/canada/templates/internal/user/new.html:18
+msgid "Why Sign Up?"
+msgstr ""
+
+#: ckanext/canada/templates/internal/user/new.html:20
 msgid ""
-"An active account linked to your organization is required in order to create "
-"or modify records in the registry."
+"An active account linked to your organization is required in order to "
+"create or modify records in the registry."
 msgstr ""
 "Un compte actif et lié à votre organisation est requis pour créer ou "
 "modifier des dossiers dans le registre."
 
-msgid "Quick Links"
-msgstr "Liens rapides"
+#: ckanext/canada/templates/internal/user/new.html:24
+msgid "Next Step..."
+msgstr "Prochaine étape..."
 
+#: ckanext/canada/templates/internal/user/new.html:26
 msgid ""
-"Welcome to the Open Government Registry. Use the Registry to add government "
-"resources that will be published on the Open Government Portal. For more "
-"information on using the Registry or to report errors, contact <a href="
-"\"mailto:open-ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a>."
+"Once an account is created you will receive an email confirming your "
+"request. Next, the Administrator will link your account to your "
+"Organization and send you a notification. At this point, you can start "
+"adding records to the Registry."
 msgstr ""
-"Bienvenue au Registre du gouvernement ouvert. Utilisez le registre pour "
-"ajouter des ressources gouvernementales qui seront publiées dans le Portail "
-"du gouvernement ouvert. Pour obtenir de plus amples renseignements sur "
-"l'utilisation du registre ou pour signaler des erreurs, communiquez avec <a "
-"href=\"mailto:open-ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a>."
+"Une fois le compte créé, vous recevrez un courriel qui confirmera votre "
+"demande. Par la suite, l'administrateur établira un lien entre votre "
+"compte et votre organisation et vous fera parvenir un avis. Vous pourrez "
+"alors commencer à ajouter des dossiers dans le registre."
 
-msgid ""
-"Add data about Government of Canada services, financials or national "
-"demographic information that is relevant to Canadians."
-msgstr ""
-"Ajouter des données sur les services du gouvernement du Canada, des données "
-"financières ou de l'information démographique nationale qui sont pertinentes "
-"pour les Canadiens."
-
-msgid "Add information about government programs, activities and publications."
-msgstr ""
-"Ajouter de l'information sur les programmes, activités et publications du "
-"gouvernement."
-
-msgid ""
-"Access, upload and modify the monthly ATI Summaries and ATI Nothing to "
-"Report for your organization"
-msgstr ""
-"Accès, téléversement et modification des rapports mensuels sur les accès à "
-"l'information sommaires et les accès à l'information rien a signaler"
-
-msgid "Open Data Records"
-msgstr "Dossiers de données ouvertes"
-
-msgid "Open Information Records"
-msgstr "Dossiers d’information ouverte"
-
-msgid "Search your Organization Records"
-msgstr "Faire une recherche dans les dossiers de votre organisation"
-
-msgid "Search All Records"
-msgstr "Faire une recherche dans tous les dossiers"
-
-msgid "View Members of your Organization"
-msgstr "Voir les members liés à votre organisation"
-
-msgid "Search all records in the Registry, for your Organization."
-msgstr ""
-"Faire une recherche dans tous les dossiers du registre, pour votre "
-"organisation."
-
-msgid "Add all Open Data and Information records in the Registry."
-msgstr "Faire une recherche dans tous les dossiers du registre."
-
-msgid "View the list of members linked to your organization."
-msgstr "Voir la liste des membres liés à votre organisation"
-
-msgid ""
-"For information on how to prepare, maintain and upload templates to the "
-"Registry, refer to the appropriate documentation posted on <a href="
-"\"%(gclink)s\">GCPEDIA</a>"
-msgstr ""
-"Pour obtenir des renseignements sur la façon de préparer, de tenir à jour et "
-"de verser des modèles de données pour le registre, consultez la "
-"documentation appropriée qui est publiée dans <a href='%(gclink)s'>Gcpédia</"
-"a>"
-
-msgid "http://www.gcpedia.gc.ca/wiki/Proactive_Disclosure_on_Open.Canada.ca"
-msgstr ""
-"http://www.gcpedia.gc.ca/wiki/Divulgation_proactive_dans_ouvert.canada.ca"
-
-msgid "Edit Profile"
-msgstr "Modifier le profil"
-
-msgid "My Profile"
-msgstr "Mes paramètres"
-
-msgid "Edit User"
-msgstr "Modifier l'utilisateur"
-
-msgid "Edit Members"
-msgstr "Modifier les membres"
-
-msgid "{0} members"
-msgstr "{0} membres"
-
-msgid "{0} member"
-msgstr "{0} membre"
-
-msgid "Frequently Asked Questions (FAQ)"
-msgstr "Foire aux questions"
-
-#: ckan/controllers/user.py:455
-msgid "Please check your inbox for a reset code."
-msgstr ""
-"S.V.P. consulter votre boîte à lettres électronique pour confirmer votre "
-"demande de réinitialisation."
-
-msgid "Column visibility"
-msgstr "Visibilité des colonnes"
-
-msgid "Create"
-msgstr "Créer"
-
-msgid "Go back"
-msgstr "Retourner"
-
-msgid "Record Status"
-msgstr "État du dossier"
-
-msgid "Pending"
-msgstr "En attente"
-
-msgid "Published"
-msgstr "Publié"
-
-msgid "FGP Metadata"
-msgstr "Métadonnées de la PGF"
-
-msgid "Data Contact"
-msgstr "Personne-ressource responsable des données"
-
-msgid "Distributor Contact"
-msgstr "Personne-ressource responsable de la distribution"
-
-msgid "Organization Name"
-msgstr "Nom de l'organisation"
-
-msgid "Telephone Number"
-msgstr "Numéro de téléphone"
-
-msgid "Address"
-msgstr "Adresse"
-
-msgid "entries"
-msgstr "entrées"
-
-msgid "login welcome text"
-msgstr ""
-"<h2>Bienvenue au registre du gouvernement ouvert</h2><p>Utilisez le registre "
-"pour publier des ressources gouvernementales dans le <a href='http://ouvert."
-"canada.ca/fr'>Portail du gouvernement ouvert</a>.<br />Pour obtenir de plus "
-"amples renseignements sur l'utilisation du registre ou pour signaler des "
-"erreurs, communiquez avec open-ouvert@tbs-sct.gc.ca. </p>"
-
-msgid "NOTE: Username and password are case sensitive."
-msgstr "NOTE: Le nom d'utilisateur et mot de passe sont sensibles à la casse."
-
+#: ckanext/canada/templates/internal/user/new_user_form.html:5
 msgid "Please fill out this field."
 msgstr "Ce champ est obligatoire."
 
-msgid "Please enter a valid email address."
-msgstr "S\\'il vous plaît, mettez une adresse email valide."
-
-msgid "Created On"
-msgstr "Date de création"
-
-msgid "Return to Index"
-msgstr "Retourner à la page de recherche"
-
-msgid "This record has been removed from %s."
-msgstr "Ce dossier a été supprimé de %s."
-
-msgid "Dataset Deleted"
-msgstr "Dossier supprimé"
-
-msgid "Government of Canada Open Government Portal"
-msgstr "Gouvernement du Canada site gouvernemental ouvert"
-
+#: ckanext/canada/templates/internal/user/new_user_form.html:8
 msgid ""
-"This catalog contains metadata records describing open datasets available "
-"from the Government of Canada"
+"Use only lowercase letters (a-z) and numbers (0-9) with optional hyphens "
+"(-) and underscores (_). Example: joe-bloggs"
 msgstr ""
-"Ce catalogue contient des enregistrements de métadonnées décrivant des "
-"ensembles de données ouverts disponibles auprès du gouvernement du Canada"
+"N’employer que des lettres minuscules (a-z) et des chiffres (0-9) et, "
+"facultativement, des traits d’union (-) et des traits de soulignement "
+"(_). Exemplar : joe-bloggs"
 
-msgid "Government of Canada, Treasury Board of Canada Secretariat"
-msgstr "Gouvernement du Canada, Secrétariat du Conseil du Trésor du Canada"
+#: ckanext/canada/templates/internal/user/new_user_form.html:10
+#, fuzzy
+msgid "Full Name"
+msgstr "Aucun nom complet fourni"
 
-msgid "Treasury Board of Canada Secretariat"
-msgstr "Secrétariat du Conseil du Trésor du Canada"
+#: ckanext/canada/templates/internal/user/new_user_form.html:11
+msgid "Example: Joe Bloggs"
+msgstr "Exemplar : Joe Bloggs"
 
-msgid "Information and Communications Government and Politics"
-msgstr "Information et communications Gouvernement et politique"
+#: ckanext/canada/templates/internal/user/new_user_form.html:13
+#: ckanext/canada/templates/public/user/edit_user_form.html:13
+#: ckanext/canada/templates/public/user/read_base.html:50
+msgid "Email"
+msgstr "Courriel"
 
+#: ckanext/canada/templates/internal/user/new_user_form.html:14
+msgid "Example: joe.bloggs@tbs-sct.gc.ca"
+msgstr "Exemplar : joe.bloggs@tbs-sct.gc.ca"
+
+#: ckanext/canada/templates/internal/user/new_user_form.html:19
+msgid "Phone Number"
+msgstr "Numéro de téléphone"
+
+#: ckanext/canada/templates/internal/user/new_user_form.html:20
+msgid "Example: 000 000 0000"
+msgstr "Exemplar : 000 000 0000"
+
+#: ckanext/canada/templates/internal/user/new_user_form.html:22
+#: ckanext/canada/templates/internal/user/snippets/login_form.html:17
+#: ckanext/canada/templates/public/user/edit_user_form.html:32
+#: ckanext/canada/templates/public/user/snippets/login_form.html:15
+#, fuzzy
+msgid "Password"
+msgstr "Réinitialiser le mot de passe"
+
+#: ckanext/canada/templates/internal/user/new_user_form.html:23
+msgid "Confirm"
+msgstr ""
+
+#: ckanext/canada/templates/internal/user/new_user_form.html:26
+#, fuzzy
 msgid ""
-"Rights under which the catalog can be reused are outlined in the Open "
-"Government Licence - Canada"
-msgstr ""
-"Les droits sous lesquels le catalogue peut être réutilisé sont décrits dans "
-"la Licence du gouvernement ouvert - Canada"
-
-msgid "Open Maps Data Viewer"
-msgstr "Visualisateur de données de Cartes ouvertes"
-
-msgid "Open Dialogue"
-msgstr "Dialogue ouvert"
-
-msgid "Consultations"
-msgstr "Consultations"
-
-msgid "Open Dialogue - Consultations"
-msgstr "Dialogue ouvert - Consultations"
-
-msgid ""
-"Access, upload and modify consultation reports for your organization\n"
-"\n"
-"- [Consultations master dataset](/static/data/consultations.csv)\n"
-"  This dataset consolidates all the consultations reports submitted by "
-"federal institutions.\n"
-msgstr ""
-"Accès, téléversement et modifications des rapports sur les consultations "
-"pour votre organisation\n"
-"\n"
-"- [Données de consultations principales](/static/data/consultations.csv)\n"
-"  Cette base de données regroupe tous les rapports de consultations soumis "
-"par les institutions fédérales\n"
-
-msgid "Service Inventory"
-msgstr "Répertoire de services"
-
-msgid ""
-"Access, upload and modify the Service Inventory of external and internal "
-"enterprise services for your organization"
-msgstr ""
-"Accèder, téléverser et modifier le catalogue des service internes intégrés "
-"et externes pour votre organisation"
-
-msgid "Service Identification Information & Metrics"
-msgstr "Renseignements sur l’identification des services, données volumétrique"
-
-msgid "Service Standards & Performance Results"
-msgstr "Normes relatives aux services et résultats de rendement"
-
-msgid "Mandatory"
-msgstr "Obligatoire"
-
-msgid "Optional"
-msgstr "Facultatif"
-
-msgid "Free text"
-msgstr "Texte libre"
-
-msgid "Free text (comma separated list of codes from reference table)"
-msgstr ""
-"Texte libre (liste des codes de la table de référence, séparées par des "
-"virgules)"
-
-msgid "Free Text (separate paragraphs with two blank lines)"
-msgstr "Texte libre (Séparez les paragraphes par deux lignes vides)"
-
-msgid "Date (Please format the data as YYYY-MM-DD)"
-msgstr "Date (format suivant: AAAA-MM-JJ)"
-
-msgid "Web address"
-msgstr "Adresse Web"
-
-msgid "This field must not be empty"
-msgstr "Cette zone ne doit pas être vide"
-
-msgid "This field must be empty"
-msgstr "Cette zone doit être vide"
-
-msgid "Controlled List"
-msgstr "Liste contrôlée"
-
-msgid "Single"
-msgstr "Une seule"
-
-msgid "Repeatable"
-msgstr "Plusieurs"
-
-msgid "Sheet {0} Row {1}:"
-msgstr "Feuille {0} rangée {1}:"
-
-msgid "invalid input syntax for type boolean"
-msgstr "Syntaxe d’entrée non valide pour ce type de recherche booléenne"
-
-msgid "invalid input syntax for type date"
-msgstr "Syntaxe d’entrée non valide pour le type de date"
-
-msgid "Invalid choice for"
-msgstr "Choix non valide pour"
-
-msgid "Record Creation Time"
-msgstr "Heure de la création du dossier"
-
-msgid "Last Record Modification Time"
-msgstr "Heure de la dernière modification au dossier"
-
-msgid "User Last Modified Record"
-msgstr "Utilisateur de la dernière modification au dossier"
-
-msgid "time_ascend"
-msgstr "Les plus anciens d’abord"
-
-msgid "time_descend"
-msgstr "Les plus récents d’abord"
-
-msgid "View this version"
-msgstr "Voir cette version"
-
-msgid "A system administrator"
-msgstr "Un administrateur du système"
-
-msgid "Open by Default Portal"
-msgstr "Portail « Ouvert par défaut »"
-
-msgid ""
-"Open by Default provides access to working documents used by the Government "
-"of Canada. Most of this information is unpublished. Documents may be in "
-"draft form, and are generally available in the language in which they were "
-"created. Unless otherwise indicated, information is made available under the "
-"<a href=\"http://open.canada.ca/en/open-government-licence-canada\">Open "
-"Government Licence</a>. To obtain documents in the official language of your "
-"choice, or in an accessible format, please <a href=\"http://open.canada.ca/"
-"en/forms/contact-us\">contact us</a>."
-msgstr ""
-"L’initiative « Ouvert par défaut » donne accès aux documents de travail "
-"utilisés par le gouvernement du Canada. La plupart de ces renseignements ne "
-"sont pas publiés. Les documents peuvent être sous la forme d’ébauche et sont "
-"en général disponibles dans la langue dans laquelle ils ont été créés. À "
-"moins d’indication contraire, les renseignements sont disponibles en vertu "
-"de la <a href=\"http://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-"
-"canada\">licence du gouvernement ouvert</a>. Afin d’obtenir les documents "
-"dans la langue officielle de votre choix ou dans un format accessible, "
-"veuillez <a href=\"http://ouvert.canada.ca/fr/formulaire/faites-nous-part-de-"
-"vos-commentaires\">communiquer avec nous</a>."
-
-msgid "Dear %(user_name)s,"
-msgstr "Cher %(user_name)s,"
-
-msgid ""
-"You have requested your password on %(site_title)s to be reset.\n"
-"\n"
-"Please click the following link to confirm this request:\n"
-"\n"
-"   %(reset_link)s"
-msgstr ""
-"Vous avez demandé la réinitialisation de votre mot de passe sur le site "
-"%(site_title)s.\n"
-"\n"
-"Merci de cliquer sur le lien suivant pour confirmer votre requête :\n"
-"%(reset_link)s"
-
-msgid "Invite for %(site_title)s"
-msgstr "Invitation pour %(site_title)s"
-
-msgid ""
-"You have been invited to %(site_title)s.\n"
-"\n"
-"A user has already been created to you with the username %(user_name)s. You "
-"can change it later.\n"
-"\n"
-"To accept this invite, please reset your password at:\n"
-"\n"
-"   %(reset_link)s\n"
-msgstr ""
-"Vous avez été invité sur %(site_title)s.\n"
-"\n"
-"Un utilisateur a déjà été créé pour vous avec l'identifiant %(user_name)s. "
-"Vous pourrez le changer ultérieurement.\n"
-"\n"
-"Pour accepter cette invitation, veuillez réinitialiser votre mot de passe "
-"via :\n"
-"%(reset_link)s\n"
-
-msgid "Have a nice day."
-msgstr "Bonne journée."
-
-msgid "Message sent by %(site_title)s (%(site_url)s)"
-msgstr "Message envoyé par %(site_title)s (%(site_url)s)"
-
-msgid ""
-"Your password must be {} characters or longer, contain no accented "
-"characters and consist of at least three of the following character sets: "
-"uppercase characters, lowercase characters, digits, punctuation & special "
-"characters."
-msgstr ""
-"Les mots de passe doivent contenir des caractères provenant d’au moins trois "
-"des quatre catégories suivantes: lettres majuscules, lettres minuscules, "
-"chiffres arabes, caractères spéciaux. Les lettres accentuées ne sont pas "
-"acceptées. Tous les mots de passe doivent compter au moins {} caractères."
-
-msgid ""
-"1. Passwords must contain characters from at least 3 of the following 4 "
-"classes:\n"
-"    * Upper Case Letters: A, B, C, … Z\n"
-"    * Lower Case Letters: a, b, c, … z\n"
-"    * Westernised Arabic Numerals: 0, 1, 2, … 9\n"
-"    * Special characters: ({}[],.<>;:'\"?/|\\`~!@#$%^&*()_-+=).\n"
-"2. No accented characters are permitted.\n"
-"3. All passwords must be at least 8 characters long.\n"
-msgstr ""
-"1. Les mots de passe doivent contenir des caractères provenant d’au moins "
-"trois des quatre catégories suivantes :\n"
-"    * Lettres majuscules :A, B, C, … Z\n"
-"    * Lettres minuscules : a, b, c, … z\n"
-"    * Chiffres arabes :0, 1, 2, … 9\n"
-"    * Caractères spéciaux : ({}[],.<>;:'\"?/|\\`~!@#$%^&*()_-+=).\n"
-"2. Les lettres accentuées ne sont pas acceptées.\n"
-"3. Tous les mots de passe doivent compter au moins huit caractères.\n"
-
-msgid ""
-"We will be completing technical work on open.canada.ca, which may create "
-"content and performance issues. If you experience any issues please notify "
-"<a href=\"mailto:open-ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a>"
-msgstr ""
-"Nous effectuerons des travaux techniques sur le site ouvert.canada.ca qui "
-"pourraient entraîner des problèmes de contenu et de performance. Si vous "
-"éprouvez des problèmes, veuillez en aviser <a href=\"mailto:open-ouvert@tbs-"
-"sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a>"
-
-msgid ""
-"If you would like to request an account for the Open Government Registry, "
-"please email <a href=\"mailto:open-ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-"
-"sct.gc.ca</a> with your name, department and email"
-msgstr ""
-"Si vous souhaitez demander un compte pour le Répertoire du gouvernement "
-"ouvert, veuillez envoyer un courriel à <a href=\"mailto:open-ouvert@tbs-sct."
-"gc.ca\">open-ouvert@tbs-sct.gc.ca</a> avec votre nom, ministère et adresse "
-"courriel."
-
-msgid "Request an account"
-msgstr "Demande d'un compte"
-
-msgid "Request an Account"
-msgstr "Demande d'un compte"
-
-msgid ""
-"We encountered an error and are unable to serve your request. Please try "
-"again in short time or contact <a href=\"mailto:open-ouvert@tbs-sct.gc.ca"
-"\">open-ouvert@tbs-sct.gc.ca</a> if you need immediate assistance or if this "
-"issue persists. Note that your login expires after 1 hour of inactivity."
-msgstr ""
-"Nous rencontrons une erreur et nous ne pouvons pas répondre à votre demande. "
-"Veuillez réessayer plus tard ou communiquer avec <a href=\"mailto:open-"
-"ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a> si votre demande est "
-"urgente ou si ce problème persiste. Veuillez noter que votre connexion "
-"expire après une heure d'inactivité."
-
-msgid "We encountered an error"
-msgstr "Nous rencontrons une erreur"
-
-msgid ""
-"Note: Only records belonging to your organizations are now visible on the "
-"Registry. Please use the portal to access published records from all "
-"organizations. If you need to see draft records or create or update records "
-"for other organizations, please send a request and justification to <a href="
-"\"mailto:open-ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a>"
-msgstr ""
-"Nota : Seuls les enregistrements appartenant à vos organisations sont "
-"désormais visibles dans le Répertoire. Veuillez vous servir du portail pour "
-"accéder aux documents publiés par toutes les organisations. Si vous avez "
-"besoin de consulter des ébauches d’enregistrements ou de créer des "
-"enregistrements pour d’autres organisations ou en effectuer la mise à jour, "
-"veuillez envoyer une demande et une justification à <a href=\"mailto:open-"
-"ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a>"
-
-msgid "Numeric only"
-msgstr "Valeur numérique seulement"
-
-msgid ""
-"\n"
-"    <h2>Terms and Conditions for the Open Government Registry</h2>\n"
-"    <p><em>Privacy Statement</em></p>\n"
-"    <p>The Government of Canada is committed to providing measures that "
-"respect and value your privacy and security. This page summarizes the "
-"privacy policy and practices that apply to your Open Government Registry "
-"Account Credentials.</p>\n"
-"    <p>The purpose for collecting and using “Username, Password and Email” "
-"is to issue, manage and validate anonymous credentials of individuals "
-"accessing and/or communicating with Government of Canada systems and "
-"applications.</p>\n"
-"    <p>The personal information may be used to establish audit trails of "
-"credential usage. In the case of suspected security or privacy breaches, "
-"personal information may be shared with departmental security and access to "
-"information and privacy officials, as well as the federal government "
-"department or agency which collects and uses the personal information "
-"considered to have been compromised (refer to Standard PIB Security "
-"Incidents - PSU 939). For suspected criminal activity, personal information "
-"may also be disclosed to the Royal Canadian Mounted Police for "
-"investigational purposes; refer to institution-specific PIB Operational Case "
-"Records - RCMP PPU 005.</p>\n"
-"    <p>We employ software programs to monitor network traffic to identify "
-"unauthorized attempts to upload or change information, or otherwise cause "
-"damage. This software receives and records the Internet Protocol (IP) "
-"address of the computer that has contacted our websites, the date and time "
-"of the visit and the pages visited. We make no attempt to link these "
-"addresses with the identity of individuals visiting our sites unless an "
-"attempt to damage the sites has been detected.</p>\n"
-"    <p>Questions, concerns and complaints regarding this notice, or the "
-"administration of the Privacy Act in connection with your GCKey may be "
-"directed to the Access to Information and Privacy Protection Division by "
-"email to <a href=\"mailto:ATIP-AIPRP@ssc-spc.gc.ca\">ATIP-AIPRP@ssc-spc.gc."
-"ca</a>, or by writing to the following address:</p>\n"
-"    <p>Access to Information and Privacy Directorate<br/>\n"
-"    Corporate Secretariat<br/>\n"
-"    Shared Services Canada<br/>\n"
-"    PO Box 9808, STN T, CSC<br/>\n"
-"    Ottawa ON K1G 4A8</p>\n"
-"    <p>For more information on privacy issues and the <em>Privacy Act</em> "
-"in general, please consult the Office of the <a href=\"http://www.priv.gc.ca/"
-"index_e.asp\">Privacy Commissioner of Canada</a> website or call "
-"1-800-282-1376.</p>\n"
-"    <p>In return for the Treasury Board of Canada Secretariat (TBS) giving "
-"you access to the Open Government Registry (the Registry), you agree to "
-"abide by the following terms and conditions of use for this and all future "
-"uses of the Registry:</p>\n"
-"    <ol><li>You agree to provide all of the required information for the "
-"creation of a registry account<br/>\n"
-"    Username<br/>\n"
-"    Full Name<br/>\n"
-"    Government of Canada Email<br/>\n"
-"    Department Name<br/>\n"
-"    Password</li>\n"
-"    <li>You agree that any information you provide is true, accurate, and "
-"complete to the best of your knowledge.</li>\n"
-"    <li>You understand and accept that you are at all times responsible for "
-"your login information . This responsibility applies even if you change your "
-"login information. This information must be kept confidential at all times "
-"and must not be shared with or disclosed to others.</li>\n"
-"    <li>If your login information (i.e. username, password) are revealed or "
-"if you suspect that someone else has learned or obtained them, you are "
-"responsible for taking all necessary measures to ensure compliance with the "
-"terms and conditions you agreed to when you created your login information.</"
-"li>\n"
-"    <li>You agree not to use your own or another individual's login "
-"information for any improper activities.</li>\n"
-"    <li>You agree to provide all of the required information for the "
-"creation of records</li>\n"
-"    <li>You agree not to use the services in a manner that harasses or may "
-"harass other parties, or that will or will have the potential to disrupt, "
-"undermine, corrupt, diminish or otherwise threaten or jeopardize the "
-"Registry.</li>\n"
-"    <li>The TBS Open Government Team will monitor access to the Registry to "
-"ensure the service is being used responsibly and in accordance with these "
-"terms and conditions.</li>\n"
-"    <li>You understand and accept that the TBS Open Government Group can "
+" <h2>Terms and Conditions for the Open Government Registry</h2> "
+"<p><em>Privacy Statement</em></p> <p>The Government of Canada is "
+"committed to providing measures that respect and value your privacy and "
+"security. This page summarizes the privacy policy and practices that "
+"apply to your Open Government Registry Account Credentials.</p> <p>The "
+"purpose for collecting and using “Username, Password and Email” is to "
+"issue, manage and validate anonymous credentials of individuals accessing"
+" and/or communicating with Government of Canada systems and "
+"applications.</p> <p>The personal information may be used to establish "
+"audit trails of credential usage. In the case of suspected security or "
+"privacy breaches, personal information may be shared with departmental "
+"security and access to information and privacy officials, as well as the "
+"federal government department or agency which collects and uses the "
+"personal information considered to have been compromised (refer to "
+"Standard PIB Security Incidents - PSU 939). For suspected criminal "
+"activity, personal information may also be disclosed to the Royal "
+"Canadian Mounted Police for investigational purposes; refer to "
+"institution-specific PIB Operational Case Records - RCMP PPU 005.</p> "
+"<p>We employ software programs to monitor network traffic to identify "
+"unauthorized attempts to upload or change information, or otherwise cause"
+" damage. This software receives and records the Internet Protocol (IP) "
+"address of the computer that has contacted our websites, the date and "
+"time of the visit and the pages visited. We make no attempt to link these"
+" addresses with the identity of individuals visiting our sites unless an "
+"attempt to damage the sites has been detected.</p> <p>Questions, concerns"
+" and complaints regarding this notice, or the administration of the "
+"Privacy Act in connection with your GCKey may be directed to the Access "
+"to Information and Privacy Protection Division by email to <a "
+"href=\"mailto:ATIP-AIPRP@ssc-spc.gc.ca\">ATIP-AIPRP@ssc-spc.gc.ca</a>, or"
+" by writing to the following address:</p> <p>Access to Information and "
+"Privacy Directorate<br/> Corporate Secretariat<br/> Shared Services "
+"Canada<br/> PO Box 9808, STN T, CSC<br/> Ottawa ON K1G 4A8</p> <p>For "
+"more information on privacy issues and the <em>Privacy Act</em> in "
+"general, please consult the Office of the <a "
+"href=\"http://www.priv.gc.ca/index_e.asp\">Privacy Commissioner of "
+"Canada</a> website or call 1-800-282-1376.</p> <p>In return for the "
+"Treasury Board of Canada Secretariat (TBS) giving you access to the Open "
+"Government Registry (the Registry), you agree to abide by the following "
+"terms and conditions of use for this and all future uses of the "
+"Registry:</p> <ol><li>You agree to provide all of the required "
+"information for the creation of a registry account<br/> Username<br/> "
+"Full Name<br/> Government of Canada Email<br/> Department Name<br/> "
+"Password</li> <li>You agree that any information you provide is true, "
+"accurate, and complete to the best of your knowledge.</li> <li>You "
+"understand and accept that you are at all times responsible for your "
+"login information . This responsibility applies even if you change your "
+"login information. This information must be kept confidential at all "
+"times and must not be shared with or disclosed to others.</li> <li>If "
+"your login information (i.e. username, password) are revealed or if you "
+"suspect that someone else has learned or obtained them, you are "
+"responsible for taking all necessary measures to ensure compliance with "
+"the terms and conditions you agreed to when you created your login "
+"information.</li> <li>You agree not to use your own or another "
+"individual's login information for any improper activities.</li> <li>You "
+"agree to provide all of the required information for the creation of "
+"records</li> <li>You agree not to use the services in a manner that "
+"harasses or may harass other parties, or that will or will have the "
+"potential to disrupt, undermine, corrupt, diminish or otherwise threaten "
+"or jeopardize the Registry.</li> <li>The TBS Open Government Team will "
+"monitor access to the Registry to ensure the service is being used "
+"responsibly and in accordance with these terms and conditions.</li> "
+"<li>You understand and accept that the TBS Open Government Group can "
 "suspend or revoke your access to the Registry without notice under the "
-"following circumstances:\n"
-"      <ul><li>we suspect unauthorized use of your personal or login "
-"information;</li>\n"
-"      <li>you fail to comply with any of the terms and conditions of use and/"
-"or agreements in place with the Treasury Board of Canada Secretariat;</li>\n"
-"      <li>as a security measure;</li>\n"
-"      <li>for operational reasons;</li>\n"
-"      <li>for administrative reasons.</li></ul></li>\n"
-"    <li>The TBS Open Government Group has taken all reasonable steps to "
-"ensure the security of this website. We have used sophisticated encryption "
-"technology and incorporated other procedures to protect your personal "
-"information at all times. However, the Internet is a public network and "
-"there is the remote possibility of data security violations.</li>\n"
-"    <li>TBS is not responsible for the failure to meet publication deadlines "
-"relating to:\n"
-"      <ul><li>the availability or unavailability, for any reason, of the "
-"Internet, login services or other infrastructure systems;</li>\n"
-"      <li>any restriction, delay, malfunction, or unavailability of the "
-"Registry</li></ul></li>\n"
-"    <li>These terms and conditions of use may be amended from time to time</"
-"li></ol>\n"
-"    <p>By selecting “I agree” you indicate that you accept these terms and "
-"conditions of use.</p>\n"
-"    <p>If you select “I do not agree” you will not have access to the "
-"Registry.</p>\n"
-"    "
+"following circumstances: <ul><li>we suspect unauthorized use of your "
+"personal or login information;</li> <li>you fail to comply with any of "
+"the terms and conditions of use and/or agreements in place with the "
+"Treasury Board of Canada Secretariat;</li> <li>as a security "
+"measure;</li> <li>for operational reasons;</li> <li>for administrative "
+"reasons.</li></ul></li> <li>The TBS Open Government Group has taken all "
+"reasonable steps to ensure the security of this website. We have used "
+"sophisticated encryption technology and incorporated other procedures to "
+"protect your personal information at all times. However, the Internet is "
+"a public network and there is the remote possibility of data security "
+"violations.</li> <li>TBS is not responsible for the failure to meet "
+"publication deadlines relating to: <ul><li>the availability or "
+"unavailability, for any reason, of the Internet, login services or other "
+"infrastructure systems;</li> <li>any restriction, delay, malfunction, or "
+"unavailability of the Registry</li></ul></li> <li>These terms and "
+"conditions of use may be amended from time to time</li></ol> <p>By "
+"selecting “I agree” you indicate that you accept these terms and "
+"conditions of use.</p> <p>If you select “I do not agree” you will not "
+"have access to the Registry.</p> "
 msgstr ""
 "\n"
 "    <h2>Modalités pour le registre du gouvernement ouvert</h2>\n"
-"    <p><em>Déclaration sur la protection des renseignements personnels</em></"
-"p>\n"
-"    <p>Le gouvernement du Canada attache de l'importance à votre vie privée "
-"et à votre sécurité et s'engage à mettre en œuvre des mesures qui respectent "
-"ces valeurs. Ce document résume la politique et les pratiques en matière de "
-"protection des renseignements personnels qui s’appliquent aux justificatifs "
-"de votre compte dans le registre du gouvernement ouvert.</p>\n"
-"    <p>La collecte et l’utilisation des « nom d’utilisateur, mot de passe et "
-"adresse courriel » servent à attribuer, à gérer et à authentifier les "
-"justificatifs d’identité anonymes des particuliers qui accèdent aux "
+"    <p><em>Déclaration sur la protection des renseignements "
+"personnels</em></p>\n"
+"    <p>Le gouvernement du Canada attache de l'importance à votre vie "
+"privée et à votre sécurité et s'engage à mettre en œuvre des mesures qui "
+"respectent ces valeurs. Ce document résume la politique et les pratiques "
+"en matière de protection des renseignements personnels qui s’appliquent "
+"aux justificatifs de votre compte dans le registre du gouvernement "
+"ouvert.</p>\n"
+"    <p>La collecte et l’utilisation des « nom d’utilisateur, mot de passe"
+" et adresse courriel » servent à attribuer, à gérer et à authentifier les"
+" justificatifs d’identité anonymes des particuliers qui accèdent aux "
 "applications en ligne du gouvernement du Canada ou qui communiquent avec "
 "celles-ci.</p>\n"
-"    <p>Les renseignements personnels peuvent être utilisés pour établir des "
-"pistes d’audit de l’utilisation des justificatifs. Dans les cas "
+"    <p>Les renseignements personnels peuvent être utilisés pour établir "
+"des pistes d’audit de l’utilisation des justificatifs. Dans les cas "
 "d’infractions présumées à la sécurité ou de violations de la "
-"confidentialité, les renseignements personnels peuvent être communiqués aux "
-"services ministériels de sécurité, aux agents de l’accès à l’information et "
-"de la protection des renseignements personnels et aux institutions fédérales "
-"où les renseignements personnels ont peut-être été compromis (veuillez vous "
-"référer aux Fichiers de renseignements personnels sur les Incidents de "
-"sécurité ordinaire - POU 939). Dans les cas d’activité criminelle présumée, "
-"les renseignements personnels peuvent également être communiqués à la "
-"Gendarmerie royale du Canada aux fins d’enquête; veuillez vous référer aux "
-"Fichiers de renseignements personnels sur les dossiers de cas opérationnels "
-"spécifiques - GRC PPU 005.</p>\n"
-"    <p>Nous utilisons des programmes logiciels pour surveiller l’achalandage "
-"sur le réseau afin de déceler toute tentative non autorisée de téléverser ou "
-"de modifier des renseignements, ou de causer d’autres dommages. Ce logiciel "
-"reçoit et enregistre l’adresse de protocole Internet (IP) de l’ordinateur "
-"qui a communiqué avec nos sites Web, ainsi que la date et l’heure de la "
-"visite et les pages visitées. Nous ne cherchons pas à établir de lien entre "
-"ces adresses et l’identité des personnes visitant nos sites, à moins qu’une "
-"manœuvre visant à endommager les sites ait été décelée. </p>\n"
+"confidentialité, les renseignements personnels peuvent être communiqués "
+"aux services ministériels de sécurité, aux agents de l’accès à "
+"l’information et de la protection des renseignements personnels et aux "
+"institutions fédérales où les renseignements personnels ont peut-être été"
+" compromis (veuillez vous référer aux Fichiers de renseignements "
+"personnels sur les Incidents de sécurité ordinaire - POU 939). Dans les "
+"cas d’activité criminelle présumée, les renseignements personnels peuvent"
+" également être communiqués à la Gendarmerie royale du Canada aux fins "
+"d’enquête; veuillez vous référer aux Fichiers de renseignements "
+"personnels sur les dossiers de cas opérationnels spécifiques - GRC PPU "
+"005.</p>\n"
+"    <p>Nous utilisons des programmes logiciels pour surveiller "
+"l’achalandage sur le réseau afin de déceler toute tentative non autorisée"
+" de téléverser ou de modifier des renseignements, ou de causer d’autres "
+"dommages. Ce logiciel reçoit et enregistre l’adresse de protocole "
+"Internet (IP) de l’ordinateur qui a communiqué avec nos sites Web, ainsi "
+"que la date et l’heure de la visite et les pages visitées. Nous ne "
+"cherchons pas à établir de lien entre ces adresses et l’identité des "
+"personnes visitant nos sites, à moins qu’une manœuvre visant à endommager"
+" les sites ait été décelée. </p>\n"
 "    <p>Toute question, préoccupation ou plainte concernant cet avis ou "
 "l’application de la Loi sur la protection des renseignements personnels "
-"relativement à votre CléGC peuvent être adressées à la Direction de l'accès "
-"à l'information et de la protection des renseignements personnels par "
-"courriel au <a href=\"mailto:ATIP-AIPRP@ssc-spc.gc.ca\">ATIP-AIPRP@ssc-spc."
-"gc.ca</a>, ou en écrivant à l’adresse suivante :</p>\n"
+"relativement à votre CléGC peuvent être adressées à la Direction de "
+"l'accès à l'information et de la protection des renseignements personnels"
+" par courriel au <a href=\"mailto:ATIP-AIPRP@ssc-spc.gc.ca\">ATIP-AIPRP"
+"@ssc-spc.gc.ca</a>, ou en écrivant à l’adresse suivante :</p>\n"
 "    <p>Direction de l'accès à l'information et de la protection des "
 "renseignements personnels<br/>\n"
 "    Secrétariat aux affaires générales<br/>\n"
@@ -2294,17 +1678,17 @@ msgstr ""
 "    Ottawa (Ontario)  K1G 4A8<br/>\n"
 "    <p>Pour en apprendre davantage sur les questions relatives à la "
 "protection des renseignements personnels ainsi que sur la <em>Loi sur la "
-"protection des renseignements personnels</em> en général, veuillez consulter "
-"le site Web du<a href=\"https://www.priv.gc.ca/fr/\">Commissariat à la "
-"protection de la vie privée du Canada</a> ou téléphoner au 1-800-282-1376.</"
-"p>\n"
+"protection des renseignements personnels</em> en général, veuillez "
+"consulter le site Web du<a "
+"href=\"https://www.priv.gc.ca/fr/\">Commissariat à la protection de la "
+"vie privée du Canada</a> ou téléphoner au 1-800-282-1376.</p>\n"
 "    <p>En échange de l’accès que vous offre le Secrétariat du Conseil du "
 "Trésor du Canada (SCT) au registre du gouvernement ouvert (le Registre), "
 "vous acceptez de vous conformer aux modalités d’utilisation suivantes "
 "relatives à l’utilisation actuelle du Registre ainsi qu’à toutes les "
 "utilisations futures :</p>\n"
-"    <ol><li>Vous convenez de fournir tous les renseignements requis pour la "
-"création d’un compte dans le Registre :<br/>\n"
+"    <ol><li>Vous convenez de fournir tous les renseignements requis pour "
+"la création d’un compte dans le Registre :<br/>\n"
 "    Nom d’utilisateur<br/>\n"
 "    Nom complet<br/>\n"
 "    Adresse courriel du gouvernement du Canada<br/>\n"
@@ -2312,76 +1696,708 @@ msgstr ""
 "    Mot de passe</li>\n"
 "    <li>Vous convenez que tous les renseignements fournis sont à votre "
 "connaissance vrais, exacts et complets.</li>\n"
-"    <li>Vous comprenez et convenez que vous êtes en tout temps responsable "
-"de vos identifiants. Cette responsabilité s’applique même si vous modifiez "
-"vos identifiants. Ceux-ci doivent demeurer confidentiels en tout temps et ne "
-"doivent pas être partagés ni divulgués à des tiers.</li>\n"
-"    <li>Si vos identifiants (c.-à-d. nom d’utilisateur, mot de passe) sont "
-"communiqués ou que vous soupçonnez qu’une autre personne les a découverts ou "
-"obtenus, il vous appartient de prendre les dispositions nécessaires afin "
-"d’assurer la conformité aux modalités auxquelles vous avez convenu lors de "
-"la création de vos identifiants.</li>\n"
-"    <li>Vous convenez de ne pas utiliser vos propres identifiants ou ceux "
-"d’une autre personne à des fins inappropriées.</li>\n"
-"    <li>Vous convenez de fournir tous les renseignements nécessaires pour la "
-"création des dossiers.</li>\n"
-"    <li>Vous convenez de ne pas utiliser le service d'une façon qui harcèle "
-"ou qui pourrait harceler d'autres parties ou qui perturbe ou a le potentiel "
-"de perturber, de miner, de corrompre, de diminuer, de menacer ou de "
-"compromettre le Registre.</li>\n"
+"    <li>Vous comprenez et convenez que vous êtes en tout temps "
+"responsable de vos identifiants. Cette responsabilité s’applique même si "
+"vous modifiez vos identifiants. Ceux-ci doivent demeurer confidentiels en"
+" tout temps et ne doivent pas être partagés ni divulgués à des "
+"tiers.</li>\n"
+"    <li>Si vos identifiants (c.-à-d. nom d’utilisateur, mot de passe) "
+"sont communiqués ou que vous soupçonnez qu’une autre personne les a "
+"découverts ou obtenus, il vous appartient de prendre les dispositions "
+"nécessaires afin d’assurer la conformité aux modalités auxquelles vous "
+"avez convenu lors de la création de vos identifiants.</li>\n"
+"    <li>Vous convenez de ne pas utiliser vos propres identifiants ou ceux"
+" d’une autre personne à des fins inappropriées.</li>\n"
+"    <li>Vous convenez de fournir tous les renseignements nécessaires pour"
+" la création des dossiers.</li>\n"
+"    <li>Vous convenez de ne pas utiliser le service d'une façon qui "
+"harcèle ou qui pourrait harceler d'autres parties ou qui perturbe ou a le"
+" potentiel de perturber, de miner, de corrompre, de diminuer, de menacer "
+"ou de compromettre le Registre.</li>\n"
 "    <li>L’équipe du gouvernement ouvert du SCT surveillera l’accès au "
 "Registre afin d’assurer l’utilisation responsable du service et la "
 "conformité à ces modalités.</li>\n"
-"    <li>Vous comprenez et acceptez que le Groupe de travail du gouvernement "
-"ouvert du SCT peut sans préavis suspendre ou révoquer votre accès au "
-"Registre dans les circonstances suivantes :\n"
+"    <li>Vous comprenez et acceptez que le Groupe de travail du "
+"gouvernement ouvert du SCT peut sans préavis suspendre ou révoquer votre "
+"accès au Registre dans les circonstances suivantes :\n"
 "      <ul><li>nous soupçonnons une utilisation non autorisée de vos "
 "renseignements personnels ou de connexion;</li>\n"
 "      <li>vous ne vous conformez pas aux modalités d’utilisation ou aux "
-"ententes en place avec le Secrétariat du Conseil du Trésor du Canada;</li>\n"
+"ententes en place avec le Secrétariat du Conseil du Trésor du "
+"Canada;</li>\n"
 "      <li>par mesure de sécurité;</li>\n"
 "      <li>pour des raisons opérationnelles;</li>\n"
 "      <li>pour des raisons administratives.</li></ul></li>\n"
-"    <li>Le Groupe de travail du gouvernement ouvert du SCT a pris toutes les "
-"mesures qui s’imposent en vue d’assurer la sécurité de ce site Web. Nous "
-"avons utilisé une technologie de chiffrement avancée et intégré d’autres "
-"procédures afin de protéger vos renseignements personnels en tout temps. "
-"Cependant, l’Internet est un réseau public et une violation de la sécurité "
-"des données demeure une possibilité.</li>\n"
+"    <li>Le Groupe de travail du gouvernement ouvert du SCT a pris toutes "
+"les mesures qui s’imposent en vue d’assurer la sécurité de ce site Web. "
+"Nous avons utilisé une technologie de chiffrement avancée et intégré "
+"d’autres procédures afin de protéger vos renseignements personnels en "
+"tout temps. Cependant, l’Internet est un réseau public et une violation "
+"de la sécurité des données demeure une possibilité.</li>\n"
 "    <li>Le SCT n’est pas responsable du non-respect des délais de "
 "publication en raison de :\n"
-"      <ul><li>la disponibilité ou non-disponibilité, peu importe la raison, "
-"d’Internet, des services de connexion ou de tout autre système "
+"      <ul><li>la disponibilité ou non-disponibilité, peu importe la "
+"raison, d’Internet, des services de connexion ou de tout autre système "
 "d’infrastructure;</li>\n"
-"      <li>restriction, de retard, d’un mauvais fonctionnement ou de la non-"
-"disponibilité du Registre.</li></ul></li>\n"
-"    <li>Ces modalités d’utilisation peuvent être modifiées de temps à autre."
-"</li></ol>\n"
-"    <p>En sélectionnant « J’accepte », vous indiquez que vous acceptez ces "
-"modalités d’utilisation.</p>\n"
-"    <p>Si vous sélectionnez « Je n’accepte pas », vous n’aurez pas accès au "
-"Registre.</p>\n"
+"      <li>restriction, de retard, d’un mauvais fonctionnement ou de la "
+"non-disponibilité du Registre.</li></ul></li>\n"
+"    <li>Ces modalités d’utilisation peuvent être modifiées de temps à "
+"autre.</li></ol>\n"
+"    <p>En sélectionnant « J’accepte », vous indiquez que vous acceptez "
+"ces modalités d’utilisation.</p>\n"
+"    <p>Si vous sélectionnez « Je n’accepte pas », vous n’aurez pas accès "
+"au Registre.</p>\n"
 "    "
 
+#: ckanext/canada/templates/internal/user/new_user_form.html:71
 msgid "I agree"
 msgstr "J’accepte"
 
+#: ckanext/canada/templates/internal/user/new_user_form.html:72
 msgid "I do not agree"
 msgstr "Je n’accepte pas"
 
+#: ckanext/canada/templates/internal/user/perform_reset.html:8
+#, fuzzy, python-format
+msgid ""
+"1. Passwords must contain characters from at least 3 of the following 4 "
+"classes: * Upper Case Letters: A, B, C, … Z * Lower Case Letters: a, b, "
+"c, … z * Westernised Arabic Numerals: 0, 1, 2, … 9 * Special characters: "
+"({}[],.<>;:'\"?/|\\`~!@#$%%^&*()_-+=). 2. No accented characters are "
+"permitted. 3. All passwords must be at least 8 characters long. "
+msgstr ""
+"1. Les mots de passe doivent contenir des caractères provenant d’au moins"
+" trois des quatre catégories suivantes :\n"
+"    * Lettres majuscules :A, B, C, … Z\n"
+"    * Lettres minuscules : a, b, c, … z\n"
+"    * Chiffres arabes :0, 1, 2, … 9\n"
+"    * Caractères spéciaux : ({}[],.<>;:'\"?/|\\`~!@#$%^&*()_-+=).\n"
+"2. Les lettres accentuées ne sont pas acceptées.\n"
+"3. Tous les mots de passe doivent compter au moins huit caractères.\n"
+
+#: ckanext/canada/templates/internal/user/read_base.html:12
+msgid "Edit User"
+msgstr "Modifier l'utilisateur"
+
+#: ckanext/canada/templates/internal/user/reports.html:4
+msgid "Reports"
+msgstr "Rapports"
+
+#: ckanext/canada/templates/internal/user/reports.html:6
+msgid "No reports are available"
+msgstr "Aucun rapport n’est disponible"
+
+#: ckanext/canada/templates/internal/user/snippets/user_search.html:2
+#: ckanext/canada/templates/internal/user/snippets/user_search.html:5
+#: ckanext/canada/templates/internal/user/snippets/user_search.html:6
+msgid "Search Users"
+msgstr "Rechercher des utilisateurs"
+
+#: ckanext/canada/templates/internal/xloader/resource_data.html:8
+msgid "Are you sure you want to delete this DataStore table and Data Dictionary?"
+msgstr ""
+"Voulez-vous vraiment supprimer cette table DataStore et ce dictionnaire "
+"de données"
+
+#: ckanext/canada/templates/internal/xloader/resource_data.html:9
+msgid "Delete DataStore table"
+msgstr "Supprimer la table DataStore"
+
+#: ckanext/canada/templates/internal/xloader/resource_data.html:18
+msgid "Upload to DataStore"
+msgstr ""
+
+#: ckanext/canada/templates/obd/package/search.html:3
+msgid "Open by Default Portal"
+msgstr "Portail « Ouvert par défaut »"
+
+#: ckanext/canada/templates/obd/package/snippets/socialmedia.html:4
+#: ckanext/canada/templates/public/package/snippets/socialmedia.html:4
+msgid "Have your say"
+msgstr "À vous la parole"
+
+#: ckanext/canada/templates/obd/package/snippets/socialmedia.html:8
+#: ckanext/canada/templates/public/package/snippets/socialmedia.html:8
+msgid "Rate this dataset"
+msgstr "Évaluez ce jeu de données"
+
+#: ckanext/canada/templates/obd/package/snippets/socialmedia.html:9
+msgid "Comment(s)"
+msgstr "Commentaire(s)"
+
+#: ckanext/canada/templates/obd/snippets/search_form.html:4
+msgid ""
+"Open by Default provides access to working documents used by the "
+"Government of Canada. Most of this information is unpublished. Documents "
+"may be in draft form, and are generally available in the language in "
+"which they were created. Unless otherwise indicated, information is made "
+"available under the <a href=\"http://open.canada.ca/en/open-government-"
+"licence-canada\">Open Government Licence</a>. To obtain documents in the "
+"official language of your choice, or in an accessible format, please <a "
+"href=\"http://open.canada.ca/en/forms/contact-us\">contact us</a>."
+msgstr ""
+"L’initiative « Ouvert par défaut » donne accès aux documents de travail "
+"utilisés par le gouvernement du Canada. La plupart de ces renseignements "
+"ne sont pas publiés. Les documents peuvent être sous la forme d’ébauche "
+"et sont en général disponibles dans la langue dans laquelle ils ont été "
+"créés. À moins d’indication contraire, les renseignements sont "
+"disponibles en vertu de la <a href=\"http://ouvert.canada.ca/fr/licence-"
+"du-gouvernement-ouvert-canada\">licence du gouvernement ouvert</a>. Afin "
+"d’obtenir les documents dans la langue officielle de votre choix ou dans "
+"un format accessible, veuillez <a "
+"href=\"http://ouvert.canada.ca/fr/formulaire/faites-nous-part-de-vos-"
+"commentaires\">communiquer avec nous</a>."
+
+#: ckanext/canada/templates/public/base.html:14
+#: ckanext/canada/templates/public/datatables/datatables_view.html:24
+#: ckanext/canada/templates/public/package/read_base.html:21
+msgid "Treasury Board of Canada Secretariat"
+msgstr "Secrétariat du Conseil du Trésor du Canada"
+
+#: ckanext/canada/templates/public/footer.html:11
+msgid "https://open.canada.ca/en/forms/contact-us"
+msgstr ""
+"https://ouvert.canada.ca/fr/formulaire/faites-nous-part-de-vos-"
+"commentaires"
+
+#: ckanext/canada/templates/public/footer.html:11
+msgid "Contact Open Government"
+msgstr "Contactez-nous du gouvernement ouvert"
+
+#: ckanext/canada/templates/public/footer.html:12
+msgid "https://www.canada.ca/en/government/dept.html"
+msgstr "https://www.canada.ca/fr/gouvernement/min.html"
+
+#: ckanext/canada/templates/public/footer.html:12
+msgid "Departments and agencies"
+msgstr "Ministères et organismes"
+
+#: ckanext/canada/templates/public/footer.html:13
+msgid "https://www.canada.ca/en/government/publicservice.html"
+msgstr "https://www.canada.ca/fr/gouvernement/fonctionpublique.html"
+
+#: ckanext/canada/templates/public/footer.html:13
+msgid "Public service and military"
+msgstr "Fonction publique et force militaire"
+
+#: ckanext/canada/templates/public/footer.html:14
+msgid "https://www.canada.ca/en/news.html"
+msgstr "https://www.canada.ca/fr/nouvelles.html"
+
+#: ckanext/canada/templates/public/footer.html:14
+msgid "News"
+msgstr "Nouvelles"
+
+#: ckanext/canada/templates/public/footer.html:15
+msgid "https://www.canada.ca/en/government/system/laws.html"
+msgstr "https://www.canada.ca/fr/gouvernement/systeme/lois.html"
+
+#: ckanext/canada/templates/public/footer.html:15
+msgid "Treaties, laws and regulations"
+msgstr "Traités, lois et règlements"
+
+#: ckanext/canada/templates/public/footer.html:16
+msgid "https://www.canada.ca/en/transparency/reporting.html"
+msgstr "https://www.canada.ca/fr/transparence/rapports.html"
+
+#: ckanext/canada/templates/public/footer.html:16
+msgid "Government-wide reporting"
+msgstr "Rapports à l'échelle du gouvernement"
+
+#: ckanext/canada/templates/public/footer.html:17
+msgid "http://pm.gc.ca/eng"
+msgstr "http://pm.gc.ca/fr"
+
+#: ckanext/canada/templates/public/footer.html:17
+msgid "Prime Minister"
+msgstr "Premier ministre"
+
+#: ckanext/canada/templates/public/footer.html:18
+msgid "https://www.canada.ca/en/government/system.html"
+msgstr "https://www.canada.ca/fr/gouvernement/systeme.html"
+
+#: ckanext/canada/templates/public/footer.html:18
+msgid "About government"
+msgstr "Au sujet du gouvernement"
+
+#: ckanext/canada/templates/public/footer.html:19
+msgid "https://open.canada.ca/en"
+msgstr "https://open.canada.ca/fr"
+
+#: ckanext/canada/templates/public/footer.html:19
+msgid "Open government"
+msgstr "Gouvernement ouvert"
+
+#: ckanext/canada/templates/public/footer.html:33
+msgid "https://www.canada.ca/en/social.html"
+msgstr "https://www.canada.ca/fr/sociaux.html"
+
+#: ckanext/canada/templates/public/footer.html:33
+msgid "Social media"
+msgstr "Médias sociaux"
+
+#: ckanext/canada/templates/public/footer.html:34
+msgid "https://www.canada.ca/en/mobile.html"
+msgstr "https://www.canada.ca/fr/mobile.html"
+
+#: ckanext/canada/templates/public/footer.html:34
+msgid "Mobile applications"
+msgstr "Applications mobiles"
+
+#: ckanext/canada/templates/public/footer.html:35
+#, fuzzy
+msgid "https://www.canada.ca/en/government/about.html"
+msgstr "https://www.canada.ca/fr/gouvernement/min.html"
+
+#: ckanext/canada/templates/public/footer.html:35
+msgid "About Canada.ca"
+msgstr "À propos de Canada.ca"
+
+#: ckanext/canada/templates/public/footer.html:36
+msgid "https://www.canada.ca/en/transparency/terms.html"
+msgstr "https://www.canada.ca/fr/transparence/avis.html"
+
+#: ckanext/canada/templates/public/footer.html:36
+msgid "Terms and conditions"
+msgstr "Avis"
+
+#: ckanext/canada/templates/public/footer.html:37
+msgid "https://www.canada.ca/en/transparency/privacy.html"
+msgstr "https://www.canada.ca/fr/transparence/confidentialite.html"
+
+#: ckanext/canada/templates/public/footer.html:37
+msgid "Privacy"
+msgstr "Confidentialité"
+
+#: ckanext/canada/templates/public/footer.html:43
+msgid "About this site"
+msgstr "À propos de ce site"
+
+#: ckanext/canada/templates/public/footer.html:46
+msgid "Symbol of the Government of Canada"
+msgstr "Symbole du gouvernement du Canada"
+
+#: ckanext/canada/templates/public/header.html:18
+msgid "Search website"
+msgstr "Recherchez le site Web"
+
+#: ckanext/canada/templates/public/header.html:21
+msgid "Search Canada.ca"
+msgstr "Rechercher dans Canada.ca"
+
+#: ckanext/canada/templates/public/organization/about.html:4
+#: ckanext/canada/templates/public/page.html:39
+#: ckanext/canada/templates/public/user/edit_user_form.html:15
+msgid "About"
+msgstr "À propos"
+
+#: ckanext/canada/templates/public/activity_streams/activity_stream_items.html:19
+msgid "Load less"
+msgstr ""
+
+#: ckanext/canada/templates/public/activity_streams/activity_stream_items.html:29
+msgid "Load more"
+msgstr "En charger davantage"
+
+#: ckanext/canada/templates/public/admin/config.html:12
+msgid "Are you sure you want to reset the config?"
+msgstr ""
+
+#: ckanext/canada/templates/public/admin/config.html:13
+msgid "Update Config"
+msgstr ""
+
+#: ckanext/canada/templates/public/admin/config.html:14
+msgid "Reset"
+msgstr ""
+
+#: ckanext/canada/templates/public/admin/config.html:25
+msgid "CKAN config options"
+msgstr ""
+
+#: ckanext/canada/templates/public/admin/config.html:33
+#, python-format
+msgid ""
+" <p><strong>Site Title:</strong> This is the title of this CKAN instance "
+"It appears in various places throughout CKAN.</p> "
+"<p><strong>Style:</strong> Choose from a list of simple variations of the"
+" main colour scheme to get a very quick custom theme working.</p> "
+"<p><strong>Site Tag Logo:</strong> This is the logo that appears in the "
+"header of all the CKAN instance templates.</p> <p><strong>About:</strong>"
+" This text will appear on this CKAN instances <a "
+"href=\"%(about_url)s\">about page</a>.</p> <p><strong>Intro "
+"Text:</strong> This text will appear on this CKAN instances <a "
+"href=\"%(home_url)s\">home page</a> as a welcome to visitors.</p> "
+"<p><strong>Custom CSS:</strong> This is a block of CSS that appears in "
+"<code>&lt;head&gt;</code> tag of every page. If you wish to customize the"
+" templates more fully we recommend <a href=\"%(docs_url)s\" "
+"target=\"_blank\">reading the documentation</a>.</p> "
+"<p><strong>Homepage:</strong> This is for choosing a predefined layout "
+"for the modules that appear on your homepage.</p> "
+msgstr ""
+
+#: ckanext/canada/templates/public/admin/index.html:18
+msgid "Administer CKAN"
+msgstr ""
+
+#: ckanext/canada/templates/public/admin/index.html:24
+#, python-format
+msgid ""
+" <p>As a sysadmin user you have full control over this CKAN instance. "
+"Proceed with care!</p> <p>For guidance on using sysadmin features, see "
+"the CKAN <a href=\"%(docs_url)s\" target=\"_blank\">sysadmin "
+"guide</a></p> "
+msgstr ""
+
+#: ckanext/canada/templates/public/admin/trash.html:26
+msgid "Purge"
+msgstr ""
+
+#: ckanext/canada/templates/public/admin/trash.html:42
+msgid " <p>Purge deleted datasets forever and irreversibly.</p> "
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:9
+msgid "CKAN Data API"
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:13
+msgid "Access resource data via a web API with powerful query support"
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:14
+msgid ""
+"Further information in the <a "
+"href=\"http://docs.ckan.org/en/latest/maintaining/datastore.html\" "
+"target=\"_blank\">main CKAN Data API and DataStore documentation</a>.</p>"
+msgstr ""
+"Plus d'informations dans la <a "
+"href=\"http://docs.ckan.org/en/latest/maintaining/datastore.html\" "
+"target=\"_blank\">documentation principale de l'API CKAN pour les données"
+" et du magasin de données</a>.</p>"
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:19
+#, fuzzy
+msgid "Endpoints"
+msgstr "Rapports"
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:23
+msgid ""
+"The Data API can be accessed via the following actions of the CKAN action"
+" API."
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:29
+msgid "Query"
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:33
+msgid "Query (via SQL)"
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:45
+msgid "Querying"
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:49
+msgid "Query example (first 5 results)"
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:54
+msgid "Query example (results containing 'jones')"
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:59
+msgid "Query example (via SQL statement)"
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:70
+msgid "Example: Javascript"
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:74
+msgid "A simple ajax (JSONP) request to the data API using jQuery."
+msgstr ""
+
+#: ckanext/canada/templates/public/ajax_snippets/api_info.html:95
+msgid "Example: Python"
+msgstr ""
+
+#: ckanext/canada/templates/public/fgpv_vpgf/index.html:2
+#: ckanext/canada/templates/public/fgpv_vpgf/index.html:5
+#: ckanext/canada/templates/public/fgpv_vpgf/index.html:10
+msgid "Open Maps Data Viewer"
+msgstr "Visualisateur de données de Cartes ouvertes"
+
+#: ckanext/canada/templates/public/fgpv_vpgf/index.html:9
+msgid "Search Open Maps"
+msgstr "Recherche de cartes ouvertes"
+
+#: ckanext/canada/templates/public/fgpv_vpgf/index.html:42
+#: ckanext/canada/templates/public/snippets/search_form.html:53
+msgid "List Cart Items"
+msgstr "Liste des articles du panier"
+
+#: ckanext/canada/templates/public/fgpv_vpgf/index.html:75
+msgid ""
+"This interactive map requires JavaScript. To view this content please "
+"enable JavaScript in your browser or download a browser that supports it."
+msgstr ""
+"Cette carte interactive nécessite le JavaScript. Pour visualiser ce "
+"contenu, veuillez activer JavaScript dans votre navigateur ou télécharger"
+" un navigateur qui le supporte."
+
+#: ckanext/canada/templates/public/fgpv_vpgf/index.html:82
+msgid "We’re sorry, your browser version is not supported by Open Maps"
+msgstr ""
+"Nous sommes désolés que votre version du navigateur n'est pas supporté "
+"par Cartes ouvertes"
+
+#: ckanext/canada/templates/public/macros/canada_read.html:36
+#, fuzzy
+msgid "Keyword"
+msgstr "Mots clés"
+
+#: ckanext/canada/templates/public/macros/canada_read.html:226
+#, fuzzy
+msgid "entry"
+msgstr "entrées"
+
+#: ckanext/canada/templates/public/macros/canada_read.html:226
+msgid "entries"
+msgstr "entrées"
+
+#: ckanext/canada/templates/public/macros/form.html:122
+msgid ""
+"You can use <a href='http://daringfireball.net/projects/markdown/syntax' "
+"target='_blank'>Markdown formatting</a> here"
+msgstr ""
+"Vous pouvez utiliser le formatage <a "
+"href=\"http://daringfireball.net/projects/markdown/syntax\" "
+"target=\"_blank\">Markdown</a> ici"
+
+#: ckanext/canada/templates/public/macros/form.html:279
+msgid "Custom"
+msgstr ""
+
+#: ckanext/canada/templates/public/macros/form.html:281
+msgid "(required)"
+msgstr ""
+
+#: ckanext/canada/templates/public/macros/form.html:438
+msgid "Clear Upload"
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/activity_stream.html:11
+#: ckanext/canada/templates/public/package/read_base.html:159
+msgid "Atom Feed"
+msgstr "Fil de nouvelles Atom"
+
+#: ckanext/canada/templates/public/organization/confirm_delete_member.html:3
+#: ckanext/canada/templates/public/organization/confirm_delete_member.html:13
+#: ckanext/canada/templates/public/package/confirm_delete.html:3
+#: ckanext/canada/templates/public/package/confirm_delete.html:13
+#: ckanext/canada/templates/public/package/confirm_delete_resource.html:3
+#: ckanext/canada/templates/public/package/confirm_delete_resource.html:12
+msgid "Confirm Delete"
+msgstr "Confirmer la suppression"
+
+#: ckanext/canada/templates/public/organization/confirm_delete_member.html:8
+msgid "Are you sure you want to delete member - {name}?"
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/index.html:13
+#, fuzzy
+msgid "There are currently no organizations for this site"
+msgstr "Aucun filtre sélectionné pour cette recherche"
+
+#: ckanext/canada/templates/public/organization/index.html:15
+msgid "How about creating one?"
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/member_new.html:8
+msgid "Back to all members"
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/member_new.html:9
+#, fuzzy
+msgid "Edit Member"
+msgstr "Modifier les membres"
+
+#: ckanext/canada/templates/public/organization/member_new.html:9
+#: ckanext/canada/templates/public/organization/member_new.html:68
+#, fuzzy
+msgid "Add Member"
+msgstr "{0} membre"
+
+#: ckanext/canada/templates/public/organization/member_new.html:17
+msgid "Existing User"
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/member_new.html:20
+msgid "If you wish to add an existing user, search for their username below."
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/member_new.html:39
+msgid "or"
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/member_new.html:45
+#, fuzzy
+msgid "New User"
+msgstr "une étoile"
+
+#: ckanext/canada/templates/public/organization/member_new.html:48
+msgid "If you wish to invite a new user, enter their email address."
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/member_new.html:51
+#, fuzzy
+msgid "Email address"
+msgstr "Adresse Web"
+
+#: ckanext/canada/templates/public/organization/member_new.html:62
+#, fuzzy
+msgid "Are you sure you want to delete this member?"
+msgstr "Êtes-vous certain de vouloir supprimer cet état?"
+
+#: ckanext/canada/templates/public/organization/member_new.html:64
+#, fuzzy
+msgid "Update Member"
+msgstr "Modifier les membres"
+
+#: ckanext/canada/templates/public/organization/member_new.html:81
+msgid "What are roles?"
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/member_new.html:84
+msgid ""
+" <p><strong>Admin:</strong> Can add/edit and delete datasets, as well as "
+"manage organization members.</p> <p><strong>Editor:</strong> Can add and "
+"edit datasets, but not manage organization members.</p> "
+"<p><strong>Member:</strong> Can view the organization's private datasets,"
+" but not add new datasets.</p> "
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/members.html:3
+#: ckanext/canada/templates/public/snippets/organization.html:30
+msgid "Members"
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/read.html:12
+msgid "Edit Organization"
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/snippets/helper.html:2
+msgid "What are Organizations?"
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/snippets/helper.html:4
+msgid ""
+" CKAN Organizations are used to create, manage and publish collections of"
+" datasets. Users can have different roles within an Organization, "
+"depending on their level of authorisation to create, edit and publish. "
+msgstr ""
+" Les organisations agissent comme des agents d'édition de dossiers (par "
+"exemple : Santé Canada). Cela signifie que les dossiers peuvent être "
+"publiés par une organisation, et leur appartenir, au lieu d'un "
+"utilisateur individuel. L'administrateur du registre peut autoriser les "
+"utilisateurs à publier des dossiers pour le compte de leurs "
+"organisations."
+
+#: ckanext/canada/templates/public/organization/snippets/organization_item.html:6
+msgid "This organization has no description"
+msgstr ""
+
+#: ckanext/canada/templates/public/organization/snippets/organization_item.html:12
+msgid "{num} Dataset"
+msgid_plural "{num} Datasets"
+msgstr[0] "{num} dossiers"
+msgstr[1] "{num} dossiers"
+
+#: ckanext/canada/templates/public/organization/snippets/organization_item.html:14
+msgid "0 Datasets"
+msgstr "0 dossiers"
+
+#: ckanext/canada/templates/public/package/base_form_page.html:7
+msgid "What are datasets?"
+msgstr "Qu’est-ce qu’un ensemble de données?"
+
+#: ckanext/canada/templates/public/package/base_form_page.html:10
+msgid ""
+" Datasets are simply used to group related pieces of data. These can then"
+" be found under a single url with a description and licensing "
+"information. "
+msgstr ""
+
+#: ckanext/canada/templates/public/package/confirm_delete.html:9
+msgid "Are you sure you want to delete dataset - {name}?"
+msgstr ""
+
+#: ckanext/canada/templates/public/package/confirm_delete_resource.html:8
+msgid "Are you sure you want to delete resource - {name}?"
+msgstr ""
+
+#: ckanext/canada/templates/public/package/deleted.html:7
+#, python-format
+msgid "This record has been removed from %s."
+msgstr "Ce dossier a été supprimé de %s."
+
+#: ckanext/canada/templates/public/package/deleted.html:7
+msgid "Open.canada.ca"
+msgstr "ouvert.canada.ca"
+
+#: ckanext/canada/templates/public/package/deleted.html:10
+msgid "Created On"
+msgstr "Date de création"
+
+#: ckanext/canada/templates/public/package/deleted.html:12
+#: ckanext/canada/templates/public/snippets/sort_by.html:22
+msgid "Last Modified"
+msgstr "Date de modification"
+
+#: ckanext/canada/templates/public/package/deleted.html:21
+msgid "Return to Index"
+msgstr "Retourner à la page de recherche"
+
+#: ckanext/canada/templates/public/package/read.html:15
+#: ckanext/canada/templates/public/package/read.html:40
+#: ckanext/canada/templates/public/package/snippets/resource_item.html:12
+#: ckanext/canada/templates/public/scheming/display_snippets/fluent_tags.html:9
+#: ckanext/canada/templates/public/snippets/package_item.html:38
+#: ckanext/canada/templates/public/snippets/package_item.html:52
+#, fuzzy
+msgid ""
+"This third party metadata element has been translated using an automated "
+"translation tool. To report any discrepancies please contact open-ouvert"
+"@tbs-sct.gc.ca"
+msgstr ""
+"Cet élément de métadonnées provenant d’une tierce partie a été traduit à "
+"l'aide d'un outil de traduction automatisée. Pour signaler toute "
+"anomalie, veuillez communiquer avec nous à open-ouvert@tbs-sct.gc.ca"
+
+#: ckanext/canada/templates/public/package/read.html:30
+#, python-format
+msgid ""
+"You're currently viewing an old version of this dataset. Some resources "
+"may no longer exist or the dataset may not display correctly. To see the "
+"current version, click <a href=\"%(url)s\">here</a>."
+msgstr ""
+"Vous consultez actuellement une ancienne version de ce jeu de données. Il"
+" se peut que certaines ressources n’existent plus ou que le jeu de "
+"données ne s’affiche pas correctement. Pour voir la version actuelle, "
+"cliquez <a href=\"%(url)s\">ici</a>."
+
+#: ckanext/canada/templates/public/package/read.html:46
+#: ckanext/canada/templates/public/snippets/search_form.html:54
+msgid "View on Map"
+msgstr "Afficher la carte"
+
+#: ckanext/canada/templates/public/package/read.html:57
 msgid "Made available by the "
 msgstr "Rendus disponibles par l’entremise du "
 
-msgid ""
-"You're currently viewing an old version of this dataset. Some resources may "
-"no longer exist or the dataset may not display correctly. To see the current "
-"version, click <a href=\"%(url)s\">here</a>."
-msgstr ""
-"Vous consultez actuellement une ancienne version de ce jeu de données. Il se "
-"peut que certaines ressources n’existent plus ou que le jeu de données ne "
-"s’affiche pas correctement. Pour voir la version actuelle, cliquez "
-"<a href=\"%(url)s\">ici</a>."
-
+#: ckanext/canada/templates/public/package/read.html:59
 msgid ""
 "<p>These resources are not under the control of the Government of Canada "
 "and the link is provided solely for the convenience of our website "
@@ -2399,1185 +2415,2557 @@ msgid ""
 "policies of this non-government website before providing personal "
 "information.</p>"
 msgstr ""
-"<p>Ces ressources ne sont pas contrôlées par le gouvernement du Canada, et "
-"l’hyperlien est fourni uniquement pour la facilité d’utilisation des "
+"<p>Ces ressources ne sont pas contrôlées par le gouvernement du Canada, "
+"et l’hyperlien est fourni uniquement pour la facilité d’utilisation des "
 "visiteurs de notre site Web. Nous ne sommes pas responsables de "
 "l’exactitude, l’actualité et la fiabilité du contenu. Le gouvernement du "
 "Canada n’offre aucune garantie à cet égard et n’est pas responsable des "
 "renseignements trouvés par l’entremise de ce lien.</p>\n"
-"<p>Les visiteurs devraient également savoir que les renseignements offerts "
-"par l’entremise de ce site Web ne sont pas gérés par le gouvernement du "
-"Canada et ne relèvent pas de la <a href=\"http://laws-lois.justice.gc.ca/fra/"
-"lois/P-21/index.html\">Loi sur la protection des renseignements personnels</"
-"a> ni de la <a href=\"http://laws-lois.justice.gc.ca/fra/lois/O-3.01/\">Loi "
-"sur les langues officielles</a>, et qu’ils pourraient ne pas être "
-"accessibles aux personnes handicapées. Les renseignements offerts pourraient "
-"être uniquement disponibles dans la langue utilisée dans le site en "
-"question. En ce qui concerne la protection des renseignements personnels, "
-"les visiteurs devraient vérifier les politiques de confidentialité de ce "
-"site Web non gouvernemental avant de fournir leurs renseignements personnels."
-"</p>"
+"<p>Les visiteurs devraient également savoir que les renseignements "
+"offerts par l’entremise de ce site Web ne sont pas gérés par le "
+"gouvernement du Canada et ne relèvent pas de la <a href=\"http://laws-"
+"lois.justice.gc.ca/fra/lois/P-21/index.html\">Loi sur la protection des "
+"renseignements personnels</a> ni de la <a href=\"http://laws-"
+"lois.justice.gc.ca/fra/lois/O-3.01/\">Loi sur les langues "
+"officielles</a>, et qu’ils pourraient ne pas être accessibles aux "
+"personnes handicapées. Les renseignements offerts pourraient être "
+"uniquement disponibles dans la langue utilisée dans le site en question. "
+"En ce qui concerne la protection des renseignements personnels, les "
+"visiteurs devraient vérifier les politiques de confidentialité de ce site"
+" Web non gouvernemental avant de fournir leurs renseignements "
+"personnels.</p>"
 
-msgid ""
-"<small class='text-info' style='margin-bottom: 15px; display: inline-block'>\n"
-"<p>Has approval been obtained? By selecting yes, you have ensured that the "
-"following statements are true:</p>\n"
-"<ol>\n"
-"<li><b>Confidentiality</b> -  The data or information resource is not "
-"subject to confidentiality restrictions, such as Cabinet confidences, "
-"solicitor-client privilege, classified or protected "
-"information, advice or recommendations, third party information, or information "
-"obtained in confidence.</li>\n"
-"<li><b>Authority to Release</b> - The institution has the mandate, legislative "
-"authority or permission from a third party provider to release the data or "
-"information resources under the <a href='https://open.canada.ca/en/open-government-licence-canada'>"
-"<u>Open Government Licence – Canada</u></a>.</li>\n"
-"<li><b>Formats</b> - The data or information resource is in an open and accessible "
-"format that complies with <a href='https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=23601'>"
-"<u>the Standard on Web Accessibility</u></a>.</li>\n"
-"<li><b>Privacy</b> - The data or information resource does not contain personal information, "
-"as defined in section 3 of the <a href='https://www.priv.gc.ca/en/privacy-topics/"
-"privacy-laws-in-canada/the-privacy-act/'><u>Privacy Act</u></a>, unless the individual "
-"to whom it relates has consented to its release or unless it meets criteria outlined "
-"in section 8(2) of the Privacy Act.</li>\n"
-"<li><b>Official Languages</b> - The data or information resource is available "
-"in both official languages and conforms to the requirements of the "
-"<a href='https://laws-lois.justice.gc.ca/eng/acts/O-3.01/'><u>Official Languages Act</u></a>.</li>\n"
-"<li><b>Security</b> - The data or information resource does not increase "
-"security risks to the institution, to other institutions, or to the government "
-"as a whole and conforms to the requirements of the "
-"<a href='https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=16578'><u>Policy on Government Security</u></a> and its related instruments.</li>\n"
-"<li><b>Other - Legal / Regulatory / Policy / Contractual</b> - The release of "
-"data or other information resource complies with all other relevant legal, regulatory, "
-"contractual, and policy requirements (e.g., it is confirmed that there are no "
-"relevant legal, contractual, or third party, policy restrictions or limitations).</li>\n"
-"</ol>\n"
-"</small>"
-msgstr ""
-"<small class='text-info' style='margin-bottom: 15px; display: inline-block'>"
-"<p>A-t-on obtenu l’approbation? En sélectionnant << oui >>, vous avez fait"
-" certain que les énoncés suivants sont vrais:</p>"
-"<ol>"
-"<li><b>Confidentialité</b> -  Les ressources en données ou"
-" documentaires ne sont pas assujetties à aucune restriction"
-" liée à la confidentialité, comme les documents confidentiels du Cabinet,"
-" le secret professionnel de l’avocat, les renseignements"
-" , conseils ou recommandations classifiés ou protégés,"
-" les renseignements"
-" de tiers ou les renseignements obtenus à titre confidentiel.</li>"
-"<li><b>Autorisation de diffuser</b> - L’institution a le"
-" mandat, l’autorisation législative ou la permission d’un fournisseur tiers"
-" de publier les ressources en données ou documentaires en vertu de la"
-" <a href='https://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada'>"
-"<u>Licence du gouvernement ouvert – Canada</u></a>.</li>"
-"<li><b>Formats</b> - Les ressources en données ou documentaires sont"
-" dans un format ouvert et accessible qui est conforme à la"
-" <a href='https://www.tbs-sct.gc.ca/pol/doc-fra.aspx?id=23601'><u>"
-"Norme sur l’accessibilité des sites Web</u></a>.</li>"
-"<li><b>Protection des renseignements personnels</b> - Les ressources en données"
-" ou documentaires ne contiennent pas des renseignements personnels, au"
-" sens de l’article 3 de la <a href='https://www.priv.gc.ca/fr/sujets-lies"
-"-a-la-protection-de-la-vie-privee/lois-sur-la-protection-des-renseignements"
-"-personnels-au-canada/la-loi-sur-la-protection-des-renseignements-personnels/'>"
-"<u>Loi sur la protection des renseignements personnels</u></a>, à moins que"
-" la personne concernée n’ait consenti à leur divulgation ou que les renseignements personnels ne"
-" répondent aux critères énoncés au paragraphe 8(2) de cette même Loi.</li>"
-"<li><b>Langues officielles</b> - Les ressources en"
-" données ou documentaires sont disponibles dans les deux"
-" langues officielles et sont conformes aux exigences de"
-" la <a href='https://laws-lois.justice.gc.ca/fra/lois/O-3.01/'>"
-"<u>Loi sur les langues officielles</u></a>.</li>"
-"<li><b>Sécurité</b> - Les ressources en données ou"
-" documentaires n’augmentent pas les risques à la sécurité"
-" de l’institution, des autres institutions ou du gouvernement"
-" dans son ensemble et sont conformes aux exigences de la"
-" <a href='https://www.tbs-sct.gc.ca/pol/doc-fra.aspx?id=16578'>"
-"<u>Politique sur la sécurité du gouvernement</u></a> et"
-" de ses instruments connexes.</li>"
-"<li><b>Autres – Aspects juridiques, réglementaires, stratégiques"
-" ou contractuelsl</b> - La diffusion des ressources en données ou d’autres"
-" ressources documentaires est conforme à toutes les autres"
-" exigences juridiques, réglementaires, contractuelles et"
-" stratégiques pertinentes (p. ex., il est confirmé qu’il n’y"
-" a pas de restrictions ou de limitations juridiques,"
-" contractuelles, de tiers ou de stratégiques pertinentes).</li>"
-"</ol>"
-"</small>"
-
-msgid ""
-"This metadata element is machine translated. If you have "
-"questions, contact open-ouvert@tbs-sct.gc.ca"
-msgstr ""
-"Cet élément de métadonnée est traduit automatiquement. "
-"Veuillez communiquer avec open-ouvert@tbs-sct.gc.ca si vous avez des "
-"questions."
-
-msgid "Edit"
-msgstr "Modifier"
-
-msgid "Edit metadata"
-msgstr "Modifier les métadonnées"
-
-msgid "Finish"
-msgstr "Soumettre"
-
-msgid ""
-"This third party metadata element has been translated using an automated "
-"translation tool.  To report any discrepancies please contact open-"
-"ouvert@tbs-sct.gc.ca"
-msgstr ""
-"Cet élément de métadonnées provenant d’une tierce partie a été traduit à "
-"l'aide d'un outil de traduction automatisée. Pour signaler toute "
-"anomalie, veuillez communiquer avec nous à open-ouvert@tbs-sct.gc.ca"
-
+#: ckanext/canada/templates/public/package/read.html:97
+#: ckanext/canada/templates/public/snippets/package_item.html:67
 msgid "Issued by"
 msgstr "Publiée par"
 
-msgid "Provincial"
-msgstr "Provinciale"
+#: ckanext/canada/templates/public/package/read.html:133
+msgid "Related Items"
+msgstr "Articles connexes"
 
-msgid "Federal"
-msgstr "Fédérale"
+#: ckanext/canada/templates/public/package/read.html:150
+msgid "Geographic Information"
+msgstr "Renseignements géographiques"
 
-msgid "Update Record"
-msgstr "Mettre à jour les données"
+#: ckanext/canada/templates/public/package/read.html:185
+msgid "Contact Information"
+msgstr "Coordonnées"
 
-msgid ""
-"Please note that the Open Information Portal contains a sample of government "
-"of Canada publications and information resources. For more resources, please "
-"visit <a href=\"http://publications.gc.ca/\">Government of Canada "
-"Publications</a> and <a href=\"http://www.bac-lac.gc.ca/\">Library and "
-"Archives Canada</a>."
-msgstr ""
-"Veuillez noter que le Portail d’information ouverte contient un échantillon "
-"de publications et de ressources d’information du gouvernement du Canada. "
-"Pour consulter d’autres ressources, veuillez visiter <a href=\"http://"
-"publications.gc.ca/\">Publications du gouvernement du Canada</a> et <a href="
-"\"http://www.bac-lac.gc.ca/Pages/default.aspx\">Bibliothèque et Archives "
-"Canada</a>."
-
-msgid "You may select or deselect multiple entries (Ctrl+Click)."
-msgstr "Vous pouvez sélectionner ou désélectionner de multiples entrées."
-
-msgid "Record %s Updated"
-msgstr "Dossier %s mis à jour"
-
-msgid "Proactive Disclosure - Briefing Note Titles and Numbers"
-msgstr "Divulgation proactive - titres et numéros des notes d’information"
-
-msgid ""
-"Access, upload and modify the Briefing Note Titles and Numbers reports for "
-"your organization"
-msgstr ""
-"Accès, téléversement et modifications des rapports sur les titres at numéros "
-"des notes d’information pour votre organisation"
-
-msgid "Proactive Disclosure - Question Period Notes"
-msgstr "Divulgation proactive - Notes pour la période des questions"
-
-msgid "Access, upload and modify the Question Period Notes for your organization"
-msgstr "Accès, téléversement et modifications des notes pour la période des questions pour votre organisation"
-
-msgid "Use of Administrative Aircraft"
-msgstr "Utilisation des avions d'affaires"
-
-msgid "Proactive Disclosure - Use of Administrative Aircraft"
-msgstr "Divulgation proactive - Utilisation des avions d'affaires"
-
-msgid "Access, upload and modify government administrative aircraft use"
-msgstr "Accès, téléversement et modifications des rapports sur la utilisation des avions d'affaires"
-
-msgid "Create Record"
-msgstr "Créer un dossier"
-
-msgid "Access, upload and modify Question Period notes for your organization"
-msgstr "Accès, téléversement et modifications des notes de la période de questions pour votre organisation"
-
-msgid "National Action Plan on Open Government Tracker"
-msgstr ""
-"Outil de suivi pour le Plan d'action national pour un gouvernement ouvert"
-
-msgid "5th National Action Plan on Open Government Tracker"
-msgstr ""
-"Outil de suivi pour le 5ᵉ Plan d'action national pour un gouvernement ouvert"
-
-msgid ""
-"Access, upload and modify the National Action Plan on Open Government "
-"Tracker for your organization"
-msgstr ""
-"Accès, téléversement et Modifier le outil de suivi pour le Plan d'action "
-"national pour un gouvernement ouvert pour votre organisation"
-
-msgid "Experimentation Inventory"
-msgstr "Répertoire d'expérimentation"
-
-msgid "This field must be populated with an NA if an amendment is disclosed under Instrument Type."
-msgstr "Ce champ doit contenir NA si une modification est divulguée sous l’élément Type d’instrument."
-
-msgid "If N/A, then Instrument Type must be identified as a standing offer/supply arrangement (SOSA)"
-msgstr "Si N/A, alors le Type d’instrument doit être identifié comme étant une offre à commandes ou un arrangement en matière d’approvisionnement (SOSA)."
-
-msgid "If the value XX (none) is entered, then no other value can be entered in this field."
-msgstr "Si la valeur XX (aucun) est inscrite, alors aucune autre valeur ne peut être inscrite dans ce champ."
-
-msgid "If the value NA (not applicable) is entered, then no other value can be entered in this field."
-msgstr "Si la valeur NA (sans objet) est inscrite, alors aucune autre valeur ne peut être inscrite dans ce champ."
-
-msgid "This field must be NA (not applicable) if the Trade Agreement field is not XX (none)."
-msgstr "Ce champ doit être NA (aucune) si les champs Accord commercial ne contiennent pas la valeur XX (aucun)."
-
-msgid "If the value 00 (none) is entered, then no other value can be entered in this field."
-msgstr "Si la valeur 00 (aucune) est inscrite, alors aucune autre valeur ne peut être inscrite dans ce champ."
-
-msgid "This field must contain the first three digits of a postal code in A1A format or the value \"NA\""
-msgstr "Ce champ doit contenir les trois premiers chiffres d’un code postal dans le format A1A ou la valeur « NA. »"
-
-msgid "This field must be N, No or Non, if the Agreement Type or Trade Agreement field is not 0 (none) or XX (none), as applicable."
-msgstr "Ce champ doit être N, No ou Non, si les champs Type d’accord ou Accord commercial ne contiennent pas la valeur 0 (aucun) ou XX (aucun), le cas échéant."
-
-msgid "This field must be N, No or Non, if the Procurement Strategy for Aboriginal Business field is MS or VS."
-msgstr "Ce champ doit être N, No ou Non, si le champ Stratégie d’approvisionnement auprès des entreprises autochtones contient MS ou VS."
-
-msgid "This field must be populated with a 1 if the solicitation procedure is identified as non-competitive (TN) or Advance Contract Award Notice (AC)."
-msgstr "Cette zone doit contenir un « 1 » si la méthode d’invitation à soumissionner est identifiée comme étant non concurrentielle (TN) ou un préavis d’attribution de contrat (AC)."
-
-msgid "If this field is populated, it must be with a “0” if the procurement was identified as non-competitive (TN) or advance contract award notice (AC) or was identified as an Amendment (A) in the Instrument type data field."
-msgstr "Si cette zone est remplie, il doit contenir un « 0 » si l’acquisition a été identifiée comme étant non concurrentielle (TN) ou un préavis d’attribution de contrat (AC) ou si l’acquisition a été identifiée comme un modification (A) dans le champ Type d’instrument."
-
-msgid "If this field is populated, it must be with a 1,2,3,4 or 5 if the procurement was identified as Open Bidding (OB), Selective Tendering (ST) or Traditional Competitive (TC)."
-msgstr "Si Cette zone est remplie, il doit contenir un 1, 2, 3, 4 ou 5 si l’acquisition a été identifiée comme étant OB : Concurrentielle – Invitation ouverte à soumissionner (SEAOG), ST : Concurrentielle – Appel d’offres sélectif ou TC : Concurrentielle – Traditionnelle."
-
-msgid "Commodity Type of G for Goods which requires a Delivery Date and not a Contract Period Start Date. Please either change the Commodity Type to S or remove the date from the Contract Period Start Date field"
-msgstr "Type de produit G pour les biens, ce qui requière une Date de livraison et non une Date de début du marché. Prière de changer le Type de produit pour S ou de retirer la date du champ Date de début du marché"
-
-msgid "If “TC” (Competitive - Traditional), “TN” (Non-Competitive) or “AC” (Advanced Contract Award Notice) is selected and trade agreement with a value other than “XX” (None) is selected, limited tendering cannot have a value of “0” or “00” (None)."
-msgstr "Si les options « TC » (Concurrentielle - Traditionnelle), « TN » (non concurrentielle) ou « AC » (préavis d’attribution de contrat) sont sélectionnées et qu’une entente de marché ayant une valeur autre que « XX » (nulle) est sélectionnée, le champ Appel d’offres restreint ne peut avoir la valeur « 0 » ou « 00 » (nulle)."
-
-msgid "If “AC” (Advanced Contract Award Notice) or “TN” (Non-competitive) is selected, Award Criteria must have a value of “0” (Not applicable)."
-msgstr "Si les options « AC » (préavis d’attribution de contrat) ou « TN » (non concurrentielle) sont sélectionnées, le champ Critère de mérite doit avoir une valeur de « 0 » (sans objet)."
-
-msgid "If “OB” (Competitive – Open bidding), “ST” (Selective Tendering) or “TC” (Competitive – Traditional) is selected, section 6 Government Contracts Regulations Exceptions must have a value of “0”."
-msgstr "Si les options « OB » (Concurrentielle – appel d’offres ouvert), « ST » (mise en concurrence) ou « TC » (Concurrentielle – Traditionnelle) sont sélectionnées, la section 6 des exceptions au Règlement sur les marchés de l’État doit avoir une valeur de « 0 »."
-
-msgid ""
-"If TC, TN or AC is selected in the Solicitation Procedure data field with a value other than XX (None) selected in the Trade Agreement data field, then a Limited Tendering value other than 00 (none) must be entered."
-msgstr ""
-"Si TC, TN ou AC est sélectionné dans le champ de données Méthode d’invitation à soumissioner avec une valeur autre que XX (Aucune) sélectionnée dans le champ de données Accord commercial, une valeur d'offre limitée autre que 0 (aucune) doit être entrée."
-
-msgid ""
-"This field may only be populated with “0” if the procurement was identified as competitive (open bidding (OB), traditional competitive (TC) or selective tendering (ST))."
-msgstr ""
-"Cette zone peut seulement contenir « 0 » si l’acquisition a été identifiée comme étant concurrentielle (invitation ouverte à soumissionner (OB) ou concurrentielle - traditionnelle (TC) ou Concurrentielle – Appel d’offres sélectif (ST))."
-
-msgid "This must list the year you are reporting on (not the fiscal year)."
-msgstr "Veuillez indiquer l’année civile visée par le rapport."
-
-msgid ""
-"Access, upload and modify the Experimentation Inventory for your organization"
-msgstr ""
-"Accès, téléversement et modifier le répertoire d'expérimentation pour votre "
-"organisation"
-
-msgid "This field is limited to only 3 or 4 digits."
-msgstr "Ce champ est limité à 3 ou 4 caractères."
-
-msgid "The field is limited to eight alpha-numeric digits or less."
-msgstr "Ce champ est limité à 8 caractères alphanumériques."
-
-#: ckanext/GCWeb/templates/error_document_template.html:11
-#: ckanext/wet_boew/templates/error_document_template.html:6
-msgid "We couldn't find that Web page"
-msgstr "Nous ne pouvons trouver cette page Web"
-
-#: ckanext/GCWeb/templates/error_document_template.html:15
-msgid "Error"
-msgstr "Erreur"
-
-#: ckanext/GCWeb/templates/error_document_template.html:21
-msgid ""
-"We're sorry you ended up here. Sometimes a page gets moved or deleted, but "
-"hopefully we can help you find what you're looking for. What next?"
-msgstr ""
-"Nous sommes désolés que vous ayez abouti ici. Il arrive parfois qu'une page "
-"ait été déplacée ou supprimée. Heureusement, nous pouvons vous aider à "
-"trouver ce que vous cherchez. Que faire?"
-
-#: ckanext/GCWeb/templates/error_document_template.html:24
-msgid "Return to the <a href=\"https://www.canada.ca/en.html\">home page</a>;"
-msgstr ""
-"Retournez à la <a href=\"http://www.canada.ca/fr/index.html\">page "
-"d'accueil</a>;"
-
-#: ckanext/GCWeb/templates/error_document_template.html:25
-msgid "Consult the <a href=\"/en/sitemap.html\">site map</a>;"
-msgstr ""
-"Consultez le <a href=\"http://www.canada.ca/fr/plan.html\">plan du site</a>;"
-
-#: ckanext/GCWeb/templates/error_document_template.html:26
-msgid ""
-"Check out the <a href=\"http://www.collectionscanada.gc.ca/012/012-412.01-e."
-"html\" rel=\"external\">Government of Canada Web Archive</a> to view an "
-"older version; or"
-msgstr ""
-"Vérifiez dans les <a href=\"http://www.collectionscanada.gc."
-"ca/012/012-412.01-f.html\" rel=\"external\">Archives Web du gouvernement du "
-"Canada</a> s’il existe une version antérieure;"
-
-#: ckanext/GCWeb/templates/error_document_template.html:27
-msgid "<a href=\"/en/contact.html\">Contact us</a> and we'll help you out."
-msgstr ""
-"<a href=\"http://www.canada.ca/fr/contact/index.html\">Contactez-nous</a> "
-"pour de l'assistance."
-
-#: ckanext/GCWeb/templates/footer.html:4
-msgid "About government"
-msgstr "Au sujet du gouvernement"
-
-#: ckanext/GCWeb/templates/footer.html:6
-msgid "https://www.canada.ca/en/contact.html"
-msgstr "https://www.canada.ca/fr/contact.html"
-
-#: ckanext/GCWeb/templates/footer.html:6
-#: ckanext/wet_boew/templates/footer.html:17
-msgid "Contact us"
-msgstr "Contactez-nous"
-
-#: ckanext/GCWeb/templates/footer.html:7
-msgid "https://www.canada.ca/en/government/dept.html"
-msgstr "https://www.canada.ca/fr/gouvernement/min.html"
-
-#: ckanext/GCWeb/templates/footer.html:7
-msgid "Departments and agencies"
-msgstr "Ministères et organismes"
-
-#: ckanext/GCWeb/templates/footer.html:8
-msgid "https://www.canada.ca/en/government/publicservice.html"
-msgstr "https://www.canada.ca/fr/gouvernement/fonctionpublique.html"
-
-#: ckanext/GCWeb/templates/footer.html:8
-msgid "Public service and military"
-msgstr "Fonction publique et force militaire"
-
-#: ckanext/GCWeb/templates/footer.html:9
-msgid "https://www.canada.ca/en/news.html"
-msgstr "https://www.canada.ca/fr/nouvelles.html"
-
-#: ckanext/GCWeb/templates/footer.html:9
-#: ckanext/wet_boew/templates/footer.html:13
-msgid "News"
-msgstr "Nouvelles"
-
-#: ckanext/GCWeb/templates/footer.html:10
-msgid "https://www.canada.ca/en/government/system/laws.html"
-msgstr "https://www.canada.ca/fr/gouvernement/systeme/lois.html"
-
-#: ckanext/GCWeb/templates/footer.html:10
-msgid "Treaties, laws and regulations"
-msgstr "Traités, lois et règlements"
-
-#: ckanext/GCWeb/templates/footer.html:11
-msgid "https://www.canada.ca/en/transparency/reporting.html"
-msgstr "https://www.canada.ca/fr/transparence/rapports.html"
-
-#: ckanext/GCWeb/templates/footer.html:11
-msgid "Government-wide reporting"
-msgstr "Rapports à l'échelle du gouvernement"
-
-#: ckanext/GCWeb/templates/footer.html:12
-msgid "https://www.canada.ca/en/news.html"
-msgstr "https://www.canada.ca/fr/nouvelles.html"
-
-#: ckanext/GCWeb/templates/footer.html:12
-msgid "Prime Minister"
-msgstr "Premier ministre"
-
-#: ckanext/GCWeb/templates/footer.html:12
-msgid "http://pm.gc.ca/eng"
-msgstr "http://pm.gc.ca/fr"
-
-#: ckanext/GCWeb/templates/footer.html:13
-msgid "https://www.canada.ca/en/government/system.html"
-msgstr "https://www.canada.ca/fr/gouvernement/systeme.html"
-
-#: ckanext/GCWeb/templates/footer.html:13
-msgid "https://open.canada.ca/en"
-msgstr "https://open.canada.ca/fr"
-
-#: ckanext/GCWeb/templates/footer.html:13
-msgid "How government works"
-msgstr "Comment le gouvernement fonctionne"
-
-#: ckanext/GCWeb/templates/footer.html:14
-msgid "http://open.canada.ca/en/"
-msgstr "http://ouvert.canada.ca/"
-
-#: ckanext/GCWeb/templates/footer.html:21
-#: ckanext/GCWeb/templates/footer.html:32
-#: ckanext/wet_boew/templates/footer.html:4
-msgid "About this site"
-msgstr "À propos de ce site"
-
-#: ckanext/GCWeb/templates/footer.html:23
-msgid "https://www1.canada.ca/en/contact/feedback.html"
-msgstr "https://www1.canada.ca/fr/contact/retroaction.html"
-
-#: ckanext/GCWeb/templates/footer.html:23
-msgid "Feedback"
-msgstr "Rétroaction"
-
-#: ckanext/GCWeb/templates/footer.html:24
-msgid "https://www.canada.ca/en/social.html"
-msgstr "https://www.canada.ca/fr/sociaux.html"
-
-#: ckanext/GCWeb/templates/footer.html:24
-msgid "Social media"
-msgstr "Médias sociaux"
-
-#: ckanext/GCWeb/templates/footer.html:25
-msgid "https://www.canada.ca/en/mobile.html"
-msgstr "https://www.canada.ca/fr/mobile.html"
-
-#: ckanext/GCWeb/templates/footer.html:25
-msgid "Mobile applications"
-msgstr "Applications mobiles"
-
-#: ckanext/GCWeb/templates/footer.html:26
-msgid "https://www1.canada.ca/fr/nouveausite.html"
-msgstr "https://www1.canada.ca/fr/nouveausite.html"
-
-#: ckanext/GCWeb/templates/footer.html:26
-msgid "About Canada.ca"
-msgstr "À propos de Canada.ca"
-
-#: ckanext/GCWeb/templates/footer.html:27
-msgid "https://www.canada.ca/en/transparency/terms.html"
-msgstr "https://www.canada.ca/fr/transparence/avis.html"
-
-#: ckanext/GCWeb/templates/footer.html:27
-msgid "Terms and conditions"
-msgstr "Avis"
-
-#: ckanext/GCWeb/templates/footer.html:28
-msgid "https://www.canada.ca/en/transparency/privacy.html"
-msgstr "https://www.canada.ca/fr/transparence/confidentialite.html"
-
-#: ckanext/GCWeb/templates/footer.html:28
-#: ckanext/wet_boew/templates/footer.html:16
-msgid "Privacy"
-msgstr "Confidentialité"
-
-#: ckanext/GCWeb/templates/footer.html:35
-#: ckanext/theme_gc_intranet/templates/snippets/wet-boew/brand.html:10
-msgid "Symbol of the Government of Canada"
-msgstr "Symbole du gouvernement du Canada"
-
-#: ckanext/GCWeb/templates/header.html:15
-#: ckanext/GCWeb/templates/header.html:17
-#: ckanext/wet_boew/templates/header.html:15
-#: ckanext/wet_boew/templates/header.html:17
-#: ckanext/wet_boew/templates/header.html:18
-msgid "Search and menus"
-msgstr "Recherche et menus"
-
-#: ckanext/GCWeb/templates/header.html:24
-#: ckanext/GCWeb/templates/header.html:35
-#: ckanext/theme_gc_intranet/templates/header.html:28
-#: ckanext/wet_boew/templates/header.html:37
-#: ckanext/wet_boew/templates/header.html:44
-#: ckanext/wet_boew/templates/home/snippets/search.html:11
-#: ckanext/wet_boew/templates/snippets/search_form.html:24
-#: ckanext/wet_boew/templates/user/snippets/followee_dropdown.html:20
-#: ckanext/wet_boew/templates/user/snippets/followee_dropdown.html:24
-msgid "Search"
-msgstr "Rechercher"
-
-#: ckanext/GCWeb/templates/header.html:27
-msgid "Search website"
-msgstr "Recherchez le site Web"
-
-#: ckanext/GCWeb/templates/header.html:28
-msgid "Search Canada.ca"
-msgstr "Rechercher dans Canada.ca"
-
-#: ckanext/GCWeb/templates/header.html:46
-#: ckanext/wet_boew/templates/header.html:56
-msgid "Site menu"
-msgstr "Menu du site"
-
-#: ckanext/GCWeb/templates/header.html:50
-msgid "http://www.esdc.gc.ca/en/jobs/index.page"
-msgstr "http://www.edsc.gc.ca/fr/emplois/index.page"
-
-#: ckanext/GCWeb/templates/header.html:51
-msgid "http://www.cic.gc.ca/english/index.asp"
-msgstr "http://www.cic.gc.ca/francais/index.asp"
-
-#: ckanext/GCWeb/templates/header.html:51
-msgid "Immigration"
-msgstr "Immigration"
-
-#: ckanext/GCWeb/templates/header.html:52
-msgid "http://travel.gc.ca"
-msgstr "https://voyage.gc.ca/"
-
-#: ckanext/GCWeb/templates/header.html:53
-msgid "http://www.canada.ca/en/services/business/index.html"
-msgstr "https://www.canada.ca/fr/services/entreprises.html"
-
-#: ckanext/GCWeb/templates/header.html:53
-msgid "Business"
-msgstr "Entreprises"
+#: ckanext/canada/templates/public/package/read.html:187
+msgid "Delivery Point"
+msgstr "Point de livraison"
 
-#: ckanext/GCWeb/templates/header.html:54
-msgid "http://www.canada.ca/en/services/benefits/index.html"
-msgstr "https://www.canada.ca/fr/services/prestations.html"
+#: ckanext/canada/templates/public/package/read.html:190
+msgid "City"
+msgstr "Ville"
 
-#: ckanext/GCWeb/templates/header.html:54
-msgid "Benefits"
-msgstr "Prestations"
+#: ckanext/canada/templates/public/package/read.html:193
+msgid "Administrative Area"
+msgstr "Zone administrative"
 
-#: ckanext/GCWeb/templates/header.html:55
-msgid "http://healthycanadians.gc.ca/index-eng.php"
-msgstr "http://canadiensensante.gc.ca/index-fra.php"
+#: ckanext/canada/templates/public/package/read.html:196
+msgid "Postal Code"
+msgstr "Code postal"
 
-#: ckanext/GCWeb/templates/header.html:56
-msgid "http://www.canada.ca/en/services/taxes/index.html"
-msgstr "https://www.canada.ca/fr/services/impots.html"
+#: ckanext/canada/templates/public/package/read.html:199
+msgid "Country"
+msgstr "Pays"
 
-#: ckanext/GCWeb/templates/header.html:56
-msgid "Taxes"
-msgstr "Impôts"
+#: ckanext/canada/templates/public/package/read.html:202
+msgid "Electronic Mail Address"
+msgstr "Adresse de courrier électronique"
 
-#: ckanext/GCWeb/templates/header.html:57
-msgid "http://www.canada.ca/en/services/index.html"
-msgstr "https://www.canada.ca/fr/services.html"
+#: ckanext/canada/templates/public/package/read.html:231
+msgid "Similar records"
+msgstr "Dossiers similaires"
 
-#: ckanext/GCWeb/templates/header.html:57
-msgid "More services"
-msgstr "Autres services"
+#: ckanext/canada/templates/public/package/read_base.html:29
+msgid "{record_title} - Open Data Portal - Open Data"
+msgstr "{record_title} - Portail des données ouvertes - Données ouvertes"
 
-#: ckanext/GCWeb/templates/snippets/wet-boew/brand.html:3
-#: ckanext/theme_gc_intranet/templates/header.html:10
-msgid "Government of Canada"
-msgstr "Gouvernement du Canada"
+#: ckanext/canada/templates/public/package/read_base.html:43
+#: ckanext/canada/templates/public/scheming/package/resource_read.html:7
+#, fuzzy
+msgid "Additional Information"
+msgstr "Informations supplémentaires en français"
 
-#: ckanext/GCWeb/templates/snippets/wet-boew/languagetoggle.html:2
-#: ckanext/theme_gc_intranet/templates/snippets/wet-boew/languagetoggle.html:2
-#: ckanext/wet_boew/templates/snippets/wet-boew/languagetoggle.html:2
-msgid "Language selection"
-msgstr "Sélection de la langue"
+#: ckanext/canada/templates/public/package/read_base.html:72
+msgid "Temporal Coverage"
+msgstr "Couverture temporelle"
 
-#: ckanext/wet_boew/plugins.py:148
-#: ckanext/wet_boew/templates/package/snippets/resource_form.html:8
-msgid "Previous"
-msgstr "Précédent"
+#: ckanext/canada/templates/public/package/read_base.html:75
+msgid "to"
+msgstr "à"
 
-#: ckanext/wet_boew/templates/footer.html:5
-msgid "About {0}"
-msgstr " propos de {0}"
+#: ckanext/canada/templates/public/package/read_base.html:77
+msgid "to undefined"
+msgstr "à non défini"
 
-#: ckanext/wet_boew/templates/footer.html:7
-msgid "Terms and Conditions"
-msgstr "Avis"
+#: ckanext/canada/templates/public/package/read_base.html:79
+msgid "undefined to"
+msgstr "non défini à"
 
-#: ckanext/wet_boew/templates/footer.html:8
-msgid "Accessibility"
-msgstr "Accessibilité"
+#: ckanext/canada/templates/public/package/read_base.html:109
+msgid "About this Record"
+msgstr "Au sujet de ce dossier"
 
-#: ckanext/wet_boew/templates/footer.html:9
-msgid "Code of conduct"
-msgstr ""
-
-#: ckanext/wet_boew/templates/footer.html:10
-msgid "Moderation policy"
-msgstr ""
-
-#: ckanext/wet_boew/templates/footer.html:15
-msgid "FAQ"
-msgstr ""
-
-#: ckanext/wet_boew/templates/header.html:41
-msgid "Search Your Data"
-msgstr "Rechercher dans vos données"
-
-#: ckanext/wet_boew/templates/header.html:71
-msgid "You are here:"
-msgstr "Vous êtes içi :"
-
-#: ckanext/wet_boew/templates/page.html:40
-#: ckanext/wet_boew/templates/home/about.html:3
-#: ckanext/wet_boew/templates/home/about.html:6
-#: ckanext/wet_boew/templates/organization/about.html:4
-#: ckanext/wet_boew/templates/user/edit_user_form.html:16
-msgid "About"
-msgstr "À propos"
-
-#: ckanext/wet_boew/templates/activity_streams/activity_stream_items.html:19
-msgid "Load less"
-msgstr ""
-
-#: ckanext/wet_boew/templates/admin/config.html:12
-msgid "Are you sure you want to reset the config?"
-msgstr ""
-
-#: ckanext/wet_boew/templates/admin/config.html:13
-msgid "Update Config"
-msgstr ""
-
-#: ckanext/wet_boew/templates/admin/config.html:14
-msgid "Reset"
-msgstr ""
-
-#: ckanext/wet_boew/templates/admin/config.html:25
-msgid "CKAN config options"
-msgstr ""
-
-#: ckanext/wet_boew/templates/admin/config.html:33
-#, python-format
-msgid ""
-" <p><strong>Site Title:</strong> This is the title of this CKAN instance It "
-"appears in various places throughout CKAN.</p> <p><strong>Style:</strong> "
-"Choose from a list of simple variations of the main colour scheme to get a "
-"very quick custom theme working.</p> <p><strong>Site Tag Logo:</strong> This "
-"is the logo that appears in the header of all the CKAN instance templates.</"
-"p> <p><strong>About:</strong> This text will appear on this CKAN instances "
-"<a href=\"%(about_url)s\">about page</a>.</p> <p><strong>Intro Text:</"
-"strong> This text will appear on this CKAN instances <a href=\"%(home_url)s"
-"\">home page</a> as a welcome to visitors.</p> <p><strong>Custom CSS:</"
-"strong> This is a block of CSS that appears in <code>&lt;head&gt;</code> tag "
-"of every page. If you wish to customize the templates more fully we "
-"recommend <a href=\"%(docs_url)s\" target=\"_blank\">reading the "
-"documentation</a>.</p> <p><strong>Homepage:</strong> This is for choosing a "
-"predefined layout for the modules that appear on your homepage.</p> "
-msgstr ""
-
-#: ckanext/wet_boew/templates/admin/index.html:18
-msgid "Administer CKAN"
-msgstr ""
-
-#: ckanext/wet_boew/templates/admin/index.html:24
-#, python-format
-msgid ""
-" <p>As a sysadmin user you have full control over this CKAN instance. "
-"Proceed with care!</p> <p>For guidance on using sysadmin features, see the "
-"CKAN <a href=\"%(docs_url)s\" target=\"_blank\">sysadmin guide</a></p> "
-msgstr ""
-
-#: ckanext/wet_boew/templates/admin/trash.html:26
-msgid "Purge"
-msgstr ""
-
-#: ckanext/wet_boew/templates/admin/trash.html:42
-msgid " <p>Purge deleted datasets forever and irreversibly.</p> "
-msgstr ""
-
-#: ckanext/wet_boew/templates/ckan/package/snippets/revisions_table.html:7
-msgid "Revision"
-msgstr ""
-
-#: ckanext/wet_boew/templates/ckan/package/snippets/revisions_table.html:8
-msgid "Timestamp"
-msgstr ""
-
-#: ckanext/wet_boew/templates/ckan/package/snippets/revisions_table.html:9
-#: ckanext/wet_boew/templates/package/snippets/additional_info.html:20
-#: ckanext/wet_boew/templates/package/snippets/additional_info.html:25
-#: ckanext/wet_boew/templates/package/snippets/additional_info2.html:16
-#: ckanext/wet_boew/templates/package/snippets/additional_info2.html:21
-msgid "Author"
-msgstr ""
-
-#: ckanext/wet_boew/templates/ckan/package/snippets/revisions_table.html:10
-msgid "Log Message"
-msgstr ""
-
-#: ckanext/wet_boew/templates/ckan/package/snippets/revisions_table.html:29
-#, python-format
-msgid "Read dataset as of %s"
-msgstr ""
-
-#: ckanext/wet_boew/templates/group/snippets/group_item.html:14
-#: ckanext/wet_boew/templates/organization/snippets/organization_item.html:13
-msgid "View {name}"
-msgstr ""
-
-#: ckanext/wet_boew/templates/group/snippets/helper.html:4
-msgid "What are Groups?"
-msgstr ""
-
-#: ckanext/wet_boew/templates/group/snippets/helper.html:7
-msgid ""
-" Groups allow you to group together datasets under a community (for example, "
-"Civil Liberty data) or topic (e.g. Transport, Health, Environment) to make "
-"it easier for users to browse datasets by theme. Datasets can be part of a "
-"group, but do not belong to the group for editing or authorisation purposes. "
-msgstr ""
-
-#: ckanext/wet_boew/templates/group/snippets/info.html:18
-#: ckanext/wet_boew/templates/snippets/organization.html:20
-#: ckanext/wet_boew/templates/user/read_base.html:22
-msgid "Followers"
-msgstr ""
-
-#: ckanext/wet_boew/templates/home/index.html:3
-msgid "E.g. environment"
-msgstr ""
-
-#: ckanext/wet_boew/templates/home/index.html:5
-msgid "Welcome"
-msgstr ""
-
-#: ckanext/wet_boew/templates/home/index.html:14
-msgid ""
-"This is a nice introductory paragraph about CKAN or the site in general. We "
-"don't have any copy to go here yet but soon we will "
-msgstr ""
-
-#: ckanext/wet_boew/templates/home/snippets/promoted.html:3
-msgid "This is a featured section"
-msgstr ""
-
-#: ckanext/wet_boew/templates/home/snippets/search.html:4
-#: ckanext/wet_boew/templates/home/snippets/search.html:7
-msgid "Search data"
-msgstr ""
-
-#: ckanext/wet_boew/templates/home/snippets/search.html:20
-msgid "Popular tags"
-msgstr ""
-
-#: ckanext/wet_boew/templates/macros/form.html:248
-#: ckanext/wet_boew/templates/snippets/search_form.html:67
-msgid "Remove"
-msgstr "Supprimer"
-
-#: ckanext/wet_boew/templates/macros/form.html:279
-msgid "Custom"
-msgstr ""
-
-#: ckanext/wet_boew/templates/macros/form.html:281
-msgid "(required)"
-msgstr ""
-
-#: ckanext/wet_boew/templates/macros/form.html:308
-msgid "The form contains invalid entries:"
-msgstr "Le formulaire contient des entrées non valides :"
-
-#: ckanext/wet_boew/templates/macros/form.html:413
-msgid "http://example.com/my-image.jpg"
-msgstr ""
-
-#: ckanext/wet_boew/templates/macros/form.html:414
-msgid "Image URL"
-msgstr ""
-
-#: ckanext/wet_boew/templates/macros/form.html:415
-msgid "Image"
-msgstr ""
-
-#: ckanext/wet_boew/templates/macros/form.html:427
-msgid "Clear Upload"
-msgstr ""
-
-#: ckanext/wet_boew/templates/organization/confirm_delete_member.html:8
-msgid "Are you sure you want to delete member - {name}?"
-msgstr ""
-
-#: ckanext/wet_boew/templates/organization/confirm_delete_member.html:12
-#: ckanext/wet_boew/templates/package/confirm_delete.html:12
-#: ckanext/wet_boew/templates/package/confirm_delete_resource.html:11
-msgid "Cancel"
-msgstr ""
-
-#: ckanext/wet_boew/templates/organization/index.html:2
-msgid "Organizations"
-msgstr ""
-
-#: ckanext/wet_boew/templates/organization/member_new.html:11
-msgid "What are roles?"
-msgstr ""
-
-#: ckanext/wet_boew/templates/organization/member_new.html:14
-msgid ""
-" <p><strong>Admin:</strong> Can add/edit and delete datasets, as well as "
-"manage organization members.</p> <p><strong>Editor:</strong> Can add and "
-"edit datasets, but not manage organization members.</p> <p><strong>Member:</"
-"strong> Can view the organization's private datasets, but not add new "
-"datasets.</p> "
-msgstr ""
-
-#: ckanext/wet_boew/templates/organization/members.html:3
-#: ckanext/wet_boew/templates/snippets/organization.html:28
-msgid "Members"
-msgstr ""
-
-#: ckanext/wet_boew/templates/organization/read.html:6
-msgid "Edit Organization"
-msgstr ""
-
-#: ckanext/wet_boew/templates/organization/snippets/helper.html:2
-msgid "What are Organizations?"
-msgstr ""
-
-#: ckanext/wet_boew/templates/organization/snippets/organization_item.html:23
-msgid "This organization has no description"
-msgstr ""
+#: ckanext/canada/templates/public/package/read_base.html:114
+msgid "Record Released"
+msgstr "Dossier publié"
 
-#: ckanext/wet_boew/templates/package/base_form_page.html:10
-msgid ""
-" Datasets are simply used to group related pieces of data. These can then be "
-"found under a single url with a description and licensing information. "
-msgstr ""
-
-#: ckanext/wet_boew/templates/package/confirm_delete.html:9
-msgid "Are you sure you want to delete dataset - {name}?"
-msgstr ""
+#: ckanext/canada/templates/public/package/read_base.html:118
+msgid "Record Modified"
+msgstr "Dossier modifié"
 
-#: ckanext/wet_boew/templates/package/confirm_delete_resource.html:8
-msgid "Are you sure you want to delete resource - {name}?"
-msgstr ""
-
-#: ckanext/wet_boew/templates/package/read.html:29
-#: ckanext/wet_boew/templates/user/read_base.html:50
-#: ckanext/wet_boew/templates/user/read_base.html:61
-msgid "Private"
-msgstr ""
+#: ckanext/canada/templates/public/package/read_base.html:122
+msgid "Record ID"
+msgstr "Identificateur du dossier"
 
-#: ckanext/wet_boew/templates/package/read.html:55
-msgid "Licence"
-msgstr ""
+#: ckanext/canada/templates/public/package/read_base.html:126
+msgid "Metadata"
+msgstr "Métadonnées"
 
-#: ckanext/wet_boew/templates/package/resource_read.html:16
-msgid "Manage"
-msgstr ""
+#: ckanext/canada/templates/public/package/read_base.html:130
+msgid "Link to JSON format"
+msgstr "Lien au format JSON"
 
-#: ckanext/wet_boew/templates/package/resource_read.html:22
-#: ckanext/wet_boew/templates/package/resource_views.html:4
-msgid "View"
+#: ckanext/canada/templates/public/package/read_base.html:136
+msgid "DCAT (JSON-LD)"
 msgstr ""
 
-#: ckanext/wet_boew/templates/package/resource_read.html:24
-msgid "API Endpoint"
+#: ckanext/canada/templates/public/package/read_base.html:143
+msgid "DCAT (XML)"
 msgstr ""
 
-#: ckanext/wet_boew/templates/package/resource_read.html:28
-msgid "Download"
-msgstr ""
+#: ckanext/canada/templates/public/package/read_base.html:151
+msgid "FGP Metadata"
+msgstr "Métadonnées de la PGF"
 
-#: ckanext/wet_boew/templates/package/resource_read.html:44
-#: ckanext/wet_boew/templates/package/resource_read.html:46
-msgid "URL:"
-msgstr ""
+#: ckanext/canada/templates/public/package/read_base.html:153
+msgid "HNAP ISO:19115 Metadata Record"
+msgstr "Enregistrement de métadonnées de HNAP ISO:19115"
 
-#: ckanext/wet_boew/templates/package/resource_read.html:56
-#, python-format
-msgid "Source: <a href=\"%(url)s\">%(dataset)s</a>"
-msgstr ""
+#: ckanext/canada/templates/public/package/resource_read.html:46
+#, fuzzy
+msgid "Data Dictionary"
+msgstr "Validation des données"
 
-#: ckanext/wet_boew/templates/package/resource_read.html:81
-msgid "There're no views created for this resource yet."
-msgstr ""
+#: ckanext/canada/templates/public/package/search.html:15
+msgid "Search Open Government"
+msgstr "Recherche du Gouvernement ouvert"
 
-#: ckanext/wet_boew/templates/package/resource_views.html:28
-msgid "This resource has no views"
+#: ckanext/canada/templates/public/package/search.html:54
+msgid "Please review your spelling, or reduce the number of filters selected."
 msgstr ""
+"S'il vous plaît vérifier l’orthographe, ou réduire le nombre de filtres "
+"sélectionnés."
 
-#: ckanext/wet_boew/templates/package/search.html:5
-#: ckanext/wet_boew/templates/user/dashboard.html:64
-msgid "Add Dataset"
-msgstr ""
+#: ckanext/canada/templates/public/package/snippets/additional_info.html:1
+msgid "Additional Info"
+msgstr "Information additionnelle"
 
-#: ckanext/wet_boew/templates/package/snippets/additional_info.html:5
+#: ckanext/canada/templates/public/package/snippets/additional_info.html:5
 msgid "Field"
 msgstr ""
 
-#: ckanext/wet_boew/templates/package/snippets/additional_info.html:13
-#: ckanext/wet_boew/templates/package/snippets/additional_info2.html:9
+#: ckanext/canada/templates/public/package/snippets/additional_info.html:6
+msgid "Value"
+msgstr "Valeur"
+
+#: ckanext/canada/templates/public/package/snippets/additional_info.html:13
+#: ckanext/canada/templates/public/package/snippets/additional_info2.html:9
 msgid "Source"
 msgstr ""
 
-#: ckanext/wet_boew/templates/package/snippets/additional_info.html:32
-#: ckanext/wet_boew/templates/package/snippets/additional_info.html:37
-#: ckanext/wet_boew/templates/package/snippets/additional_info2.html:28
-#: ckanext/wet_boew/templates/package/snippets/additional_info2.html:33
+#: ckanext/canada/templates/public/package/snippets/additional_info.html:20
+#: ckanext/canada/templates/public/package/snippets/additional_info.html:25
+#: ckanext/canada/templates/public/package/snippets/additional_info2.html:16
+#: ckanext/canada/templates/public/package/snippets/additional_info2.html:21
+msgid "Author"
+msgstr ""
+
+#: ckanext/canada/templates/public/package/snippets/additional_info.html:32
+#: ckanext/canada/templates/public/package/snippets/additional_info.html:37
+#: ckanext/canada/templates/public/package/snippets/additional_info2.html:28
+#: ckanext/canada/templates/public/package/snippets/additional_info2.html:33
 msgid "Maintainer"
 msgstr ""
 
-#: ckanext/wet_boew/templates/package/snippets/additional_info.html:44
-#: ckanext/wet_boew/templates/package/snippets/additional_info2.html:40
+#: ckanext/canada/templates/public/package/snippets/additional_info.html:44
+#: ckanext/canada/templates/public/package/snippets/additional_info2.html:40
 msgid "Version"
 msgstr ""
 
-#: ckanext/wet_boew/templates/package/snippets/additional_info.html:51
-#: ckanext/wet_boew/templates/package/snippets/additional_info2.html:47
+#: ckanext/canada/templates/public/package/snippets/additional_info.html:51
+#: ckanext/canada/templates/public/package/snippets/additional_info2.html:47
 msgid "State"
 msgstr ""
 
-#: ckanext/wet_boew/templates/package/snippets/resource_form.html:4
+#: ckanext/canada/templates/public/package/snippets/resource_form.html:4
 msgid "URL"
 msgstr ""
 
-#: ckanext/wet_boew/templates/package/snippets/resource_form.html:4
+#: ckanext/canada/templates/public/package/snippets/resource_form.html:4
 msgid "http://whatever"
 msgstr ""
 
-#: ckanext/wet_boew/templates/package/snippets/resources_list.html:29
-#, python-format
+#: ckanext/canada/templates/public/package/snippets/resource_form.html:11
+msgid "Save & add another"
+msgstr "Sauvegarder et ajouter une autre ressource ou objet annexe"
+
+#: ckanext/canada/templates/public/package/snippets/resource_item.html:63
+#, fuzzy
+msgid "Go to resource"
+msgstr "Modifier ressources"
+
+#: ckanext/canada/templates/public/package/snippets/resource_item.html:66
+msgid "Download"
+msgstr ""
+
+#: ckanext/canada/templates/public/package/snippets/schemaorg.html:5
+msgid "Government of Canada Open Government Portal"
+msgstr "Gouvernement du Canada site gouvernemental ouvert"
+
+#: ckanext/canada/templates/public/package/snippets/schemaorg.html:19
 msgid ""
-" <p class=\"empty\">This dataset has no data, <a href=\"%(url)s\">why not "
-"add some?</a> "
+"This catalog contains metadata records describing open datasets available"
+" from the Government of Canada"
+msgstr ""
+"Ce catalogue contient des enregistrements de métadonnées décrivant des "
+"ensembles de données ouverts disponibles auprès du gouvernement du Canada"
+
+#: ckanext/canada/templates/public/package/snippets/schemaorg.html:23
+msgid "http://open.canada.ca"
+msgstr "http://ouvert.canada.ca"
+
+#: ckanext/canada/templates/public/package/snippets/schemaorg.html:26
+msgid "Government of Canada, Treasury Board of Canada Secretariat"
+msgstr "Gouvernement du Canada, Secrétariat du Conseil du Trésor du Canada"
+
+#: ckanext/canada/templates/public/package/snippets/schemaorg.html:29
+msgid "Information and Communications Government and Politics"
+msgstr "Information et communications Gouvernement et politique"
+
+#: ckanext/canada/templates/public/package/snippets/schemaorg.html:40
+msgid ""
+"Rights under which the catalog can be reused are outlined in the Open "
+"Government Licence - Canada"
+msgstr ""
+"Les droits sous lesquels le catalogue peut être réutilisé sont décrits "
+"dans la Licence du gouvernement ouvert - Canada"
+
+#: ckanext/canada/templates/public/package/snippets/socialmedia.html:9
+msgid "Provide feedback"
 msgstr ""
 
-#: ckanext/wet_boew/templates/snippets/activity_item.html:3
-msgid "New activity item"
-msgstr ""
-
-#: ckanext/wet_boew/templates/snippets/geomap_dynamic.html:18
-#: ckanext/wet_boew/templates/snippets/geomap_static.html:15
-msgid "Name"
-msgstr "Nom"
-
-#: ckanext/wet_boew/templates/snippets/home_breadcrumb_item.html:1
-msgid "Registry Home"
-msgstr "Accueil du registre"
-
-#: ckanext/wet_boew/templates/snippets/user.html:11
-msgid "Signed in as"
-msgstr "Connecté en tant que"
-
-#: ckanext/wet_boew/templates/snippets/user.html:12
-msgid "View profile"
-msgstr ""
-
-#: ckanext/wet_boew/templates/snippets/wet-boew/skip.html:2
-msgid "Skip to main content"
-msgstr "Passer au contenu principal"
-
-#: ckanext/wet_boew/templates/snippets/wet-boew/skip.html:3
-msgid "Skip to site information"
-msgstr "Passer aux informations sur le site"
-
-msgid "Suggested Dataset"
-msgstr "Jeu de données suggéré"
-
-msgid "Suggested Datasets"
-msgstr "Jeux de données suggérés"
-
-msgid "Access the suggested datasets that your organization has received in order to provide a status update."
-msgstr "Veuillez accéder aux jeux de données proposés que votre organisation a reçus afin de faire le point sur ceux-ci."
-
-msgid "Suggested Datasets - Update Status"
-msgstr "Le point sur les jeux de données proposés"
-
-#: ckanext/canada/templates/internal/snippets/user.html:49
-msgid "Get Help"
-msgstr "Obtenez de l’aide"
-
-#: ckanext/canada/templates/internal/snippets/user.html:49
-msgid "Help using the Open Government Registry"
-msgstr "Aide à l'utilisation du registre du gouvernement ouvert"
-
-msgid "View on Portal"
-msgstr "Consulter le Portail"
-
-msgid "Create an Open Data Record"
-msgstr "Créer un enregistrement de données ouvert"
-
-msgid "Create Information Asset"
-msgstr "Créer un enregistrement d'informations ouvertes"
-
-msgid "Update Status"
-msgstr "Mettre à jour un statut"
-
-msgid "Consultations master dataset"
-msgstr "Données de consultations principals"
-
-msgid "Briefing packages"
-msgstr "Documents d’information"
-
-msgid "New or incoming ministers"
-msgstr "Documents d'information pour les nouveaux ministres"
-
-msgid "New or incoming deputy heads"
-msgstr "Documents d'information pour les nouveaux administrateurs généraux"
-
-msgid "Parliamentary Committee appearances for ministers"
-msgstr "Documents d'information à l'intention des ministres pour les comparutions devant un comité parlementaire"
-
-msgid "Parliamentary Committee appearances for deputy heads"
-msgstr "Documents d'information à l'intention des administrateurs généraux pour les comparutions devant un comité parlementaire"
-
-msgid "Reports Tabled in Parliament"
-msgstr "Rapports déposés au Parlement"
-
-msgid "Acts of Founded Wrongdoing"
-msgstr "Dossiers sur les actes répréhensibles fondés"
-
-msgid "Aggregated Contracts from -$10K to $10K"
-msgstr "Contrats agrégés de -10 000$ à 10 000$"
-
-msgid "Briefing Note Titles and Numbers"
-msgstr "Titres et numéros des notes d’information"
-
-msgid "Contracts over $10,000"
-msgstr "Contrats attribués de plus de 10 000 $"
-
-msgid "Departmental Audit Committee"
-msgstr "Comités ministériels d’audit"
-
-msgid "Grants and Contributions"
-msgstr "Subventions et les contributions"
-
-msgid "Hospitality Expenses"
-msgstr "Dépenses d'accueil"
-
-msgid "Position Reclassification"
-msgstr "Reclassifications de postes"
-
-msgid "Question Period Notes"
-msgstr "Notes pour la période des questions"
-
-msgid "Travel Expenses"
-msgstr "Dépenses de voyage"
-
-msgid "Annual Travel, Hospitality and Conferences"
-msgstr "Dépenses annuelles de voyages, d’accueil, de conférences et d’événements"
-
-msgid "Access, add or modify briefing package information for your new or incoming minister."
-msgstr "Consultez la trousse d’information pour le nouveau ministre, ajoutez-y du contenu ou modifiez-la."
-
-msgid "Access, add or modify briefing package information for your new or incoming deputy head."
-msgstr "Consultez la trousse d’information pour le nouvel administrateur général, ajoutez-y du contenu ou modifiez-la."
-
-msgid "Access, add or modify briefing packages for Parliamentary Committee appearance for your minister."
-msgstr "Consultez la trousse d’information pour la comparution de votre ministre devant un comité parlementaire, ajoutez-y du contenu ou modifiez-la."
-
-msgid "Access, add or modify briefing packages for Parliamentary Committee appearance for your deputy head."
-msgstr "Consultez la trousse d’information pour la comparution de votre administrateur général devant un comité parlementaire, ajoutez-y du contenu ou modifiez-la."
-
-msgid "Access, add or modify your reports tabled in Parliament."
-msgstr "Consultez vos rapports déposés au Parlement, ajoutez-y du contenu ou modifiez-les."
-
-msgid "Date may not be in the future when this record is marked ready to publish"
-msgstr "Une fois que ce document est marqué comme étant prêt à publier, la date ne peut pas être dans le futur"
-
+#: ckanext/canada/templates/public/scheming/display_snippets/email_with_parameters.html:7
 msgid "The following is a question related to the record {url} found on {site}"
 msgstr "La question suivante est liée au dossier {url} qu’on retrouve dans {site}"
 
-msgid "Suggestion Status"
-msgstr "État de la suggestion"
-
-#: ckanext/canada/templates/internal/scheming/snippets/form_field.html
-msgid "Are you sure you want to delete this status?"
-msgstr "Êtes-vous certain de vouloir supprimer cet état?"
-
-msgid "The status has been added / updated for this suggested  dataset. This update will be reflected on open.canada.ca shortly."
-msgstr "L’état a été ajouté/mis à jour pour cet ensemble de données suggéré. Cette mise à jour sera bientôt effectuée dans ouvert.canada.ca."
-
-msgid "These fields have been removed, click save below to update the record with your changes."
-msgstr "Ces champs ont été supprimés. Cliquez sur « Enregistrer » ci-dessous pour mettre à jour le document."
-
-msgid "Your user sessions has timed out due to inactivity"
-msgstr "Vos sessions d’utilisateur ont été interrompues pour cause d’inactivité"
-
-msgid ""
-"If you are currently entering data on this page, you may lose it when submitted. "
-"To avoid this, you can click on the log in button below to log in again in a new tab "
-"without losing your progress and you can then keep working on this page. If you have "
-"any issues please contact <a href=\"mailto:open-ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a>."
+#: ckanext/canada/templates/public/snippets/activity_item.html:3
+msgid "New activity item"
 msgstr ""
-"Si vous êtes en train de consigner des données sur cette page, vous risquez "
-"de les perdre au moment de la soumission. Pour éviter que cela se produise, vous pouvez "
-"cliquer sur le bouton de connexion ci‑dessous pour vous reconnecter dans un nouvel onglet "
-"sans perdre ce que vous avez déjà fait et continuer à travailler sur cette page. Si vous "
-"avez des problèmes, veuillez contacter <a href=\"mailto:open-ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a>."
 
-msgid "Request sent to data owner – awaiting response"
-msgstr "Demande envoyée au propriétaire des données, en attente de réponse"
+#: ckanext/canada/templates/public/snippets/dataset_facets.html:59
+msgid "Viewable on Map"
+msgstr "Visible sur une carte"
 
-# FGP viewer
-msgid "This interactive map requires JavaScript. To view this content please enable JavaScript in your browser or download a browser that supports it."
-msgstr "Cette carte interactive nécessite le JavaScript. Pour visualiser ce contenu, veuillez activer JavaScript dans votre navigateur ou télécharger un navigateur qui le supporte."
+#: ckanext/canada/templates/public/snippets/facet_list.html:49
+#: ckanext/canada/templates/public/snippets/facet_list.html:51
+msgid "Show more"
+msgstr "Afficher plus"
 
-msgid "We’re sorry, your browser version is not supported by Open Maps"
-msgstr "Nous sommes désolés que votre version du navigateur n'est pas supporté par Cartes ouvertes"
+#: ckanext/canada/templates/public/snippets/facet_list.html:54
+#: ckanext/canada/templates/public/snippets/facet_list.html:56
+msgid "Show less"
+msgstr "Afficher moins"
 
-msgid "Access, upload and modify your Departmental Audit Committee members’ remuneration and expenses."
-msgstr "Accès, téléversement et modification de la rémunération et des dépenses des membres de votre Comité ministériel d’audit."
+#: ckanext/canada/templates/public/snippets/geomap_dynamic.html:12
+#: ckanext/canada/templates/public/snippets/geomap_dynamic.html:14
+#: ckanext/canada/templates/public/snippets/geomap_dynamic.html:15
+#: ckanext/canada/templates/public/snippets/geomap_static.html:7
+#: ckanext/canada/templates/public/snippets/geomap_static.html:11
+msgid "Spatial Feature"
+msgstr "Élément spatial"
 
-msgid "This text must be provided in both languages"
-msgstr "Ce texte doit être fourni dans les deux langues"
+#: ckanext/canada/templates/public/snippets/menu.html:2
+#, fuzzy
+msgid "Topics menu"
+msgstr "Menu du site"
 
-#: ckanext/canada/templates/public/ajax_snippets/api_info.html:14
+#: ckanext/canada/templates/public/snippets/organization.html:23
+#, fuzzy
+msgid "read more"
+msgstr "En charger davantage"
+
+#: ckanext/canada/templates/public/snippets/package_item.html:56
+msgid "This dataset has no description"
+msgstr "Aucune description disponible pour cet ensemble de données"
+
+#: ckanext/canada/templates/public/snippets/package_item.html:86
+#: ckanext/canada/templates/public/snippets/package_item.html:99
+#, fuzzy
+msgid "Status"
+msgstr "Contactez-nous"
+
+#: ckanext/canada/templates/public/snippets/package_item.html:94
+#, fuzzy
+msgid "Date"
+msgstr "Date de fin"
+
+#: ckanext/canada/templates/public/snippets/package_item.html:107
+msgid "Resource Formats"
+msgstr "Formats des ressources"
+
+#: ckanext/canada/templates/public/snippets/package_item.html:123
+msgid "Add to Map Cart"
+msgstr "Ajouter au panier de cartes"
+
+#: ckanext/canada/templates/public/snippets/package_item.html:126
+msgid "Remove from Map Cart"
+msgstr "Supprimer du panier"
+
+#: ckanext/canada/templates/public/snippets/search_form.html:6
+#: ckanext/canada/templates/public/snippets/sort_by.html:16
+#: ckanext/canada/templates/public/snippets/sort_by.html:19
+msgid "Name Ascending"
+msgstr "alphabétique croissant"
+
+#: ckanext/canada/templates/public/snippets/search_form.html:6
+#: ckanext/canada/templates/public/snippets/sort_by.html:17
+#: ckanext/canada/templates/public/snippets/sort_by.html:20
+msgid "Name Descending"
+msgstr "alphabétique décroissant"
+
+#: ckanext/canada/templates/public/snippets/search_form.html:19
 msgid ""
-"Further information in the <a "
-"href=\"http://docs.ckan.org/en/latest/maintaining/datastore.html\" "
-"target=\"_blank\">main CKAN Data API and DataStore documentation</a>.</p>"
+"Search for geospatial data or click <b>Add to cart</b> to select multiple"
+" datasets to plot on a single map.<br/>Click <b>View on Map</b> to "
+"visualize and overlay the datasets using a geospatial viewer"
 msgstr ""
-"Plus d'informations dans la <a "
-"href=\"http://docs.ckan.org/en/latest/maintaining/datastore.html\" "
-"target=\"_blank\">documentation principale de l'API CKAN pour les données et du magasin de données</a>.</p>"
+"Rechercher des données géospatiales ou cliquer sur <b>Ajouter au "
+"panier</b> pour sélectionner de multiples jeux de données à tracer sur "
+"une seule carte<br/>Cliquez <b>Afficher la carte</b> pour visualiser et "
+"superposer les jeux de données à l'aide d'une visualisateur géospatiale."
 
+#: ckanext/canada/templates/public/snippets/search_form.html:24
 msgid ""
-"Internet Explorer is no longer being supported within the Open Government Registry. "
-"Some features will not work as expected, including publication of records. Please use"
-" MS Edge or Google Chrome, or contact <a href=\"mailto:open-ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a> for additional support."
+"We will be completing technical work on open.canada.ca, which may create "
+"content and performance issues. If you experience any issues please "
+"notify <a href=\"mailto:open-ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-"
+"sct.gc.ca</a>"
 msgstr ""
-"Internet Explorer n’est plus pris en charge par le Registre du gouvernement ouvert."
-" Par conséquent, certains éléments ne fonctionneront pas comme prévu, y compris la publication de documents."
-" Veuillez utiliser MS Edge ou Google Chrome, ou contacter <a href=\"mailto:open-ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a> pour obtenir une aide supplémentaire."
+"Nous effectuerons des travaux techniques sur le site ouvert.canada.ca qui"
+" pourraient entraîner des problèmes de contenu et de performance. Si vous"
+" éprouvez des problèmes, veuillez en aviser <a href=\"mailto:open-ouvert"
+"@tbs-sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a>"
 
-msgid "Are you sure you want to delete this Organization? Note*: Deleting cannot be performed while public or private datasets belong to this organization."
-msgstr "Voulez-vous vraiment supprimer cette organisation? Remarque* : il n'est pas possible de supprimer une organisation qui détient encore des jeux de données publics ou privés."
-
-msgid "Date format incorrect. Expecting YYYY-MM-DD"
-msgstr "Le format de la date est incorrect. Il devrait être AAAA-MM-JJ"
-
-msgid "Invalid licence"
-msgstr "Licence non valide"
-
-msgid "Are you sure you want to delete this DataStore table and Data Dictionary?"
-msgstr "Voulez-vous vraiment supprimer cette table DataStore et ce dictionnaire de données"
-
-msgid "Delete DataStore table"
-msgstr "Supprimer la table DataStore"
-
-msgid "Data Validation"
-msgstr "Validation des données"
-
-#: ckanext/canada/templates/internal/recombinant/resource_edit.html:19
-#, python-format
+#: ckanext/canada/templates/public/snippets/search_form.html:34
 msgid ""
-"Informal Requests for ATI Records Previously Released are being sent to "
-"<strong>%s.</strong> Please contact <a href=\"mailto:open-ouvert@tbs-"
-"sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a> if that address is no longer "
-"valid."
+"Please note that the Open Information Portal contains a sample of "
+"government of Canada publications and information resources. For more "
+"resources, please visit <a href=\"http://publications.gc.ca/\">Government"
+" of Canada Publications</a> and <a href=\"http://www.bac-"
+"lac.gc.ca/\">Library and Archives Canada</a>."
 msgstr ""
-"Les demandes informelle d'enregistrements ATI précédemment publiés sont envoyées à "
-"<strong>%s.</strong> Veuillez contacter <a href=\"mailto:open-ouvert@tbs-"
-"sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a> si cette adresse n'est plus "
-"valide."
+"Veuillez noter que le Portail d’information ouverte contient un "
+"échantillon de publications et de ressources d’information du "
+"gouvernement du Canada. Pour consulter d’autres ressources, veuillez "
+"visiter <a href=\"http://publications.gc.ca/\">Publications du "
+"gouvernement du Canada</a> et <a href=\"http://www.bac-"
+"lac.gc.ca/Pages/default.aspx\">Bibliothèque et Archives Canada</a>."
 
-#: ckanext/canada/templates/internal/recombinant/resource_edit.html:23
-msgid ""
-"Your organization does not have an Access to Information email on file. "
-"Please contact <a href=\"mailto:open-ouvert@tbs-sct.gc.ca\">open-ouvert"
-"@tbs-sct.gc.ca</a> with the email for your organization's Access to "
-"Information Coordinator."
+#: ckanext/canada/templates/public/snippets/search_form.html:45
+msgid "/en/suggested-datasets"
+msgstr "/fr/jeux-de-donnees-suggeres"
+
+#: ckanext/canada/templates/public/snippets/search_form.html:45
+msgid "Suggest a Dataset"
+msgstr "Proposez un jeu de données"
+
+#: ckanext/canada/templates/public/snippets/search_form.html:52
+msgid "Tally of Cart Items"
+msgstr "Décompte des articles du panier"
+
+#: ckanext/canada/templates/public/snippets/search_form.html:55
+msgid "Empty Cart"
+msgstr "Vider le panier"
+
+#: ckanext/canada/templates/public/snippets/sort_by.html:12
+msgid "Order by"
+msgstr "Trier par"
+
+#: ckanext/canada/templates/public/snippets/sort_by.html:14
+msgid "Relevance"
+msgstr "pertinence"
+
+#: ckanext/canada/templates/public/snippets/user.html:59
+#, fuzzy
+msgid "Register"
+msgstr "Premier ministre"
+
+#: ckanext/canada/templates/public/snippets/activities/deleted_datastore.html:6
+msgid "{actor} {activity_type} for resource \"{resource}\""
 msgstr ""
-"Votre organisation n'a pas d'adresse électronique d'accès à l'information dans ses dossiers. "
-"Veuillez contacter <a href=\"mailto:open-ouvert@tbs-sct.gc.ca\">open-ouvert"
-"@tbs-sct.gc.ca</a> avec l'adresse électronique du coordinateur de l'accès à l'information de "
-"votre organisation."
 
-#: ckanext/canada/templates/internal/user/snippets/search.html:2
-msgid "Search Users"
-msgstr "Rechercher des utilisateurs"
+#: ckanext/canada/templates/public/snippets/wet-boew/brand.html:4
+msgid "Government of Canada"
+msgstr "Gouvernement du Canada"
 
-#: ckanext/canada/templates/internal/user/list.html:80
-msgid "Search and manage users."
-msgstr "Rechercher et gérer les utilisateurs."
+#: ckanext/canada/templates/public/snippets/wet-boew/languagetoggle.html:2
+msgid "Language selection"
+msgstr "Sélection de la langue"
 
-#: ckanext/canada/templates/internal/user/snippets/search.html:78
-msgid "Search and view users."
-msgstr "Rechercher et afficher les utilisateurs."
+#: ckanext/canada/templates/public/snippets/wet-boew/skip.html:2
+msgid "Skip to main content"
+msgstr "Passer au contenu principal"
+
+#: ckanext/canada/templates/public/snippets/wet-boew/skip.html:3
+msgid "Skip to site information"
+msgstr "Passer aux informations sur le site"
+
+#: ckanext/canada/templates/public/user/dashboard.html:12
+#: ckanext/canada/templates/public/user/dashboard.html:67
+msgid "News feed"
+msgstr "Fil de nouvelles"
+
+#: ckanext/canada/templates/public/user/dashboard.html:15
+msgid "Activity from items that you follow"
+msgstr "Activité en lien avec les éléments que vous surveillez"
+
+#: ckanext/canada/templates/public/user/dashboard.html:35
+#: ckanext/canada/templates/public/user/dashboard.html:68
+msgid "My Datasets"
+msgstr "Mes dossiers"
+
+#: ckanext/canada/templates/public/user/dashboard.html:48
+msgid "You do not have any datasets"
+msgstr "Vous n'avez aucun ensemble de données"
+
+#: ckanext/canada/templates/public/user/dashboard.html:54
+#: ckanext/canada/templates/public/user/dashboard.html:60
+msgid "Add Dataset"
+msgstr ""
+
+#: ckanext/canada/templates/public/user/edit.html:8
+msgid "Manage"
+msgstr ""
+
+#: ckanext/canada/templates/public/user/edit_base.html:5
+msgid "My Profile"
+msgstr "Mes paramètres"
+
+#: ckanext/canada/templates/public/user/edit_user_form.html:7
+msgid "Change your details"
+msgstr "Modifier vos détails"
+
+#: ckanext/canada/templates/public/user/edit_user_form.html:11
+#, fuzzy
+msgid "Full name"
+msgstr "Aucun nom complet fourni"
+
+#: ckanext/canada/templates/public/user/edit_user_form.html:11
+#, fuzzy
+msgid "eg. Joe Bloggs"
+msgstr "Exemplar : Joe Bloggs"
+
+#: ckanext/canada/templates/public/user/edit_user_form.html:13
+msgid "eg. joe@example.com"
+msgstr ""
+
+#: ckanext/canada/templates/public/user/edit_user_form.html:15
+msgid "A little information about yourself"
+msgstr "Un peu d'information vous concernant"
+
+#: ckanext/canada/templates/public/user/edit_user_form.html:18
+msgid "Subscribe to notification emails"
+msgstr ""
+
+#: ckanext/canada/templates/public/user/edit_user_form.html:26
+msgid "Change your password"
+msgstr "Modifier votre mot de passe"
+
+#: ckanext/canada/templates/public/user/edit_user_form.html:29
+#, fuzzy
+msgid "Old Password"
+msgstr "Réinitialiser le mot de passe"
+
+#: ckanext/canada/templates/public/user/edit_user_form.html:34
+#, fuzzy
+msgid "Confirm Password"
+msgstr "Modifier votre mot de passe"
+
+#: ckanext/canada/templates/public/user/edit_user_form.html:38
+msgid "Update Profile"
+msgstr "Mettre à jour le profil"
+
+#: ckanext/canada/templates/public/user/login.html:18
+#, fuzzy
+msgid " Create an Account"
+msgstr "Créer un compte"
+
+#: ckanext/canada/templates/public/user/login.html:28
+#, fuzzy
+msgid "Forgot your password?"
+msgstr "Réinitialiser le mot de passe"
+
+#: ckanext/canada/templates/public/user/logout.html:3
+msgid "You are now logged out."
+msgstr "Vous êtes maintenant déconnecté"
+
+#: ckanext/canada/templates/public/user/new_user_form.html:4
+#, fuzzy
+msgid "Create Account"
+msgstr "Créer un compte"
+
+#: ckanext/canada/templates/public/user/perform_reset.html:8
+#, fuzzy
+msgid "Update Password"
+msgstr "Réinitialiser le mot de passe"
+
+#: ckanext/canada/templates/public/user/read_base.html:6
+msgid "Details"
+msgstr ""
+
+#: ckanext/canada/templates/public/user/read_base.html:22
+msgid "Followers"
+msgstr ""
+
+#: ckanext/canada/templates/public/user/read_base.html:26
+#, fuzzy
+msgid "Edits"
+msgstr "Modifier"
+
+#: ckanext/canada/templates/public/user/read_base.html:40
+msgid "Open ID"
+msgstr ""
+
+#: ckanext/canada/templates/public/user/read_base.html:51
+#: ckanext/canada/templates/public/user/read_base.html:62
+msgid "This means only you can see this"
+msgstr ""
+
+#: ckanext/canada/templates/public/user/read_base.html:51
+#: ckanext/canada/templates/public/user/read_base.html:62
+msgid "Private"
+msgstr ""
+
+#: ckanext/canada/templates/public/user/read_base.html:56
+msgid "Member Since"
+msgstr "Membre depuis"
+
+#: ckanext/canada/templates/public/user/read_base.html:61
+#: ckanext/canada/templates/public/user/read_base.html:69
+msgid "API Key"
+msgstr ""
+
+#: ckanext/canada/templates/public/user/read_base.html:64
+msgid "Show API Key"
+msgstr ""
+
+#: ckanext/canada/templates/public/user/read_base.html:70
+#: ckanext/canada/templates/public/user/read_base.html:76
+msgid "Close"
+msgstr ""
+
+#: ckanext/canada/templates/public/user/snippets/followee_dropdown.html:13
+#, fuzzy
+msgid "Activity from:"
+msgstr "Flux d'Activités"
+
+#: ckanext/canada/templates/public/user/snippets/followee_dropdown.html:21
+#, fuzzy
+msgid "Search list..."
+msgstr "Recherche..."
+
+#: ckanext/canada/templates/public/user/snippets/followee_dropdown.html:46
+msgid "You are not following anything"
+msgstr "Vous ne suivez rien"
+
+#: ckanext/canada/templates/public/user/snippets/login_form.html:17
+msgid "Remember me"
+msgstr "Mémoriser mes informations"
+
+#~ msgid "Plot Cart Items on a Map"
+#~ msgstr "Tracer les article due panier sur une carte"
+
+#~ msgid "Delete all items from Map Cart"
+#~ msgstr "Effacer tous items du panier de cartes"
+
+# Generic
+#~ msgid "You are now following {0}"
+#~ msgstr "Vous êtes maintenant abonné à {0}"
+
+#~ msgid "You are no longer following {0}"
+#~ msgstr "Vous n'êtes plus abonné à {0}"
+
+#~ msgid "Dataset has been deleted."
+#~ msgstr "L'ensemble de données a été supprimé."
+
+#~ msgid "French"
+#~ msgstr "Français"
+
+#~ msgid "No activities are within this activity stream"
+#~ msgstr "Aucune activité pour cet élément"
+
+#~ msgid "Edit Dataset"
+#~ msgstr "Modifier ensemble de données "
+
+#~ msgid "Next: Add Data"
+#~ msgstr "Suivant : Ajouter une ressource ou un connexe"
+
+#~ msgid "Next: Additional Info"
+#~ msgstr "Suivant : renseignements supplémentaires"
+
+#~ msgid "Data and Resources"
+#~ msgstr "Données et ressources"
+
+#~ msgid "Show More {facet}"
+#~ msgstr "Afficher plus d'{facet}"
+
+#~ msgid "Show Only Popular {facet}"
+#~ msgstr "Afficher uniquement les {facet} populaires"
+
+#~ msgid "Go"
+#~ msgstr "Allez"
+
+#~ msgid "Popular"
+#~ msgstr "popularité"
+
+#~ msgid "{number} dataset found for \"{query}\""
+#~ msgid_plural "{number} datasets found for \"{query}\""
+#~ msgstr[0] "{number} dossier trouvé"
+#~ msgstr[1] "{number} dossiers trouvés"
+
+#~ msgid "Sorry no datasets found for \"{query}\""
+#~ msgstr "0 ensemble de données trouvé"
+
+#~ msgid "Sorry no datasets found"
+#~ msgstr "0 ensembles de données trouvés"
+
+#~ msgid "Sorry no organizations found for \"{query}\""
+#~ msgstr "0 organisations trouvées"
+
+#~ msgid "Upload"
+#~ msgstr "Téléverser"
+
+#~ msgid "Account Info"
+#~ msgstr "Renseignements sur le compte"
+
+#~ msgid "Register for an Account"
+#~ msgstr "S’inscrire pour obtenir un compte"
+
+#~ msgid "Reset Your Password"
+#~ msgstr "Réinitialiser votre mot de passe"
+
+#~ msgid "You haven't created any datasets."
+#~ msgstr "Vous n'avez créé aucun ensemble de données"
+
+#~ msgid "Create one now?"
+#~ msgstr "Vous voulez en créer un maintenant?"
+
+#~ msgid "Request Reset"
+#~ msgstr "Demander une réinitialisation"
+
+#~ msgid "E-mail"
+#~ msgstr "Courriel"
+
+#~ msgid "E-Mail"
+#~ msgstr "Courriel"
+
+#~ msgid "Open.Canada.ca"
+#~ msgstr "Ouvert.Canada.ca"
+
+#~ msgid "Add to Portal"
+#~ msgstr "Ajouter au Portail"
+
+#~ msgid "About the Registry"
+#~ msgstr "À Propos du Registre"
+
+#~ msgid "Open Data Registry (staging)"
+#~ msgstr "Registre de données ouvertes (stadification)"
+
+#~ msgid "Open Data Registry (dev)"
+#~ msgstr "Registre de données ouvertes (dev)"
+
+#~ msgid "Open Government Registry (staging)"
+#~ msgstr "Registre du gouvernement ouvert (stadification)"
+
+#~ msgid "Open Government Registry (dev)"
+#~ msgstr "Registre du gouvernement ouvert (dev)"
+
+#~ msgid "Departments"
+#~ msgstr "Ministères"
+
+#~ msgid "Need an Account"
+#~ msgstr "Besoin d’un compte"
+
+#~ msgid "Forgotten your details"
+#~ msgstr "Vous avez oublié vos coordonnées"
+
+#~ msgid "Search Data"
+#~ msgstr "Recherche de dossiers"
+
+#~ msgid "Help"
+#~ msgstr "Aide"
+
+#~ msgid "Stay connected"
+#~ msgstr "Restez branchés"
+
+#~ msgid "Health"
+#~ msgstr "Santé"
+
+#~ msgid "Jobs"
+#~ msgstr "Emplois"
+
+#~ msgid "Economy"
+#~ msgstr "Économie"
+
+#~ msgid "healthycanadians.gc.ca"
+#~ msgstr "canadiensensante.gc.ca"
+
+#~ msgid "travel.gc.ca"
+#~ msgstr "voyage.gc.ca"
+
+#~ msgid "jobbank.gc.ca"
+#~ msgstr "guichetemplois.gc.ca"
+
+#~ msgid "actionplan.gc.ca"
+#~ msgstr "plandaction.gc.ca"
+
+#~ msgid "What are Organizations"
+#~ msgstr "Qu’est qu’une organisation"
+
+#~ msgid "Search Open Information"
+#~ msgstr "Chercher dans les information ouvertes"
+
+#~ msgid "Select at least one"
+#~ msgstr "Sélectionnez au moins un"
+
+#~ msgid "File Format"
+#~ msgstr "Format du fichier"
+
+#~ msgid "Published or Pending"
+#~ msgstr "Publié ou en attente de publication"
+
+#~ msgid "My Account"
+#~ msgstr "Mon compte"
+
+#~ msgid "Activities"
+#~ msgstr "Activités"
+
+#~ msgid "You have not provided a biography"
+#~ msgstr "Vous n’avez pas fourni de biographie"
+
+#~ msgid ""
+#~ " Your profile lets other Open Data"
+#~ " Registry users know about who you"
+#~ " are and what you do. "
+#~ msgstr ""
+#~ "Votre profil permet aux autres "
+#~ "utilisateurs de Registre de données "
+#~ "ouvertes de savoir qui vous êtes "
+#~ "et ce que vous faites"
+
+#~ msgid "Developer Tools"
+#~ msgstr "Outils pour le développeur"
+
+#~ msgid "Guidelines"
+#~ msgstr "Lignes directrices"
+
+#~ msgid "Open Data Portal Metadata Implementation Guide"
+#~ msgstr "Guide de mise en place des métadonnées pour les ressources Web"
+
+#~ msgid "Catalog Type"
+#~ msgstr "Type de Catalogue"
+
+#~ msgid "Resource Name"
+#~ msgstr "Nom de la ressource"
+
+#~ msgid "Size (MB)"
+#~ msgstr "Taille (Mo)"
+
+#~ msgid "Link"
+#~ msgstr "Lien"
+
+#~ msgid "Links"
+#~ msgstr "Liens"
+
+#~ msgid "Program Page"
+#~ msgstr "Page du programme"
+
+#~ msgid "Save And Add another Resource or Related Item"
+#~ msgstr "Sauvegarder et Ajouter une autre ressource ou objet connexe"
+
+#~ msgid "Dataset Resources"
+#~ msgstr "Ressources de l'ensemble de données"
+
+#~ msgid ""
+#~ "The information on this page (the "
+#~ "publication metadata) is also available "
+#~ "in JSON format"
+#~ msgstr ""
+#~ "L’information sur cette page (les "
+#~ "métadonnées du jeu de données) est "
+#~ "aussi disponible en format JSON"
+
+#~ msgid "About this Asset"
+#~ msgstr "Détails au sujet du bien"
+
+#~ msgid ""
+#~ "Read more about this site's API: "
+#~ "<a href='%(portal)s/eng/developers-corner-api'>About"
+#~ " the API</a>"
+#~ msgstr ""
+#~ "En savoir plus sur l’API du site:"
+#~ " <a href='%(portal)s/fra/coin-des-"
+#~ "developpeurs-ipa'>À propos du API</a>"
+
+#~ msgid "Data Type"
+#~ msgstr "Type de données"
+
+#~ msgid "No datasets were found to match your query."
+#~ msgstr "Aucun jeu de données ne correspond aux termes de recherche spécifiés."
+
+#~ msgid "No datasets found for \"{query}\""
+#~ msgstr "Aucun dossier trouvé pour \"{query}\""
+
+#~ msgid "The following fields are required to publish this dataset:"
+#~ msgstr ""
+#~ "Les champs suivants doivent être remplis"
+#~ " afin de publier ce jeu de "
+#~ "données:"
+
+#~ msgid "A resource has been added"
+#~ msgstr "Une ressource a été ajoutée"
+
+#~ msgid "A related item has been added"
+#~ msgstr "Un article connexe a été ajouté"
+
+#~ msgid "This dataset is currently unrated"
+#~ msgstr ""
+#~ "Aucune évaluation n’est disponible "
+#~ "actuellement pour cet ensemble de "
+#~ "données"
+
+#~ msgid "This dataset is currently ranked zero stars"
+#~ msgstr "Cet ensemble est considéré comme des données sans étoile"
+
+#~ msgid "This dataset is currently ranked one star"
+#~ msgstr "Cet ensemble est considéré comme des données une étoile"
+
+#~ msgid "This dataset is currently ranked two stars"
+#~ msgstr "Cet ensemble est considéré comme des données deux étoiles"
+
+#~ msgid "This dataset is currently ranked three stars"
+#~ msgstr "Cet ensemble est considéré comme des données trois étoiles"
+
+#~ msgid "This dataset is currently ranked four stars"
+#~ msgstr "Cet ensemble est considéré comme des données quatre étoiles"
+
+#~ msgid "This dataset is currently ranked five stars"
+#~ msgstr "Cet ensemble est considéré comme des données cinq étoiles"
+
+#~ msgid "About data.gc.ca"
+#~ msgstr "À propos de donnees.gc.ca"
+
+#~ msgid "About data.gc.ca - Main page"
+#~ msgstr "À propos de donnees.gc.ca - Page principal"
+
+#~ msgid "Open Government Licence"
+#~ msgstr "Licence du gouvernement ouvert – Canada"
+
+#~ msgid "Frequently Asked Questions"
+#~ msgstr "Foire aux questions"
+
+#~ msgid "Open Data 101"
+#~ msgstr "L'abc des données ouverte"
+
+#~ msgid "Open Data Principles"
+#~ msgstr "Principes de données ouvertes"
+
+#~ msgid "Open Data - Main page"
+#~ msgstr "Données ouvertes - Page principal"
+
+#~ msgid "Showcase"
+#~ msgstr "Recherche de dossiers"
+
+#~ msgid "Open Data in Canada"
+#~ msgstr "Données ouvertes au Canada"
+
+#~ msgid "Featured Data"
+#~ msgstr "Données regardées de près"
+
+#~ msgid "Developer's Corner"
+#~ msgstr "Coin des développeurs"
+
+#~ msgid "Facts & Figures"
+#~ msgstr "Faits et chiffres"
+
+#~ msgid "Principes de données ouvertes"
+#~ msgstr "Open Data Principles"
+
+#~ msgid "Search Summaries of Completed ATI requests"
+#~ msgstr "Recherche des sommaires de demandes d'AI complétées"
+
+#~ msgid "Canada's Action Plan on Open Government"
+#~ msgstr "Plan d'action du Canada pour un gouvernement ouvert"
+
+#~ msgid "Advisory Panel"
+#~ msgstr "Comité consultatif"
+
+#~ msgid "Open Government - Main page"
+#~ msgstr "Gouvernement ouvert - Page principal"
+
+#~ msgid "Participate"
+#~ msgstr "Participer"
+
+#~ msgid "Give Us Your Feedback"
+#~ msgstr "Faites-nous part de vos commentaires"
+
+#~ msgid "Blog"
+#~ msgstr "Blogue"
+
+#~ msgid "Submit Your App"
+#~ msgstr "Informez-nous de votre application"
+
+#~ msgid "Participate - Main page"
+#~ msgstr "Participer - Page principal"
+
+#~ msgid "data.gc.ca"
+#~ msgstr "donnees.gc.ca"
+
+#~ msgid "Submit"
+#~ msgstr "Soumettre"
+
+#~ msgid "data.gc.ca Dataset Feed"
+#~ msgstr "Nouveaux jeux de données"
+
+#~ msgid "Rate this record"
+#~ msgstr "Coter ce enregistrement"
+
+#~ msgid "Comment"
+#~ msgstr "Commentaire"
+
+#~ msgid "Comments"
+#~ msgstr "Commentaires"
+
+#~ msgid "RSS Feed"
+#~ msgstr "Fils RSS"
+
+#~ msgid "From the dataset abstract"
+#~ msgstr "Résumé du jeu de données"
+
+#~ msgid "Ready to Publish"
+#~ msgstr "Prêt à publier"
+
+#~ msgid "true"
+#~ msgstr "vrai"
+
+#~ msgid "Compare"
+#~ msgstr "Comparer"
+
+#~ msgid "Revision Differences"
+#~ msgstr "Différences entre les révisions"
+
+#~ msgid ""
+#~ "This is an old revision of this"
+#~ " dataset, as edited at %(timestamp)s. "
+#~ "It may differ significantly from the "
+#~ "<a href=\"%(url)s\">current revision</a>."
+#~ msgstr ""
+#~ "Il s’agit d’une ancienne révision de "
+#~ "cet ensemble de données, qui a été"
+#~ " effectuée le %(timestamp)s. Cette révision"
+#~ " peut différer considérablement de la "
+#~ "<a href=\"%(url)s\">révision actuelle</a>."
+
+#~ msgid ""
+#~ "This is the current revision of "
+#~ "this dataset, as edited at "
+#~ "%(timestamp)s."
+#~ msgstr ""
+#~ "Voici la révision actuelle de cet "
+#~ "ensemble de données, qui a été "
+#~ "effectuée le %(timestamp)s."
+
+#~ msgid ""
+#~ "An active account linked to your "
+#~ "department is required to create or "
+#~ "modify datasets in the registry."
+#~ msgstr ""
+#~ "Il faut d'obtenir une compte actif "
+#~ "et relié à votre ministère de "
+#~ "créer ou modifier de jeux de "
+#~ "données dans le registre."
+
+#~ msgid "Department"
+#~ msgstr "Ministère"
+
+#~ msgid ""
+#~ "ATI Summaries and ATI Nothing to "
+#~ "Report templates have now been combined."
+#~ " Now, you will only need to "
+#~ "download and submit one template (see"
+#~ " the 2 tabs in the template). "
+#~ "Please email <a href=\"mailto:open-ouvert"
+#~ "@tbs-sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a> "
+#~ "with any questions."
+#~ msgstr ""
+#~ "Les documents modèles « L’accès à "
+#~ "l’information sommaires complétés » et «"
+#~ " L’accès à l’information rien à "
+#~ "signaler » ont été combinées. À "
+#~ "partir de maintenant, vous n’aurez "
+#~ "besoin de télécharger et d'envoyer qu’un"
+#~ " seul document modèle (voir les 2 "
+#~ "languettes dans le modèle). Si vous "
+#~ "avez des questions, veuillez envoyer un"
+#~ " courriel à <a href=\"mailto:open-ouvert"
+#~ "@tbs-sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a>."
+
+#~ msgid ""
+#~ "Please note – if you have "
+#~ "downloaded a template before MAY 10, "
+#~ "2017, please download the updated "
+#~ "version before submitting your information."
+#~ msgstr ""
+#~ "Veuillez noter que les modèles Excel "
+#~ "ont été mis-à-jour le 10 mai 2017."
+#~ " Si le modèle que vous utilisez "
+#~ "a été téléchargé avant cette date, "
+#~ "veuillez télécharger la nouvelle version "
+#~ "avant de soumettre vos informations."
+
+#~ msgid "ATI Summaries"
+#~ msgstr "Accès à l’information sommaires complétés"
+
+#~ msgid ""
+#~ "Access, upload and modify the monthly"
+#~ " ATI Summaries and ATI Nothing to "
+#~ "Report for your organization."
+#~ msgstr ""
+#~ "Accès, téléversement et modification des "
+#~ "sommaires mensuels des demandes d’accès "
+#~ "à l’information et des demandes d’accès"
+#~ " pour lesquelles rien n’est à "
+#~ "signaler pour votre organisation"
+
+#~ msgid "ATI Nothing to Report"
+#~ msgstr "Accès à l’information rien à signaler"
+
+#~ msgid "Please enter a valid year"
+#~ msgstr "Veuillez entrer une année valide"
+
+#~ msgid "Please enter a month number from 1-12"
+#~ msgstr "Veuillez entrer une valeur comprise entre 1 et 12"
+
+#~ msgid "This value must not be negative"
+#~ msgstr "Cette valeur ne doit pas être négatif"
+
+#~ msgid ""
+#~ "IMPORTANT: New or updated inventories /"
+#~ " rows will be published on "
+#~ "open.canada.ca daily. IMSO approval must "
+#~ "be obtained and sent to <a "
+#~ "href=\"mailto:open-ouvert@tbs-sct.gc.ca\">open-"
+#~ "ouvert@tbs-sct.gc.ca</a> before uploading your"
+#~ " inventory data. By clicking the "
+#~ "Submit button, you are confirming IMSO"
+#~ " approval."
+#~ msgstr ""
+#~ "IMPORTANT : De nouvelles rangées/répertoires"
+#~ " seront créé(e)s ou mis(es) à jour"
+#~ " chaque jour au site ouvert.canada.ca. "
+#~ "Il est important d’obtenir l’approbation "
+#~ "d’un CSGI et d’envoyer celle-ci à"
+#~ " l’adresse <a href=\"mailto:open-ouvert@tbs-"
+#~ "sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a> avant "
+#~ "de procéder au téléversement de vos "
+#~ "données de répertoire. En cliquant sur"
+#~ " le bouton « Soumettre », vous "
+#~ "confirmez que vous avez obtenu "
+#~ "l’approbation du CSGI."
+
+#~ msgid ""
+#~ "Please ensure that transactions uploaded "
+#~ "into the Registry meet the requirements"
+#~ " for public disclosure set out in "
+#~ "the <a href=\"https://www.tbs-sct.gc.ca/pol/doc-"
+#~ "eng.aspx?id=14676\" target=\"_blank\">Guidelines on "
+#~ "the Proactive Disclosure of Contracts</a>. "
+#~ "The Registry will publicly disclose all"
+#~ " transactions populated in the template,"
+#~ " and will not remove any transactions"
+#~ " that should not be disclosed. For"
+#~ " example, transactions should be consistent"
+#~ " with the dollar thresholds for "
+#~ "public disclosure set out in section "
+#~ "4.1.1 of the Guidelines"
+#~ msgstr ""
+#~ "Veuillez vous assurer que les opérations"
+#~ " téléchargées dans le registre respectent"
+#~ " les exigences en matière de "
+#~ "divulgation publique énoncées dans les "
+#~ "<a href=\"https://www.tbs-sct.gc.ca/pol/doc-"
+#~ "fra.aspx?id=14676\" target=\"_blank\">Lignes directrices"
+#~ " sur la divulgation proactive des "
+#~ "marchés</a>. Le registre divulguera "
+#~ "publiquement toutes les opérations saisies "
+#~ "dans le gabarit, sans retirer les "
+#~ "opérations qui ne devraient pas être "
+#~ "divulguées. À titre d’exemple, les "
+#~ "opérations devraient être conformes aux "
+#~ "montants précisés à la section 4.1.1 "
+#~ "des lignes directives."
+
+#~ msgid "Year"
+#~ msgstr "Année"
+
+#~ msgid "Month"
+#~ msgstr "Mois"
+
+#~ msgid "Proactive Disclosure - Travel Expenses"
+#~ msgstr "Divulgation proactive – Dépenses de voyage"
+
+#~ msgid "Proactive Disclosure - Travel Expenses Nothing to Report"
+#~ msgstr "Divulgation proactive – Dépenses de voyage (Rien à signaler)"
+
+#~ msgid "Travel Expenditures"
+#~ msgstr "Divulgation proactive – Dépenses de voyage"
+
+#~ msgid ""
+#~ "Access, upload and modify the monthly"
+#~ " travel expense reports for your "
+#~ "organization"
+#~ msgstr ""
+#~ "Accès, téléversement et modification des "
+#~ "rapports mensuels sur les frais de "
+#~ "déplacement pour votre organisation"
+
+#~ msgid "Quarter"
+#~ msgstr "trimestre"
+
+#~ msgid "Fiscal Year Ending"
+#~ msgstr "Exercice financier se terminant"
+
+#~ msgid "Proactive Disclosure - Hospitality Expenses"
+#~ msgstr "Divulgation proactive – Dépenses d'accueil"
+
+#~ msgid "Proactive Disclosure - Hospitality Nothing to Report"
+#~ msgstr "Divulgation proactive – Dépenses d'accueil (Rien à signaler)"
+
+#~ msgid ""
+#~ "Access, upload and modify the monthly"
+#~ " hospitality expenses for your organization"
+#~ msgstr ""
+#~ "Accès, téléversement et modification des "
+#~ "dépenses mensuelles liées à l’accueil "
+#~ "pour votre organisation"
+
+#~ msgid "Proactive Publication - Contracts over $10,000"
+#~ msgstr "Publication proactive – Contrats attribués de plus de 10 000 $"
+
+#~ msgid "Proactive Publication - Aggregated Contracts from -$10,000 to $10,000"
+#~ msgstr "Publication proactive - Contrats agrégés de -10 000$ à 10 000$"
+
+#~ msgid ""
+#~ "Access, upload and modify the aggregated"
+#~ " Contracts from -$10K to $10K reports"
+#~ " for your organization"
+#~ msgstr ""
+#~ "Accès, téléversement et modification des "
+#~ "rapports sur les Contrats agrégés de "
+#~ "-10 000$ à 10 000$ pour votre "
+#~ "organisation"
+
+#~ msgid ""
+#~ "Access, upload and modify the Contracts"
+#~ " over 10K reports for your "
+#~ "organization"
+#~ msgstr ""
+#~ "Accès, téléversement et modification des "
+#~ "rapports  sur les contrats attribués de"
+#~ " plus de 10 000 $ pour votre"
+#~ " organisation"
+
+#~ msgid "Import"
+#~ msgstr "Importer"
+
+#~ msgid ""
+#~ "Goods Contracts Amendments from -$10K to"
+#~ " $10K – Net Amendment Value ($ "
+#~ "000)"
+#~ msgstr ""
+#~ "Modifications de marchés de biens de "
+#~ "-10 000 $ à 10 000 $ - Valeur nette "
+#~ "des modifications (000 $)"
+
+#~ msgid "Goods Contracts $10K and under - Total Value ($ 000)"
+#~ msgstr "Marchés de biens de 10 000 $ et moins - Valeur totale (000 $)"
+
+#~ msgid "Number of Service Contracts $10K and under"
+#~ msgstr "Nombre de marchés de services de 10 000 $ et moins"
+
+#~ msgid "Service Contracts $10K and under – Original Value ($ 000)"
+#~ msgstr "Marchés de services de 10 000 $ et moins – Valeur initiale (000 $)"
+
+#~ msgid ""
+#~ "Service Contracts Amendments from -$10K "
+#~ "to $10K – Net Amendment Value ($"
+#~ " 000)"
+#~ msgstr ""
+#~ "Marchés de services de -10 000 $ à "
+#~ "10 000 $ - Valeur nette des "
+#~ "modifications (000 $)"
+
+#~ msgid "Service Contracts $10K and under - Total Value ($ 000)"
+#~ msgstr "Marchés de services de 10 000 $ et moins - Valeur totale (000 $)"
+
+#~ msgid "Number of Construction Contracts $10K and under"
+#~ msgstr "Nombre de marchés de services de construction de 10 000 $ et moins"
+
+#~ msgid "Construction Contracts $10K and under – Original Value ($ 000)"
+#~ msgstr ""
+#~ "Marchés de services de construction de"
+#~ " 10 000 $ et moins - Valeur initiale"
+#~ " (000 $)"
+
+#~ msgid ""
+#~ "Construction Contracts Amendments from -$10K"
+#~ " to $10K – Net Amendment Value "
+#~ "($ 000)"
+#~ msgstr ""
+#~ "Modifications de marchés de construction "
+#~ "de -10 000 $ à 10 000 $ - Valeur "
+#~ "nette des modifications (000 $)"
+
+#~ msgid "Construction Contracts $10K and under - Total Value ($ 000)"
+#~ msgstr ""
+#~ "Marchés de services de construction de"
+#~ " 10 000 $ et moins - Valeur totale"
+#~ " (000 $)"
+
+#~ msgid "Total Number of Contracts $10K and under"
+#~ msgstr "Nombre total de marchés de 10 000 $ et moins"
+
+#~ msgid "Total Original Value of All Contracts $10K and under ($ 000)"
+#~ msgstr "Valeur initiale totale de tous les marchés de 10 000 $ et moins (000 $)"
+
+#~ msgid ""
+#~ "Total Net Amendment Value of All "
+#~ "Contracts Amendments from -$10K to $10K"
+#~ " ($ 000)"
+#~ msgstr ""
+#~ "Valeur totale des modifications nettes "
+#~ "de toutes les modifications de marchés"
+#~ " de -10 000 $ à 10 000 $ (000 $)"
+
+#~ msgid "Total Value of All Contracts $10K and under ($ 000)"
+#~ msgstr "Valeur totale de tous les marchés de 10 000 $ et moins (000 $)"
+
+#~ msgid "Number of Acquisition Card Transactions for all Dollar Values"
+#~ msgstr ""
+#~ "Nombre d'opérations réalisées au moyen "
+#~ "de la carte d'acquisition pour toutes"
+#~ " les valeurs en dollars"
+
+#~ msgid ""
+#~ "Acquisition Card Transactions for all "
+#~ "dollar values – Total Value ($ "
+#~ "000)"
+#~ msgstr ""
+#~ "Carte d'acquisition pour toutes les "
+#~ "valeurs en dollars– Valeur totale (000"
+#~ " $)"
+
+#~ msgid "Proactive Publication - Contracts"
+#~ msgstr "Publication proactive - Contrats"
+
+#~ msgid "Proactive Publication - Contracts Nothing to Report"
+#~ msgstr "Publication proactive – Contrats (Rien à signaler)"
+
+#~ msgid ""
+#~ "This dataset includes all of the "
+#~ "reports on contracts issued by or "
+#~ "on behalf of your organization."
+#~ msgstr ""
+#~ "Ce jeu de données comprend tous "
+#~ "les rapports sur les contrats qui "
+#~ "ont été émis par ou pour le "
+#~ "compte de votre organisation."
+
+#~ msgid "Additional Comments English"
+#~ msgstr "Commentaires additionnels en anglais"
+
+#~ msgid "Additional Comments French"
+#~ msgstr "Commentaires additionnels en français"
+
+#~ msgid "Proactive Disclosure - Grants and Contributions"
+#~ msgstr "Divulgation proactive - Subventions et les contributions"
+
+#~ msgid "Proactive Disclosure - Grants and Contributions Nothing to Report"
+#~ msgstr ""
+#~ "Divulgation proactive - Subventions et "
+#~ "les contributions  (Rien à signaler)"
+
+#~ msgid "Program Number"
+#~ msgstr "Numéro d’identification du programme"
+
+#~ msgid "Program Name English"
+#~ msgstr "Nom du programme en anglais"
+
+#~ msgid "Program Name French"
+#~ msgstr "Nom du programme en français"
+
+#~ msgid "Project Number"
+#~ msgstr "Numéro d’identification du projet"
+
+#~ msgid "Project Name English"
+#~ msgstr "Nom du bénéficiaire en anglais"
+
+#~ msgid "Project Name French"
+#~ msgstr "Nom du bénéficiaire en français"
+
+#~ msgid "Recipient Name English"
+#~ msgstr "Nom du récipient en anglais"
+
+#~ msgid "Recipient Name French"
+#~ msgstr "Nom du récipient en français"
+
+#~ msgid "Purpose English"
+#~ msgstr "Objectif en anglais"
+
+#~ msgid "Purpose French"
+#~ msgstr "Objectif en français"
+
+#~ msgid "Additional Information English"
+#~ msgstr "Informations supplémentaires en anglais"
+
+#~ msgid "Proactive Disclosure - Annual Travel, Hospitality and Conferences"
+#~ msgstr ""
+#~ "Divulgation proactive – Dépenses annuelles "
+#~ "de voyages, d’accueil, de conférences et"
+#~ " d’événements"
+
+#~ msgid ""
+#~ "This dataset includes all of the "
+#~ "annual reports on travel expenses "
+#~ "incurred within your organization."
+#~ msgstr ""
+#~ "Ce jeu de données comprend tous "
+#~ "les rapports annuels sur les dépenses"
+#~ " de voyage engagées au sein de "
+#~ "votre organisation."
+
+#~ msgid "Mandatory if year ≥ 2018"
+#~ msgstr "Obligatoire si année ≥ 2018"
+
+#~ msgid "Mandatory if year < 2018"
+#~ msgstr "Obligatoire si année < 2018"
+
+#~ msgid "Proactive Disclosure - Acts of Founded Wrongdoing"
+#~ msgstr "Divulgation proactive – Dossiers sur les actes répréhensibles fondés"
+
+#~ msgid "Proactive Disclosure - Founded Wrongdoing"
+#~ msgstr "Divulgation proactive – Dossiers sur les actes répréhensibles fondés"
+
+#~ msgid ""
+#~ "Access, upload and modify the Acts "
+#~ "of Founded Wrongdoing reports for your"
+#~ " organization"
+#~ msgstr ""
+#~ "Accès, téléversement et modifications des "
+#~ "dossiers sur les actes répréhensibles "
+#~ "fondés pour votre organisation"
+
+#~ msgid "Proactive Disclosure - Position Reclassification"
+#~ msgstr "Divulgation proactive - Reclassifications de postes"
+
+#~ msgid "Proactive Disclosure - Position Reclassification Nothing to Report"
+#~ msgstr "Divulgation proactive - Reclassifications de postes (Rien à signaler)"
+
+#~ msgid "Proactive Disclosure - Departmental Audit Committee"
+#~ msgstr "Divulgation proactive - Comités ministériels d’audit"
+
+#~ msgid ""
+#~ "Access, upload and modify the Grants "
+#~ "and Contributions reports for your "
+#~ "organization"
+#~ msgstr ""
+#~ "Accès, téléversement et modifications des "
+#~ "rapports sur les contributions et les"
+#~ " subventions pour votre organisation"
+
+#~ msgid ""
+#~ "Access, upload and modify the position"
+#~ " reclassification reports for your "
+#~ "organization"
+#~ msgstr ""
+#~ "Accès, téléversement et modifications des "
+#~ "rapports sur les contributions et les"
+#~ " subventions pour votre organisation"
+
+#~ msgid "Description of Work Code"
+#~ msgstr "Code de la description du travail"
+
+#~ msgid "Instrument Type"
+#~ msgstr "Type d’instrument"
+
+#~ msgid "Unique Identifier"
+#~ msgstr "Identifiant unique"
+
+#~ msgid "Location and Hospitality Provider (French)"
+#~ msgstr "Fournisseur de services d’emplacement et d’accueil (français)"
+
+#~ msgid "Start Date"
+#~ msgstr "Date du début"
+
+#~ msgid "Location and Hospitality Provider (English)"
+#~ msgstr "Fournisseur de services d’emplacement et d’accueil (anglais)"
+
+#~ msgid "Previous Position Classification Group"
+#~ msgstr "Groupe de classification du poste antérieur"
+
+#~ msgid "Previous Position Classification Sub Group"
+#~ msgstr "Sous-groupe de classification du poste antérieur"
+
+#~ msgid "Previous Position Classification Level Number"
+#~ msgstr "Numéro de niveau de la classification du poste antérieur"
+
+#~ msgid "Reclassified Position Classification Group"
+#~ msgstr "Groupe de classification du poste reclassifié"
+
+#~ msgid "Reclassified Position Classification Sub Group"
+#~ msgstr "Groupe de classification du poste reclassifié"
+
+#~ msgid "Reclassified Position Classification Level Number"
+#~ msgstr "Numéro de niveau de la classification du poste reclassifié"
+
+#~ msgid "Purpose of Travel (French)"
+#~ msgstr "But du voyage (français)"
+
+#~ msgid "Purpose of Travel (English)"
+#~ msgstr "But du voyage (anglais)"
+
+#~ msgid "Travel Start Date"
+#~ msgstr "Date du début du voyage"
+
+#~ msgid "Travel End Date"
+#~ msgstr "Date de fin du voyage"
+
+#~ msgid "Destination (French)"
+#~ msgstr "Destination (français)"
+
+#~ msgid "Destination (English)"
+#~ msgstr "Destination (anglais)"
+
+#~ msgid "Program Name (English)"
+#~ msgstr "Nom du programme (anglais)"
+
+#~ msgid "Program Name (French)"
+#~ msgstr "Nom du programme (français)"
+
+#~ msgid "Project Name (English)"
+#~ msgstr "Nom du bénéficiaire (anglais)"
+
+#~ msgid "Project Name (French)"
+#~ msgstr "Nom du bénéficiaire (français)"
+
+#~ msgid "Recipient Name (English)"
+#~ msgstr "Nom du récipient (anglais)"
+
+#~ msgid "Recipient Name (French)"
+#~ msgstr "Nom du récipient (français)"
+
+#~ msgid "Recipient Business Number"
+#~ msgstr "Numéro de l’entreprise bénéficiaire"
+
+#~ msgid "Region (English)"
+#~ msgstr "Région (anglais)"
+
+#~ msgid "Region (French)"
+#~ msgstr "Région (français)"
+
+#~ msgid "Additional Information (English)"
+#~ msgstr "Informations supplémentaires (anglais)"
+
+#~ msgid "Additional Information (French)"
+#~ msgstr "Informations supplémentaires (français)"
+
+#~ msgid "Resources associates with this dataset."
+#~ msgstr "Ressources associés avec cet ensemble de données."
+
+#~ msgid "other"
+#~ msgstr "autre"
+
+#~ msgid "Other"
+#~ msgstr "Autre"
+
+#~ msgid "Search Open Data"
+#~ msgstr "Recherche de données ouvertes"
+
+#~ msgid "Open Canada Dataset Feed"
+#~ msgstr "Nouveaux jeux de données"
+
+#~ msgid "Open Canada"
+#~ msgstr "Canada ouvert"
+
+#~ msgid "Open Government Portal"
+#~ msgstr "Portail du gouvernement ouvert"
+
+#~ msgid "Open Government Portal (staging)"
+#~ msgstr "Portail du gouvernement ouvert (stadification)"
+
+#~ msgid "Open Data Portal"
+#~ msgstr "Portail des données ouvertes"
+
+#~ msgid "Open Data Portal (staging)"
+#~ msgstr "Portail des données ouvertes (stadification)"
+
+#~ msgid "Open Data Portal - Open Data"
+#~ msgstr "Portail des données ouvertes - Données ouvertes"
+
+#~ msgid "Bilingual (English and French)"
+#~ msgstr "Bilingue (français et anglais)"
+
+#~ msgid "Open Data Inventory"
+#~ msgstr "Inventaire des données ouvertes"
+
+#~ msgid ""
+#~ "This dataset houses your departmental "
+#~ "open data inventory. This is where "
+#~ "you can access and upload your "
+#~ "open data inventory template."
+#~ msgstr ""
+#~ "Ce jeu de données contient l’inventaire"
+#~ " des données ouvertes de votre "
+#~ "ministère. C’est l’occasion pour accéder "
+#~ "à et pour télécharger votre modèle "
+#~ "d'inventaire des données ouvertes. "
+
+#~ msgid "Publisher - Name at Publication (English)"
+#~ msgstr "Éditeur – Nom de l'organisation au moment de la publication (anglais)"
+
+#~ msgid "Publisher - Name at Publication (French)"
+#~ msgstr "Éditeur – Nom de l'organisation au moment de la publication (français)"
+
+#~ msgid "Date Published"
+#~ msgstr "Date de publication "
+
+#~ msgid "Language"
+#~ msgstr "Langue"
+
+#~ msgid "Size"
+#~ msgstr "Taille"
+
+#~ msgid "Eligible for Release"
+#~ msgstr "Admissible à la publication"
+
+#~ msgid "Program Alignment Architecture (English)"
+#~ msgstr "Architecture d'alignement des programmes (anglais)"
+
+#~ msgid "Program Alignment Architecture (French)"
+#~ msgstr "Architecture d'alignement des programmes (français)"
+
+#~ msgid "Date Released"
+#~ msgstr "Date de sortie"
+
+#~ msgid "Open Government Portal Record (English)"
+#~ msgstr "Enregistrement de la portail du Gouvernement ouvert (anglais)"
+
+#~ msgid "Open Government Portal Record (French)"
+#~ msgstr "Enregistrement de la portail du Gouvernement ouvert (français)"
+
+#~ msgid "User Votes"
+#~ msgstr "Votes des utilisateurs"
+
+#~ msgid "Template"
+#~ msgstr "Modèle"
+
+#~ msgid "You do not have permission to upload to {0}"
+#~ msgstr "Vous n'avez pas la permission de télécharger à {0}"
+
+#~ msgid "You must provide a valid file"
+#~ msgstr "Voud devez fournir un fichier valide"
+
+#~ msgid "Sheet name '{0}' not found in list of valid tables"
+#~ msgstr ""
+#~ "Le nom de la feuille '{0}' n'a "
+#~ "pas été trouvé dans la liste des"
+#~ " tableaux valides"
+
+#~ msgid "Search Assets"
+#~ msgstr "Rechercher des biens"
+
+#~ msgid "Add Assets"
+#~ msgstr "Ajouter des biens"
+
+#~ msgid "Open Information Registry"
+#~ msgstr "Registre pour les information ouverte"
+
+#~ msgid "Add Asset"
+#~ msgstr "Ajouter des biens"
+
+#~ msgid "New Password"
+#~ msgstr "Nouveau mot de passe"
+
+#~ msgid "Open Information Portal"
+#~ msgstr "Registre pour les information ouverte"
+
+#~ msgid "{number} asset found"
+#~ msgid_plural "{number} assets found"
+#~ msgstr[0] "{number}  bien  trouvé"
+#~ msgstr[1] "{number} biens  trouvés"
+
+#~ msgid "{number} Asset"
+#~ msgid_plural "{number} Assets"
+#~ msgstr[0] "{number} Bien"
+#~ msgstr[1] "{number} Biens"
+
+#~ msgid "0 Assets"
+#~ msgstr "0 Biens"
+
+#~ msgid "No assets were found to match your query."
+#~ msgstr "Aucun bien trouvé qui corresponde à votre requête."
+
+#~ msgid "Asset Resources"
+#~ msgstr "Biens de la ressource"
+
+#~ msgid "Settings"
+#~ msgstr "Paramètres"
+
+#~ msgid "* indicates a mandatory field"
+#~ msgstr "* Indique un champ obligatoire "
+
+#~ msgid "Next: Add Resource or Related Item"
+#~ msgstr "Suivant: Ajouter une ressource ou un objet connexe"
+
+#~ msgid "No file chosen"
+#~ msgstr "Aucun fichier choisi"
+
+#~ msgid "{actor} created the dataset {dataset}"
+#~ msgstr "{actor} a créé le dosier {dataset}"
+
+#~ msgid "{actor} updated the dataset {dataset}"
+#~ msgstr "{actor} a mis à jour le dossier {dataset}"
+
+#~ msgid "Specialized enquiries"
+#~ msgstr "Requêtes particulières"
+
+#~ msgid "Open Government Log In"
+#~ msgstr "Ouverture de session Gouvernement ouvert"
+
+#~ msgid "/en/user"
+#~ msgstr "/fr/user"
+
+#~ msgid "Receive Open Government Email"
+#~ msgstr "Courriels sur le Gouvernement ouvert"
+
+#~ msgid "/en/forms/receive-open-government-email-form"
+#~ msgstr "/fr/formulaire/courriels-gouvernement-ouvert"
+
+#~ msgid "Most asked-about topics"
+#~ msgstr "Sujets sur lesquels portent la plupart des questions"
+
+#~ msgid "http://open.canada.ca/en/contact/index.html#aat"
+#~ msgstr "http://ouvert.canada.ca/fr/contact/index.html#slq"
+
+#~ msgid "http://open.canada.ca/en/contact/index.html#gen"
+#~ msgstr "http://www.canada.ca/fr/contact/index.html#gen"
+
+# Dataset view page
+#~ msgid "Access"
+#~ msgstr "Accès"
+
+#~ msgid "Select the role this user should have within this organization."
+#~ msgstr ""
+#~ "Sélectionnez le rôle du nouvel "
+#~ "utilisateur au sein de cette "
+#~ "organisation."
+
+#~ msgid "IMSO Approved"
+#~ msgstr "Approuvé du CSGI"
+
+#~ msgid "Create Organization"
+#~ msgstr "Créer l'orgaisation"
+
+#~ msgid ""
+#~ " You can also access this registry"
+#~ " using the %(api_link)s (see "
+#~ "%(api_doc_link)s). "
+#~ msgstr ""
+#~ " Vous pouvez également accéder à "
+#~ "ce catalogue en utilisant %(api_link)s "
+#~ "(voir documentation de l’API %(api_doc_link)s)"
+
+#~ msgid "Relationship"
+#~ msgstr "Type de relation"
+
+#~ msgid "Powered by"
+#~ msgstr "Réalisé avec"
+
+#~ msgid "Quick Links"
+#~ msgstr "Liens rapides"
+
+#~ msgid ""
+#~ "Add data about Government of Canada "
+#~ "services, financials or national demographic"
+#~ " information that is relevant to "
+#~ "Canadians."
+#~ msgstr ""
+#~ "Ajouter des données sur les services "
+#~ "du gouvernement du Canada, des données"
+#~ " financières ou de l'information "
+#~ "démographique nationale qui sont pertinentes"
+#~ " pour les Canadiens."
+
+#~ msgid "Add information about government programs, activities and publications."
+#~ msgstr ""
+#~ "Ajouter de l'information sur les "
+#~ "programmes, activités et publications du "
+#~ "gouvernement."
+
+#~ msgid ""
+#~ "Access, upload and modify the monthly"
+#~ " ATI Summaries and ATI Nothing to "
+#~ "Report for your organization"
+#~ msgstr ""
+#~ "Accès, téléversement et modification des "
+#~ "rapports mensuels sur les accès à "
+#~ "l'information sommaires et les accès à"
+#~ " l'information rien a signaler"
+
+#~ msgid "Open Data Records"
+#~ msgstr "Dossiers de données ouvertes"
+
+#~ msgid "Open Information Records"
+#~ msgstr "Dossiers d’information ouverte"
+
+#~ msgid "Search your Organization Records"
+#~ msgstr "Faire une recherche dans les dossiers de votre organisation"
+
+#~ msgid "Search All Records"
+#~ msgstr "Faire une recherche dans tous les dossiers"
+
+#~ msgid "View Members of your Organization"
+#~ msgstr "Voir les members liés à votre organisation"
+
+#~ msgid "Search all records in the Registry, for your Organization."
+#~ msgstr ""
+#~ "Faire une recherche dans tous les "
+#~ "dossiers du registre, pour votre "
+#~ "organisation."
+
+#~ msgid "Add all Open Data and Information records in the Registry."
+#~ msgstr "Faire une recherche dans tous les dossiers du registre."
+
+#~ msgid "View the list of members linked to your organization."
+#~ msgstr "Voir la liste des membres liés à votre organisation"
+
+#~ msgid "http://www.gcpedia.gc.ca/wiki/Proactive_Disclosure_on_Open.Canada.ca"
+#~ msgstr "http://www.gcpedia.gc.ca/wiki/Divulgation_proactive_dans_ouvert.canada.ca"
+
+#~ msgid "{0} members"
+#~ msgstr "{0} membres"
+
+#~ msgid "Please check your inbox for a reset code."
+#~ msgstr ""
+#~ "S.V.P. consulter votre boîte à lettres"
+#~ " électronique pour confirmer votre demande"
+#~ " de réinitialisation."
+
+#~ msgid "Column visibility"
+#~ msgstr "Visibilité des colonnes"
+
+#~ msgid "Data Contact"
+#~ msgstr "Personne-ressource responsable des données"
+
+#~ msgid "Distributor Contact"
+#~ msgstr "Personne-ressource responsable de la distribution"
+
+#~ msgid "Organization Name"
+#~ msgstr "Nom de l'organisation"
+
+#~ msgid "Telephone Number"
+#~ msgstr "Numéro de téléphone"
+
+#~ msgid "Address"
+#~ msgstr "Adresse"
+
+#~ msgid "Dataset Deleted"
+#~ msgstr "Dossier supprimé"
+
+#~ msgid "Consultations"
+#~ msgstr "Consultations"
+
+#~ msgid "Open Dialogue - Consultations"
+#~ msgstr "Dialogue ouvert - Consultations"
+
+#~ msgid ""
+#~ "Access, upload and modify consultation reports for your organization\n"
+#~ "\n"
+#~ "- [Consultations master dataset](/static/data/consultations.csv)\n"
+#~ "  This dataset consolidates all the "
+#~ "consultations reports submitted by federal "
+#~ "institutions.\n"
+#~ msgstr ""
+#~ "Accès, téléversement et modifications des "
+#~ "rapports sur les consultations pour "
+#~ "votre organisation\n"
+#~ "\n"
+#~ "- [Données de consultations "
+#~ "principales](/static/data/consultations.csv)\n"
+#~ "  Cette base de données regroupe "
+#~ "tous les rapports de consultations "
+#~ "soumis par les institutions fédérales\n"
+
+#~ msgid "Service Inventory"
+#~ msgstr "Répertoire de services"
+
+#~ msgid ""
+#~ "Access, upload and modify the Service"
+#~ " Inventory of external and internal "
+#~ "enterprise services for your organization"
+#~ msgstr ""
+#~ "Accèder, téléverser et modifier le "
+#~ "catalogue des service internes intégrés "
+#~ "et externes pour votre organisation"
+
+#~ msgid "Service Identification Information & Metrics"
+#~ msgstr "Renseignements sur l’identification des services, données volumétrique"
+
+#~ msgid "Service Standards & Performance Results"
+#~ msgstr "Normes relatives aux services et résultats de rendement"
+
+#~ msgid "Mandatory"
+#~ msgstr "Obligatoire"
+
+#~ msgid "Optional"
+#~ msgstr "Facultatif"
+
+#~ msgid "Free text"
+#~ msgstr "Texte libre"
+
+#~ msgid "Free text (comma separated list of codes from reference table)"
+#~ msgstr ""
+#~ "Texte libre (liste des codes de la"
+#~ " table de référence, séparées par des"
+#~ " virgules)"
+
+#~ msgid "Free Text (separate paragraphs with two blank lines)"
+#~ msgstr "Texte libre (Séparez les paragraphes par deux lignes vides)"
+
+#~ msgid "Date (Please format the data as YYYY-MM-DD)"
+#~ msgstr "Date (format suivant: AAAA-MM-JJ)"
+
+#~ msgid "Controlled List"
+#~ msgstr "Liste contrôlée"
+
+#~ msgid "Single"
+#~ msgstr "Une seule"
+
+#~ msgid "Repeatable"
+#~ msgstr "Plusieurs"
+
+#~ msgid "Sheet {0} Row {1}:"
+#~ msgstr "Feuille {0} rangée {1}:"
+
+#~ msgid "invalid input syntax for type boolean"
+#~ msgstr "Syntaxe d’entrée non valide pour ce type de recherche booléenne"
+
+#~ msgid "invalid input syntax for type date"
+#~ msgstr "Syntaxe d’entrée non valide pour le type de date"
+
+#~ msgid "Record Creation Time"
+#~ msgstr "Heure de la création du dossier"
+
+#~ msgid "Last Record Modification Time"
+#~ msgstr "Heure de la dernière modification au dossier"
+
+#~ msgid "User Last Modified Record"
+#~ msgstr "Utilisateur de la dernière modification au dossier"
+
+#~ msgid "time_ascend"
+#~ msgstr "Les plus anciens d’abord"
+
+#~ msgid "time_descend"
+#~ msgstr "Les plus récents d’abord"
+
+#~ msgid "View this version"
+#~ msgstr "Voir cette version"
+
+#~ msgid "Dear %(user_name)s,"
+#~ msgstr "Cher %(user_name)s,"
+
+#~ msgid ""
+#~ "You have requested your password on %(site_title)s to be reset.\n"
+#~ "\n"
+#~ "Please click the following link to confirm this request:\n"
+#~ "\n"
+#~ "   %(reset_link)s"
+#~ msgstr ""
+#~ "Vous avez demandé la réinitialisation de"
+#~ " votre mot de passe sur le site"
+#~ " %(site_title)s.\n"
+#~ "\n"
+#~ "Merci de cliquer sur le lien suivant pour confirmer votre requête :\n"
+#~ "%(reset_link)s"
+
+#~ msgid "Invite for %(site_title)s"
+#~ msgstr "Invitation pour %(site_title)s"
+
+#~ msgid ""
+#~ "You have been invited to %(site_title)s.\n"
+#~ "\n"
+#~ "A user has already been created to"
+#~ " you with the username %(user_name)s. "
+#~ "You can change it later.\n"
+#~ "\n"
+#~ "To accept this invite, please reset your password at:\n"
+#~ "\n"
+#~ "   %(reset_link)s\n"
+#~ msgstr ""
+#~ "Vous avez été invité sur %(site_title)s.\n"
+#~ "\n"
+#~ "Un utilisateur a déjà été créé "
+#~ "pour vous avec l'identifiant %(user_name)s."
+#~ " Vous pourrez le changer ultérieurement."
+#~ "\n"
+#~ "\n"
+#~ "Pour accepter cette invitation, veuillez "
+#~ "réinitialiser votre mot de passe via "
+#~ ":\n"
+#~ "%(reset_link)s\n"
+
+#~ msgid "Have a nice day."
+#~ msgstr "Bonne journée."
+
+#~ msgid "Message sent by %(site_title)s (%(site_url)s)"
+#~ msgstr "Message envoyé par %(site_title)s (%(site_url)s)"
+
+#~ msgid ""
+#~ "Your password must be {} characters "
+#~ "or longer, contain no accented "
+#~ "characters and consist of at least "
+#~ "three of the following character sets:"
+#~ " uppercase characters, lowercase characters, "
+#~ "digits, punctuation & special characters."
+#~ msgstr ""
+#~ "Les mots de passe doivent contenir "
+#~ "des caractères provenant d’au moins "
+#~ "trois des quatre catégories suivantes: "
+#~ "lettres majuscules, lettres minuscules, "
+#~ "chiffres arabes, caractères spéciaux. Les "
+#~ "lettres accentuées ne sont pas "
+#~ "acceptées. Tous les mots de passe "
+#~ "doivent compter au moins {} caractères."
+
+#~ msgid ""
+#~ "If you would like to request an"
+#~ " account for the Open Government "
+#~ "Registry, please email <a href=\"mailto"
+#~ ":open-ouvert@tbs-sct.gc.ca\">open-ouvert@tbs-"
+#~ "sct.gc.ca</a> with your name, department "
+#~ "and email"
+#~ msgstr ""
+#~ "Si vous souhaitez demander un compte "
+#~ "pour le Répertoire du gouvernement "
+#~ "ouvert, veuillez envoyer un courriel à"
+#~ " <a href=\"mailto:open-ouvert@tbs-sct.gc.ca"
+#~ "\">open-ouvert@tbs-sct.gc.ca</a> avec votre "
+#~ "nom, ministère et adresse courriel."
+
+#~ msgid "Request an account"
+#~ msgstr "Demande d'un compte"
+
+#~ msgid ""
+#~ "Note: Only records belonging to your "
+#~ "organizations are now visible on the "
+#~ "Registry. Please use the portal to "
+#~ "access published records from all "
+#~ "organizations. If you need to see "
+#~ "draft records or create or update "
+#~ "records for other organizations, please "
+#~ "send a request and justification to "
+#~ "<a href=\"mailto:open-ouvert@tbs-sct.gc.ca"
+#~ "\">open-ouvert@tbs-sct.gc.ca</a>"
+#~ msgstr ""
+#~ "Nota : Seuls les enregistrements "
+#~ "appartenant à vos organisations sont "
+#~ "désormais visibles dans le Répertoire. "
+#~ "Veuillez vous servir du portail pour "
+#~ "accéder aux documents publiés par toutes"
+#~ " les organisations. Si vous avez "
+#~ "besoin de consulter des ébauches "
+#~ "d’enregistrements ou de créer des "
+#~ "enregistrements pour d’autres organisations ou"
+#~ " en effectuer la mise à jour, "
+#~ "veuillez envoyer une demande et une "
+#~ "justification à <a href=\"mailto:open-ouvert"
+#~ "@tbs-sct.gc.ca\">open-ouvert@tbs-sct.gc.ca</a>"
+
+#~ msgid "Numeric only"
+#~ msgstr "Valeur numérique seulement"
+
+#~ msgid ""
+#~ "This metadata element is machine "
+#~ "translated. If you have questions, "
+#~ "contact open-ouvert@tbs-sct.gc.ca"
+#~ msgstr ""
+#~ "Cet élément de métadonnée est traduit"
+#~ " automatiquement. Veuillez communiquer avec "
+#~ "open-ouvert@tbs-sct.gc.ca si vous avez"
+#~ " des questions."
+
+#~ msgid "Finish"
+#~ msgstr "Soumettre"
+
+#~ msgid "Federal"
+#~ msgstr "Fédérale"
+
+#~ msgid "Proactive Disclosure - Briefing Note Titles and Numbers"
+#~ msgstr "Divulgation proactive - titres et numéros des notes d’information"
+
+#~ msgid ""
+#~ "Access, upload and modify the Briefing"
+#~ " Note Titles and Numbers reports for"
+#~ " your organization"
+#~ msgstr ""
+#~ "Accès, téléversement et modifications des "
+#~ "rapports sur les titres at numéros "
+#~ "des notes d’information pour votre "
+#~ "organisation"
+
+#~ msgid "Proactive Disclosure - Question Period Notes"
+#~ msgstr "Divulgation proactive - Notes pour la période des questions"
+
+#~ msgid ""
+#~ "Access, upload and modify the Question"
+#~ " Period Notes for your organization"
+#~ msgstr ""
+#~ "Accès, téléversement et modifications des "
+#~ "notes pour la période des questions "
+#~ "pour votre organisation"
+
+#~ msgid "Use of Administrative Aircraft"
+#~ msgstr "Utilisation des avions d'affaires"
+
+#~ msgid "Proactive Disclosure - Use of Administrative Aircraft"
+#~ msgstr "Divulgation proactive - Utilisation des avions d'affaires"
+
+#~ msgid "Access, upload and modify government administrative aircraft use"
+#~ msgstr ""
+#~ "Accès, téléversement et modifications des "
+#~ "rapports sur la utilisation des avions"
+#~ " d'affaires"
+
+#~ msgid "Access, upload and modify Question Period notes for your organization"
+#~ msgstr ""
+#~ "Accès, téléversement et modifications des "
+#~ "notes de la période de questions "
+#~ "pour votre organisation"
+
+#~ msgid "National Action Plan on Open Government Tracker"
+#~ msgstr ""
+#~ "Outil de suivi pour le Plan "
+#~ "d'action national pour un gouvernement "
+#~ "ouvert"
+
+#~ msgid "5th National Action Plan on Open Government Tracker"
+#~ msgstr ""
+#~ "Outil de suivi pour le 5ᵉ Plan "
+#~ "d'action national pour un gouvernement "
+#~ "ouvert"
+
+#~ msgid ""
+#~ "Access, upload and modify the National"
+#~ " Action Plan on Open Government "
+#~ "Tracker for your organization"
+#~ msgstr ""
+#~ "Accès, téléversement et Modifier le "
+#~ "outil de suivi pour le Plan "
+#~ "d'action national pour un gouvernement "
+#~ "ouvert pour votre organisation"
+
+#~ msgid "Experimentation Inventory"
+#~ msgstr "Répertoire d'expérimentation"
+
+#~ msgid ""
+#~ "This field must be NA (not "
+#~ "applicable) if the Trade Agreement field"
+#~ " is not XX (none)."
+#~ msgstr ""
+#~ "Ce champ doit être NA (aucune) si"
+#~ " les champs Accord commercial ne "
+#~ "contiennent pas la valeur XX (aucun)."
+
+#~ msgid ""
+#~ "If this field is populated, it "
+#~ "must be with a “0” if the "
+#~ "procurement was identified as non-"
+#~ "competitive (TN) or advance contract "
+#~ "award notice (AC) or was identified "
+#~ "as an Amendment (A) in the "
+#~ "Instrument type data field."
+#~ msgstr ""
+#~ "Si cette zone est remplie, il doit"
+#~ " contenir un « 0 » si "
+#~ "l’acquisition a été identifiée comme "
+#~ "étant non concurrentielle (TN) ou un "
+#~ "préavis d’attribution de contrat (AC) ou"
+#~ " si l’acquisition a été identifiée "
+#~ "comme un modification (A) dans le "
+#~ "champ Type d’instrument."
+
+#~ msgid ""
+#~ "If this field is populated, it "
+#~ "must be with a 1,2,3,4 or 5 "
+#~ "if the procurement was identified as "
+#~ "Open Bidding (OB), Selective Tendering "
+#~ "(ST) or Traditional Competitive (TC)."
+#~ msgstr ""
+#~ "Si Cette zone est remplie, il doit"
+#~ " contenir un 1, 2, 3, 4 ou "
+#~ "5 si l’acquisition a été identifiée "
+#~ "comme étant OB : Concurrentielle – "
+#~ "Invitation ouverte à soumissionner (SEAOG),"
+#~ " ST : Concurrentielle – Appel "
+#~ "d’offres sélectif ou TC : "
+#~ "Concurrentielle – Traditionnelle."
+
+#~ msgid ""
+#~ "If “TC” (Competitive - Traditional), "
+#~ "“TN” (Non-Competitive) or “AC” (Advanced"
+#~ " Contract Award Notice) is selected "
+#~ "and trade agreement with a value "
+#~ "other than “XX” (None) is selected, "
+#~ "limited tendering cannot have a value"
+#~ " of “0” or “00” (None)."
+#~ msgstr ""
+#~ "Si les options « TC » "
+#~ "(Concurrentielle - Traditionnelle), « TN "
+#~ "» (non concurrentielle) ou « AC »"
+#~ " (préavis d’attribution de contrat) sont"
+#~ " sélectionnées et qu’une entente de "
+#~ "marché ayant une valeur autre que "
+#~ "« XX » (nulle) est sélectionnée, "
+#~ "le champ Appel d’offres restreint ne "
+#~ "peut avoir la valeur « 0 » "
+#~ "ou « 00 » (nulle)."
+
+#~ msgid ""
+#~ "If “AC” (Advanced Contract Award Notice)"
+#~ " or “TN” (Non-competitive) is "
+#~ "selected, Award Criteria must have a "
+#~ "value of “0” (Not applicable)."
+#~ msgstr ""
+#~ "Si les options « AC » (préavis "
+#~ "d’attribution de contrat) ou « TN "
+#~ "» (non concurrentielle) sont sélectionnées,"
+#~ " le champ Critère de mérite doit "
+#~ "avoir une valeur de « 0 » "
+#~ "(sans objet)."
+
+#~ msgid ""
+#~ "If “OB” (Competitive – Open bidding),"
+#~ " “ST” (Selective Tendering) or “TC” "
+#~ "(Competitive – Traditional) is selected, "
+#~ "section 6 Government Contracts Regulations "
+#~ "Exceptions must have a value of "
+#~ "“0”."
+#~ msgstr ""
+#~ "Si les options « OB » "
+#~ "(Concurrentielle – appel d’offres ouvert), "
+#~ "« ST » (mise en concurrence) ou"
+#~ " « TC » (Concurrentielle – "
+#~ "Traditionnelle) sont sélectionnées, la section"
+#~ " 6 des exceptions au Règlement sur"
+#~ " les marchés de l’État doit avoir "
+#~ "une valeur de « 0 »."
+
+#~ msgid ""
+#~ "If TC, TN or AC is selected "
+#~ "in the Solicitation Procedure data field"
+#~ " with a value other than XX "
+#~ "(None) selected in the Trade Agreement"
+#~ " data field, then a Limited Tendering"
+#~ " value other than 00 (none) must "
+#~ "be entered."
+#~ msgstr ""
+#~ "Si TC, TN ou AC est sélectionné"
+#~ " dans le champ de données Méthode "
+#~ "d’invitation à soumissioner avec une "
+#~ "valeur autre que XX (Aucune) "
+#~ "sélectionnée dans le champ de données"
+#~ " Accord commercial, une valeur d'offre "
+#~ "limitée autre que 0 (aucune) doit "
+#~ "être entrée."
+
+#~ msgid ""
+#~ "This field may only be populated "
+#~ "with “0” if the procurement was "
+#~ "identified as competitive (open bidding "
+#~ "(OB), traditional competitive (TC) or "
+#~ "selective tendering (ST))."
+#~ msgstr ""
+#~ "Cette zone peut seulement contenir « "
+#~ "0 » si l’acquisition a été "
+#~ "identifiée comme étant concurrentielle "
+#~ "(invitation ouverte à soumissionner (OB) "
+#~ "ou concurrentielle - traditionnelle (TC) "
+#~ "ou Concurrentielle – Appel d’offres "
+#~ "sélectif (ST))."
+
+#~ msgid "This must list the year you are reporting on (not the fiscal year)."
+#~ msgstr "Veuillez indiquer l’année civile visée par le rapport."
+
+#~ msgid ""
+#~ "Access, upload and modify the "
+#~ "Experimentation Inventory for your "
+#~ "organization"
+#~ msgstr ""
+#~ "Accès, téléversement et modifier le "
+#~ "répertoire d'expérimentation pour votre "
+#~ "organisation"
+
+#~ msgid "This field is limited to only 3 or 4 digits."
+#~ msgstr "Ce champ est limité à 3 ou 4 caractères."
+
+#~ msgid "The field is limited to eight alpha-numeric digits or less."
+#~ msgstr "Ce champ est limité à 8 caractères alphanumériques."
+
+#~ msgid "Error"
+#~ msgstr "Erreur"
+
+#~ msgid ""
+#~ "We're sorry you ended up here. "
+#~ "Sometimes a page gets moved or "
+#~ "deleted, but hopefully we can help "
+#~ "you find what you're looking for. "
+#~ "What next?"
+#~ msgstr ""
+#~ "Nous sommes désolés que vous ayez "
+#~ "abouti ici. Il arrive parfois qu'une "
+#~ "page ait été déplacée ou supprimée. "
+#~ "Heureusement, nous pouvons vous aider à"
+#~ " trouver ce que vous cherchez. Que"
+#~ " faire?"
+
+#~ msgid "Return to the <a href=\"https://www.canada.ca/en.html\">home page</a>;"
+#~ msgstr ""
+#~ "Retournez à la <a "
+#~ "href=\"http://www.canada.ca/fr/index.html\">page d'accueil</a>;"
+
+#~ msgid "Consult the <a href=\"/en/sitemap.html\">site map</a>;"
+#~ msgstr ""
+#~ "Consultez le <a "
+#~ "href=\"http://www.canada.ca/fr/plan.html\">plan du "
+#~ "site</a>;"
+
+#~ msgid ""
+#~ "Check out the <a "
+#~ "href=\"http://www.collectionscanada.gc.ca/012/012-412.01-e.html\" "
+#~ "rel=\"external\">Government of Canada Web "
+#~ "Archive</a> to view an older version;"
+#~ " or"
+#~ msgstr ""
+#~ "Vérifiez dans les <a "
+#~ "href=\"http://www.collectionscanada.gc.ca/012/012-412.01-f.html\" "
+#~ "rel=\"external\">Archives Web du gouvernement "
+#~ "du Canada</a> s’il existe une version"
+#~ " antérieure;"
+
+#~ msgid "<a href=\"/en/contact.html\">Contact us</a> and we'll help you out."
+#~ msgstr ""
+#~ "<a href=\"http://www.canada.ca/fr/contact/index.html"
+#~ "\">Contactez-nous</a> pour de l'assistance."
+
+#~ msgid "https://www.canada.ca/en/contact.html"
+#~ msgstr "https://www.canada.ca/fr/contact.html"
+
+#~ msgid "How government works"
+#~ msgstr "Comment le gouvernement fonctionne"
+
+#~ msgid "http://open.canada.ca/en/"
+#~ msgstr "http://ouvert.canada.ca/"
+
+#~ msgid "https://www1.canada.ca/en/contact/feedback.html"
+#~ msgstr "https://www1.canada.ca/fr/contact/retroaction.html"
+
+#~ msgid "Feedback"
+#~ msgstr "Rétroaction"
+
+#~ msgid "https://www1.canada.ca/fr/nouveausite.html"
+#~ msgstr "https://www1.canada.ca/fr/nouveausite.html"
+
+#~ msgid "Search and menus"
+#~ msgstr "Recherche et menus"
+
+#~ msgid "http://www.esdc.gc.ca/en/jobs/index.page"
+#~ msgstr "http://www.edsc.gc.ca/fr/emplois/index.page"
+
+#~ msgid "http://www.cic.gc.ca/english/index.asp"
+#~ msgstr "http://www.cic.gc.ca/francais/index.asp"
+
+#~ msgid "Immigration"
+#~ msgstr "Immigration"
+
+#~ msgid "http://travel.gc.ca"
+#~ msgstr "https://voyage.gc.ca/"
+
+#~ msgid "http://www.canada.ca/en/services/business/index.html"
+#~ msgstr "https://www.canada.ca/fr/services/entreprises.html"
+
+#~ msgid "http://www.canada.ca/en/services/benefits/index.html"
+#~ msgstr "https://www.canada.ca/fr/services/prestations.html"
+
+#~ msgid "Benefits"
+#~ msgstr "Prestations"
+
+#~ msgid "http://healthycanadians.gc.ca/index-eng.php"
+#~ msgstr "http://canadiensensante.gc.ca/index-fra.php"
+
+#~ msgid "http://www.canada.ca/en/services/taxes/index.html"
+#~ msgstr "https://www.canada.ca/fr/services/impots.html"
+
+#~ msgid "Taxes"
+#~ msgstr "Impôts"
+
+#~ msgid "http://www.canada.ca/en/services/index.html"
+#~ msgstr "https://www.canada.ca/fr/services.html"
+
+#~ msgid "More services"
+#~ msgstr "Autres services"
+
+#~ msgid "About {0}"
+#~ msgstr " propos de {0}"
+
+#~ msgid "Terms and Conditions"
+#~ msgstr "Avis"
+
+#~ msgid "Accessibility"
+#~ msgstr "Accessibilité"
+
+#~ msgid "Code of conduct"
+#~ msgstr ""
+
+#~ msgid "Moderation policy"
+#~ msgstr ""
+
+#~ msgid "Search Your Data"
+#~ msgstr "Rechercher dans vos données"
+
+#~ msgid "Revision"
+#~ msgstr ""
+
+#~ msgid "Timestamp"
+#~ msgstr ""
+
+#~ msgid "Log Message"
+#~ msgstr ""
+
+#~ msgid "Read dataset as of %s"
+#~ msgstr ""
+
+#~ msgid "View {name}"
+#~ msgstr ""
+
+#~ msgid "What are Groups?"
+#~ msgstr ""
+
+#~ msgid ""
+#~ " Groups allow you to group "
+#~ "together datasets under a community (for"
+#~ " example, Civil Liberty data) or "
+#~ "topic (e.g. Transport, Health, Environment)"
+#~ " to make it easier for users to"
+#~ " browse datasets by theme. Datasets "
+#~ "can be part of a group, but "
+#~ "do not belong to the group for "
+#~ "editing or authorisation purposes. "
+#~ msgstr ""
+
+#~ msgid "E.g. environment"
+#~ msgstr ""
+
+#~ msgid "Welcome"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "This is a nice introductory paragraph"
+#~ " about CKAN or the site in "
+#~ "general. We don't have any copy to"
+#~ " go here yet but soon we will"
+#~ " "
+#~ msgstr ""
+
+#~ msgid "This is a featured section"
+#~ msgstr ""
+
+#~ msgid "Search data"
+#~ msgstr ""
+
+#~ msgid "Popular tags"
+#~ msgstr ""
+
+#~ msgid "Licence"
+#~ msgstr ""
+
+#~ msgid "View"
+#~ msgstr ""
+
+#~ msgid "API Endpoint"
+#~ msgstr ""
+
+#~ msgid "URL:"
+#~ msgstr ""
+
+#~ msgid "Source: <a href=\"%(url)s\">%(dataset)s</a>"
+#~ msgstr ""
+
+#~ msgid "There're no views created for this resource yet."
+#~ msgstr ""
+
+#~ msgid "This resource has no views"
+#~ msgstr ""
+
+#~ msgid ""
+#~ " <p class=\"empty\">This dataset has no"
+#~ " data, <a href=\"%(url)s\">why not add "
+#~ "some?</a> "
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Access the suggested datasets that your"
+#~ " organization has received in order "
+#~ "to provide a status update."
+#~ msgstr ""
+#~ "Veuillez accéder aux jeux de données "
+#~ "proposés que votre organisation a reçus"
+#~ " afin de faire le point sur "
+#~ "ceux-ci."
+
+#~ msgid "Suggested Datasets - Update Status"
+#~ msgstr "Le point sur les jeux de données proposés"
+
+#~ msgid "Create Information Asset"
+#~ msgstr "Créer un enregistrement d'informations ouvertes"
+
+#~ msgid "Update Status"
+#~ msgstr "Mettre à jour un statut"
+
+#~ msgid "Acts of Founded Wrongdoing"
+#~ msgstr "Dossiers sur les actes répréhensibles fondés"
+
+#~ msgid "Aggregated Contracts from -$10K to $10K"
+#~ msgstr "Contrats agrégés de -10 000$ à 10 000$"
+
+#~ msgid "Briefing Note Titles and Numbers"
+#~ msgstr "Titres et numéros des notes d’information"
+
+#~ msgid "Contracts over $10,000"
+#~ msgstr "Contrats attribués de plus de 10 000 $"
+
+#~ msgid "Departmental Audit Committee"
+#~ msgstr "Comités ministériels d’audit"
+
+#~ msgid "Grants and Contributions"
+#~ msgstr "Subventions et les contributions"
+
+#~ msgid "Hospitality Expenses"
+#~ msgstr "Dépenses d'accueil"
+
+#~ msgid "Position Reclassification"
+#~ msgstr "Reclassifications de postes"
+
+#~ msgid "Question Period Notes"
+#~ msgstr "Notes pour la période des questions"
+
+#~ msgid "Travel Expenses"
+#~ msgstr "Dépenses de voyage"
+
+#~ msgid "Annual Travel, Hospitality and Conferences"
+#~ msgstr ""
+#~ "Dépenses annuelles de voyages, d’accueil, "
+#~ "de conférences et d’événements"
+
+#~ msgid ""
+#~ "Access, add or modify briefing package"
+#~ " information for your new or incoming"
+#~ " minister."
+#~ msgstr ""
+#~ "Consultez la trousse d’information pour "
+#~ "le nouveau ministre, ajoutez-y du "
+#~ "contenu ou modifiez-la."
+
+#~ msgid ""
+#~ "Access, add or modify briefing package"
+#~ " information for your new or incoming"
+#~ " deputy head."
+#~ msgstr ""
+#~ "Consultez la trousse d’information pour "
+#~ "le nouvel administrateur général, ajoutez-y"
+#~ " du contenu ou modifiez-la."
+
+#~ msgid ""
+#~ "Access, add or modify briefing packages"
+#~ " for Parliamentary Committee appearance for"
+#~ " your minister."
+#~ msgstr ""
+#~ "Consultez la trousse d’information pour "
+#~ "la comparution de votre ministre devant"
+#~ " un comité parlementaire, ajoutez-y du "
+#~ "contenu ou modifiez-la."
+
+#~ msgid ""
+#~ "Access, add or modify briefing packages"
+#~ " for Parliamentary Committee appearance for"
+#~ " your deputy head."
+#~ msgstr ""
+#~ "Consultez la trousse d’information pour "
+#~ "la comparution de votre administrateur "
+#~ "général devant un comité parlementaire, "
+#~ "ajoutez-y du contenu ou modifiez-la."
+
+#~ msgid "Access, add or modify your reports tabled in Parliament."
+#~ msgstr ""
+#~ "Consultez vos rapports déposés au "
+#~ "Parlement, ajoutez-y du contenu ou "
+#~ "modifiez-les."
+
+#~ msgid ""
+#~ "These fields have been removed, click"
+#~ " save below to update the record "
+#~ "with your changes."
+#~ msgstr ""
+#~ "Ces champs ont été supprimés. Cliquez"
+#~ " sur « Enregistrer » ci-dessous "
+#~ "pour mettre à jour le document."
+
+#~ msgid ""
+#~ "Access, upload and modify your "
+#~ "Departmental Audit Committee members’ "
+#~ "remuneration and expenses."
+#~ msgstr ""
+#~ "Accès, téléversement et modification de "
+#~ "la rémunération et des dépenses des "
+#~ "membres de votre Comité ministériel "
+#~ "d’audit."
+
+#~ msgid "This text must be provided in both languages"
+#~ msgstr "Ce texte doit être fourni dans les deux langues"
+
+#~ msgid ""
+#~ "Are you sure you want to delete"
+#~ " this Organization? Note*: Deleting cannot"
+#~ " be performed while public or private"
+#~ " datasets belong to this organization."
+#~ msgstr ""
+#~ "Voulez-vous vraiment supprimer cette "
+#~ "organisation? Remarque* : il n'est pas"
+#~ " possible de supprimer une organisation "
+#~ "qui détient encore des jeux de "
+#~ "données publics ou privés."
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,20 @@
+[extract_messages]
+keywords = translate isPlural
+add_comments = TRANSLATORS:
+output_file = ckanext/canada/i18n/ckanext-canada.pot
+width = 80
+
+[init_catalog]
+domain = ckanext-canada
+input_file = ckanext/canada/i18n/ckanext-canada.pot
+output_dir = ckanext/canada/i18n
+
+[update_catalog]
+domain = ckanext-canada
+input_file = ckanext/canada/i18n/ckanext-canada.pot
+output_dir = ckanext/canada/i18n
+
+[compile_catalog]
+domain = ckanext-canada
+directory = ckanext/canada/i18n
+statistics = true


### PR DESCRIPTION
Added the `setup.cfg` file used by Babel to do message extraction and cataloging for translation files.

Ran `extract_messages` with the new babel config.

Ran `update_catalog` for `en` and `fr` locales with the new babel config.