### PR TITLE
Add `tmpdir` Option to Makefile

### DIFF
--- a/bin/pd/Makefile
+++ b/bin/pd/Makefile
@@ -32,7 +32,7 @@ ckanapi := $(REGISTRY_CKANAPI_COMMAND)
 ogc_search := $(OGC_SEARCH_COMMAND)
 oc_search := $(OC_SEARCH_COMMAND)
 backup_dir := $(PD_BACKUP_DIRECTORY)
-tmp_dir := $(or $(PD_TMP_DIRECTORY),$(TMPDIR),/tmp)
+tmp_dir := $(or $(PD_TMP_DIRECTORY),$(TMPDIR))
 registry_static := $(REGISTRY_STATIC_SMB_DIRECTORY)
 portal_static := $(PORTAL_STATIC_SMB_DIRECTORY)
 
@@ -49,7 +49,7 @@ endif
 .PHONY: help
 help:
 	@echo Usage:
-	@echo '    make target ... [workdir=/path/to/working/directory]'
+	@echo '    make target ... [workdir=/path/to/working/directory] [tmpdir=/path/to/tmp/directory]'
 	@echo
 	@echo Targets:
 	@echo '    nightly                  dump, filter, backup, upload, rebuild all targets'
@@ -65,6 +65,10 @@ help:
 	@for t in $(targets); do \
 		printf '    %-24s upload and rebuild search\n' "$$t"; \
 	done
+
+ifdef tmpdir
+tmp_dir := $(tmpdir)
+endif
 
 ifeq ($(fdir),)
 $(error PD_FILTER_SCRIPT_DIRECTORY is undefined)
@@ -88,7 +92,8 @@ else ifeq ($(registry_static),)
 $(error REGISTRY_STATIC_SMB_DIRECTORY is undefined)
 else ifeq ($(portal_static),)
 $(error PORTAL_STATIC_SMB_DIRECTORY is undefined)
-
+else ifeq ($(tmp_dir),)
+$(error PD_TMP_DIRECTORY and TMPDIR are undefined or tmpdir not supplied)
 else ifeq ($(workdir),)
 location = $(CURDIR)/$(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST))
 self := $(location)

--- a/changes/1497.changes
+++ b/changes/1497.changes
@@ -1,0 +1,1 @@
+The Makefile no longer falls back to `/tmp` for the temporary directory. It will always use the `PD_TMP_DIRECTORY` or `TMPDIR` environment variables. You can now supply `tmpdir=/path/to/tmp/directory`. The Makefile will fail if no temporary directory is found.

--- a/ckanext/canada/tests/test_make.py
+++ b/ckanext/canada/tests/test_make.py
@@ -53,6 +53,7 @@ class TestMakePD(CanadaTestBase):
 
         self.tmp_dir = mkdtemp()
 
+        os.environ['TMPDIR'] = '/tmp'
         os.environ['PD_FILTER_SCRIPT_DIRECTORY'] = PD_FILTER_SCRIPT_DIRECTORY
         os.environ['REGISTRY_PASTER_COMMAND'] = 'paster'
         os.environ['REGISTRY_PYTHON_COMMAND'] = 'python3'


### PR DESCRIPTION
feat(pd): no fallback tmp;

- Never fallback to the `/tmp` directory for the makefile.