### PR TITLE
Hide Datatable View for Recombinant Resource out of Datastore

### DIFF
--- a/ckanext/canada/templates/internal/recombinant/resource_edit.html
+++ b/ckanext/canada/templates/internal/recombinant/resource_edit.html
@@ -55,7 +55,7 @@
 
 {% block primary %}
   {{ super() }}
-  {% if resource and has_datastore_table is defined and has_datastore_table.get(resource.id) %}
+  {% if resource and 'error' not in resource %}
     {{ h.get_datapreview_recombinant(resource.name, resource.id, organization.name, dataset.dataset_type) }}
   {% endif %}
 {% endblock %}

--- a/ckanext/canada/templates/internal/recombinant/resource_edit.html
+++ b/ckanext/canada/templates/internal/recombinant/resource_edit.html
@@ -55,7 +55,7 @@
 
 {% block primary %}
   {{ super() }}
-  {% if resource and has_datastore_table %}
+  {% if resource and has_datastore_table.get(resource.id) %}
     {{ h.get_datapreview_recombinant(resource.name, resource.id, organization.name, dataset.dataset_type) }}
   {% endif %}
 {% endblock %}

--- a/ckanext/canada/templates/internal/recombinant/resource_edit.html
+++ b/ckanext/canada/templates/internal/recombinant/resource_edit.html
@@ -55,7 +55,7 @@
 
 {% block primary %}
   {{ super() }}
-  {% if resource and has_datastore_table.get(resource.id) %}
+  {% if resource and has_datastore_table is defined and has_datastore_table.get(resource.id) %}
     {{ h.get_datapreview_recombinant(resource.name, resource.id, organization.name, dataset.dataset_type) }}
   {% endif %}
 {% endblock %}

--- a/ckanext/canada/templates/internal/recombinant/resource_edit.html
+++ b/ckanext/canada/templates/internal/recombinant/resource_edit.html
@@ -55,7 +55,7 @@
 
 {% block primary %}
   {{ super() }}
-  {% if resource %}
+  {% if resource and has_datastore_table %}
     {{ h.get_datapreview_recombinant(resource.name, resource.id, organization.name, dataset.dataset_type) }}
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
feat(templates): recombinant new var;

- Use new recombinant template var.

Depends on https://github.com/open-data/ckanext-recombinant/pull/118

This will just use the new template variable to prevent AJAX errors from popping up on users in the Datatable view.