### PR TITLE
add 3 open maps file formats

### DIFF
--- a/changes/1490.misc
+++ b/changes/1490.misc
@@ -1,0 +1,1 @@
+add 3 open maps file formats: COG, APRX, PBF

--- a/ckanext/canada/schemas/presets.yaml
+++ b/ckanext/canada/schemas/presets.yaml
@@ -3276,6 +3276,7 @@ presets:
       mimetype: audio/mp4
     - value: AIFF
       mimetype: audio/aiff
+    - value: APRX
     - value: ASCII Grid
       label:
         en: ASCII Grid
@@ -3306,6 +3307,7 @@ presets:
       label:
         en: Blackberry Application
         fr: Application Blackberry
+    - value: COG
     - value: CSV
       mimetype: text/csv
       openness_score: 3
@@ -3475,6 +3477,7 @@ presets:
       replaces: [ppt]
     - value: QLR
       mimetype: application/x-qgis-layer-definition
+    - value: PBF
     - value: PPTX
       mimetype: application/vnd.openxmlformats-officedocument.presentationml.presentation
     - value: RDF


### PR DESCRIPTION
@JVickery-TBS not using the full English/French text provided to be consistent with the other types in the list.

Original request:
> COG: Cloud Optimized GeoTIFF / GeoTIFF optimisé pour le nuage
> APRX: ArcGIS Pro Project File / Fichier de projet d’ArcGIS Pro
> PBF: OpenStreetMap Download Format / Format de téléchargement de OpenStreetMap