### PR TITLE
Trim `metadata_modified` from Resources (Major Fix for Post to Portal)

### DIFF
--- a/changes/1482.bugfix
+++ b/changes/1482.bugfix
@@ -1,0 +1,1 @@
+Ignore the `metadata_modified` Resource field in the "Post to Portal" code. Fixing a major issue where a Dataset's `metadata_modified` field would be updated, and a lot of activities would be created on the Portal.

--- a/ckanext/canada/cli.py
+++ b/ckanext/canada/cli.py
@@ -69,7 +69,7 @@ RESOURCE_TRIM_FIELDS = ['package_id', 'revision_id',
                 'webstore_last_updated', 'state',
                 'description', 'tracking_summary', 'mimetype_inner',
                 'mimetype', 'cache_url', 'created', 'webstore_url',
-                'position']
+                'position', 'metadata_modified']
 
 
 class PortalUpdater(object):


### PR DESCRIPTION
fix(cli): trim resource fields;

- Added `metadata_modified` resource field to trim fields for post to portal and copy datasets commands.

@wardi looks like this major issue has been happening since the CKAN 2.9 upgrade for us. See: https://github.com/ckan/ckan/commit/913d70be0d896c0e948e8ded232a3b2460189708

So the Resource's `metadata_modified` on the Portal would always be different than the Registry. This explains the giant activity table on the Portal.