### PR TITLE
Implement Default Data Dictionary Info

### DIFF
--- a/ckanext/canada/plugins.py
+++ b/ckanext/canada/plugins.py
@@ -6,6 +6,7 @@ import ckan.plugins as p
 from ckan.lib.plugins import DefaultDatasetForm, DefaultTranslation
 import ckan.lib.helpers as hlp
 from ckan.logic import validators as logic_validators
+from ckanext.datastore.interfaces import IDataDictionaryForm
 
 from ckan.plugins.toolkit import (
     c,
@@ -107,6 +108,8 @@ class CanadaDatasetsPlugin(SchemingDatasetsPlugin):
     p.implements(p.IDatasetForm, inherit=True)
     p.implements(p.IPackageController, inherit=True)
     p.implements(p.IBlueprint)
+    p.implements(IDataDictionaryForm, inherit=True)
+
     try:
         from ckanext.validation.interfaces import IDataValidation
     except ImportError:
@@ -305,6 +308,16 @@ class CanadaDatasetsPlugin(SchemingDatasetsPlugin):
                 cr.pop('__extras', None)
 
         return data_dict
+
+    # IDataDictionaryForm
+
+    def update_datastore_info_field(self, field, plugin_data):
+        if 'info' or '_info' in plugin_data and 'info' not in field:
+            if 'info' in plugin_data:
+                field['info'] = plugin_data.get('info', {})
+            elif '_info' in plugin_data:
+                field['info'] = plugin_data.get('_info', {})
+        return field
 
 
 class DataGCCAInternal(p.SingletonPlugin):

--- a/ckanext/canada/templates/public/datastore/snippets/dictionary_view.html
+++ b/ckanext/canada/templates/public/datastore/snippets/dictionary_view.html
@@ -1,0 +1,15 @@
+{% ckan_extends %}
+
+{% block dictionary_field_extras %}
+  {# we save <field>_en and <field>_fr, not <field>_translated_<lang> #}
+  {# so get_translated will not work for our data dictionary fields. #}
+  {{ super() }}
+  {% if res.url_type != 'tabledesigner' %}
+    {% call dictionary_field(_('Label')) %}
+      {{ field.get('info', {}).get('label_' ~ h.lang()) }}
+    {% endcall %}
+    {% call dictionary_field(_('Description')) %}
+      {{ field.get('info', {}).get('notes_' ~ h.lang()) }}
+    {% endcall %}
+  {% endif %}
+{% endblock %}

--- a/ckanext/canada/tests/test_logic.py
+++ b/ckanext/canada/tests/test_logic.py
@@ -1,0 +1,43 @@
+# -*- coding: UTF-8 -*-
+from ckanext.canada.tests import CanadaTestBase
+from ckanapi import LocalCKAN
+
+from ckanext.canada.tests.factories import CanadaResource as Resource
+
+
+class TestCanadaLogic(CanadaTestBase):
+    @classmethod
+    def setup_method(self, method):
+        """Method is called at class level before EACH test methods of the class are called.
+        Setup any state specific to the execution of the given class methods.
+        """
+        super(TestCanadaLogic, self).setup_method(method)
+
+        self.lc = LocalCKAN()
+
+    def test_data_dictionary(self):
+        """
+        The custom fields should get saved in the Data Dictionary,
+        and be returned from datastore_info.
+        """
+        resource = Resource()
+        self.lc.action.datastore_create(resource_id=resource['id'],
+                                        force=True,
+                                        fields=[{'id': 'exampled_id',
+                                                 'type': 'text',
+                                                 'info': {'label_en': 'Example Label',
+                                                          'label_fr': 'Example Label FR',
+                                                          'notes_en': 'Example Description',
+                                                          'notes_fr': 'Example Description FR'}}])
+
+        ds_info = self.lc.action.datastore_info(id=resource['id'])
+
+        assert 'fields' in ds_info
+        assert len(ds_info['fields']) == 1
+        assert ds_info['fields'][0]['id'] == 'exampled_id'
+        assert 'info' in ds_info['fields'][0]
+        assert 'label_en' in ds_info['fields'][0]['info']
+        assert 'label_fr' in ds_info['fields'][0]['info']
+        assert 'notes_en' in ds_info['fields'][0]['info']
+        assert 'notes_fr' in ds_info['fields'][0]['info']
+

--- a/ckanext/canada/tests/test_logic.py
+++ b/ckanext/canada/tests/test_logic.py
@@ -37,7 +37,11 @@ class TestCanadaLogic(CanadaTestBase):
         assert ds_info['fields'][0]['id'] == 'exampled_id'
         assert 'info' in ds_info['fields'][0]
         assert 'label_en' in ds_info['fields'][0]['info']
+        assert ds_info['fields'][0]['info']['label_en'] == 'Example Label'
         assert 'label_fr' in ds_info['fields'][0]['info']
+        assert ds_info['fields'][0]['info']['label_fr'] == 'Example Label FR'
         assert 'notes_en' in ds_info['fields'][0]['info']
+        assert ds_info['fields'][0]['info']['notes_en'] == 'Example Description'
         assert 'notes_fr' in ds_info['fields'][0]['info']
+        assert ds_info['fields'][0]['info']['notes_fr'] == 'Example Description FR'
 


### PR DESCRIPTION
fix(dev): datastore info;

- Fix datastore info by implementing a default info return.
- Fix get_translated for data dictionary.