### PR TITLE
Round Money DS Types in Triggers

### DIFF
--- a/changes/1496.changes
+++ b/changes/1496.changes
@@ -1,0 +1,1 @@
+Money fields for PD types now get rounded to 2 decimals when inserting into the database.

--- a/ckanext/canada/tables/contracts.yaml
+++ b/ckanext/canada/tables/contracts.yaml
@@ -25,14 +25,14 @@ upload_info:
 
 upload_warn:
   en: |
-    As of March 6, 2024, all contracts and associated amendments will appear 
-    as a single contract with their respective amendments linked on the Portal. 
-    Please email the Portal team at <a href="mailto:open-ouvert@tbs-sct.gc.ca">open-ouvert@tbs-sct.gc.ca</a> 
+    As of March 6, 2024, all contracts and associated amendments will appear
+    as a single contract with their respective amendments linked on the Portal.
+    Please email the Portal team at <a href="mailto:open-ouvert@tbs-sct.gc.ca">open-ouvert@tbs-sct.gc.ca</a>
     should you have additional questions or concerns.
   fr: |
-    À partir du 6 mars 2024, tous les contrats et leurs modifications apparaîtront 
-    comme un seul contrat avec leurs modifications respectifs liés sur le portail. 
-    Si vous avez des questions ou préoccupations, veuillez communiquer avec l'équipe 
+    À partir du 6 mars 2024, tous les contrats et leurs modifications apparaîtront
+    comme un seul contrat avec leurs modifications respectifs liés sur le portail.
+    Si vous avez des questions ou préoccupations, veuillez communiquer avec l'équipe
     du portail à <a href="mailto:open-ouvert@tbs-sct.gc.ca">open-ouvert@tbs-sct.gc.ca</a>.
 
 template_version: 3
@@ -2165,6 +2165,10 @@ resources:
             {reporting_period},
             'reporting_period');
         END IF;
+
+        NEW.contract_value := round(NEW.contract_value, 2);
+        NEW.original_value := round(NEW.original_value, 2);
+        NEW.amendment_value := round(NEW.amendment_value, 2);
 
         IF errors = '{{}}' THEN
           RETURN NEW;

--- a/ckanext/canada/tables/contractsa.yaml
+++ b/ckanext/canada/tables/contractsa.yaml
@@ -378,7 +378,13 @@ resources:
         IF NEW.year > date_part('year', CURRENT_DATE) THEN
           errors := errors || ARRAY[['year', {year_error}]];
         END IF;
-
+        NEW.contracts_goods_original_value := round(NEW.contracts_goods_original_value, 2);
+        NEW.contracts_goods_amendment_value := round(NEW.contracts_goods_amendment_value, 2);
+        NEW.contracts_service_original_value := round(NEW.contracts_service_original_value, 2);
+        NEW.contracts_service_amendment_value := round(NEW.contracts_service_amendment_value, 2);
+        NEW.contracts_construction_original_value := round(NEW.contracts_construction_original_value, 2);
+        NEW.contracts_construction_amendment_value := round(NEW.contracts_construction_amendment_value, 2);
+        NEW.acquisition_card_transactions_total_value := round(NEW.acquisition_card_transactions_total_value, 2);
         IF errors = '{{}}' THEN
           RETURN NEW;
         END IF;

--- a/ckanext/canada/tables/dac.yaml
+++ b/ckanext/canada/tables/dac.yaml
@@ -307,6 +307,8 @@ resources:
         errors := errors || required_error(NEW.remuneration, 'remuneration');
         errors := errors || required_error(NEW.travel_expenses, 'travel_expenses');
         errors := errors || required_error(NEW.travel_expenses, 'travel_expenses');
+        NEW.remuneration := round(NEW.remuneration, 2);
+        NEW.travel_expenses := round(NEW.travel_expenses, 2);
         IF errors = '{{}}' THEN
           RETURN NEW;
         END IF;

--- a/ckanext/canada/tables/grants.yaml
+++ b/ckanext/canada/tables/grants.yaml
@@ -819,6 +819,8 @@ resources:
           errors := errors || required_error(NEW.description_en, 'description_en');
           errors := errors || required_error(NEW.description_fr, 'description_fr');
         END IF;
+        NEW.agreement_value := round(NEW.agreement_value, 2);
+        NEW.foreign_currency_value := round(NEW.foreign_currency_value, 2);
         IF errors = '{{}}' THEN
           RETURN NEW;
         END IF;

--- a/ckanext/canada/tables/hospitalityq.yaml
+++ b/ckanext/canada/tables/hospitalityq.yaml
@@ -434,6 +434,7 @@ resources:
           errors := errors || required_error(NEW.guest_attendees, 'guest_attendees');
           errors := errors || required_error(NEW.total, 'total');
         END IF;
+        NEW.total := round(NEW.total, 2);
         IF errors = '{{}}' THEN
           RETURN NEW;
         END IF;

--- a/ckanext/canada/tables/travelq.yaml
+++ b/ckanext/canada/tables/travelq.yaml
@@ -418,6 +418,12 @@ resources:
           errors := errors || required_error(NEW.meals, 'meals');
           errors := errors || required_error(NEW.total, 'total');
         END IF;
+        NEW.airfare := round(NEW.airfare, 2);
+        NEW.other_transport := round(NEW.other_transport, 2);
+        NEW.lodging := round(NEW.lodging, 2);
+        NEW.meals := round(NEW.meals, 2);
+        NEW.other_expenses := round(NEW.other_expenses, 2);
+        NEW.total := round(NEW.total, 2);
         IF errors = '{{}}' THEN
           RETURN NEW;
         END IF;


### PR DESCRIPTION
The money psql type is not rounding to 2 decimal places. Use DB triggers to round before inserting into tables.