### PR TITLE
Include Data for recently_changed_packages_activity_list

### DIFF
--- a/ckanext/canada/activity.py
+++ b/ckanext/canada/activity.py
@@ -3,6 +3,8 @@ from ckan.logic import get_action
 from ckan.common import _, ungettext
 from ckan.lib.helpers import url_for
 import datetime
+import ckan.logic as logic
+import ckan.lib.dictization.model_dictize as model_dictize
 
 MERGE_ACTIVITIES_WITHIN_SECONDS = 2
 
@@ -54,3 +56,39 @@ def datastore_activity_create(context, act_data):
         'session': context['session'],
     }
     get_action('activity_create')(activity_create_context, activity_dict)
+
+
+@logic.validate(logic.schema.default_dashboard_activity_list_schema)
+def recently_changed_packages_activity_list(context, data_dict):
+    '''Copied from ckan/ckan/logic/action/get.py
+    Custom: Sets include_data to True
+    TODO: Remove this action override in CKAN 2.10 upgrade
+
+    Return the activity stream of all recently added or changed packages.
+
+    :param offset: where to start getting activity items from
+        (optional, default: ``0``)
+    :type offset: int
+    :param limit: the maximum number of activities to return
+        (optional, default: ``31`` unless set in site's configuration
+        ``ckan.activity_list_limit``, upper limit: ``100`` unless set in
+        site's configuration ``ckan.activity_list_limit_max``)
+    :type limit: int
+
+    :rtype: list of dictionaries
+
+    '''
+    # FIXME: Filter out activities whose subject or object the user is not
+    # authorized to read.
+    model = context['model']
+    offset = data_dict.get('offset', 0)
+    data_dict['include_data'] = True
+    limit = data_dict['limit']  # defaulted, limited & made an int by schema
+
+    activity_objects = \
+        model.activity.recently_changed_packages_activity_list(
+            limit=limit, offset=offset)
+
+    return model_dictize.activity_list_dictize(
+        activity_objects, context,
+        include_data=data_dict['include_data'])

--- a/ckanext/canada/plugins.py
+++ b/ckanext/canada/plugins.py
@@ -564,7 +564,9 @@ ckanext.canada:schemas/prop.yaml
     def get_actions(self):
         return {
                 'datastore_upsert': datastore_upsert,
-                'datastore_delete': datastore_delete}
+                'datastore_delete': datastore_delete,
+                'recently_changed_packages_activity_list': act.recently_changed_packages_activity_list,  #TODO: Remove this action override in CKAN 2.10 upgrade
+               }
 
     # IAuthFunctions
     def get_auth_functions(self):


### PR DESCRIPTION
fix(api): override action callback method;

- Overrode `recently_changed_packages_activity_list` callback to set `include_data` to `True`.

Includes `TODO` comments to remove in 2.10 upgrade as this exclusion of data in this action method is only in CKAN 2.9