### PR TITLE
Trim Text Fields for PD Record Solr Indices

### DIFF
--- a/changes/1489.bugfix
+++ b/changes/1489.bugfix
@@ -1,0 +1,1 @@
+Trim Proactive Disclosure text fields to 28kB for Solr record indexing. This affects PD types that do not use the Advanced Search (Django) app.

--- a/ckanext/canada/pd.py
+++ b/ckanext/canada/pd.py
@@ -23,6 +23,8 @@ from ckanext.canada.dataset import (
     data_batch,
     safe_for_solr)
 
+SOLR_MAX_TEXT_LENGTH = 28000
+
 
 def get_commands():
     return pd
@@ -288,7 +290,8 @@ def _update_records(records, org_detail, conn, resource_name, unmatched):
                 except ValueError:
                     pass
 
-            solrrec[key] = value
+            # limit text values to 28K for indexing. Solr max 32K minus a threshold for synonym replacements.
+            solrrec[key] = value[:SOLR_MAX_TEXT_LENGTH] if (f.get('datastore_type') == 'text' and len(value) > SOLR_MAX_TEXT_LENGTH) else value
 
             choices = choice_fields.get(f['datastore_id'])
             if choices:

--- a/ckanext/canada/tests/test_pd.py
+++ b/ckanext/canada/tests/test_pd.py
@@ -1,5 +1,12 @@
 # -*- coding: UTF-8 -*-
 from ckanext.canada.pd import dollar_range_facet
+from ckanext.canada.tests import CanadaTestBase
+from ckanapi import LocalCKAN
+
+from ckanext.canada.tests.factories import CanadaOrganization as Organization
+
+from ckanext.recombinant.tables import get_chromo
+from ckanext.canada.pd import _update_records, clear_index, solr_connection
 
 
 class TestDollarRangeFacet(object):
@@ -30,3 +37,51 @@ class TestDollarRangeFacet(object):
            'foo_range': u'1',
             'foo_en': u'B: $500.00 - $999.99',
             'foo_fr': u'B: 500,00\xa0$ - 999,99\xa0$'}
+
+
+class TestIndex(CanadaTestBase):
+
+    ds_type = 'ati'
+
+    @classmethod
+    def setup_method(self, method):
+        """Method is called at class level before EACH test methods of the class are called.
+        Setup any state specific to the execution of the given class methods.
+        """
+        super(TestIndex, self).setup_method(method)
+
+        self.org = Organization()
+        self.lc = LocalCKAN()
+
+        self.lc.action.recombinant_create(dataset_type=self.ds_type, owner_org=self.org['name'])
+        rval = self.lc.action.recombinant_show(dataset_type=self.ds_type, owner_org=self.org['name'])
+
+        self.resource_id = rval['resources'][0]['id']
+
+
+    def get_records(self):
+        rval = self.lc.action.datastore_search(
+            resource_id=self.resource_id,
+            limit=25000,
+            offset=0)
+        records = rval['records']
+        return records
+
+
+    def test_max_text_length(self):
+        record = get_chromo(self.ds_type)['examples']['record']
+        record['summary_en'] = 'e' * 33000
+        record['summary_fr'] = 'é' * 33000
+        self.lc.action.datastore_upsert(
+            resource_id=self.resource_id,
+            records=[record])
+
+        clear_index(self.ds_type)
+        conn = solr_connection(self.ds_type)
+
+        org_detail = self.lc.action.organization_show(id=self.org['id'])
+        resource = self.lc.action.resource_show(id=self.resource_id)
+
+        _update_records(self.get_records(), org_detail, conn, resource['name'], None, retry=False)
+
+        conn.commit()


### PR DESCRIPTION
fix(cli): solr index max length;

- Max length for PD records into solr for text fields.