### PR TITLE
Service Inventory No Commas in Primary Key Fields

### DIFF
--- a/changes/1535.hotfix
+++ b/changes/1535.hotfix
@@ -1,0 +1,1 @@
+Service Inventory primary key fields no longer allow commas.

--- a/ckanext/canada/i18n/ckanext-canada.pot
+++ b/ckanext/canada/i18n/ckanext-canada.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-canada 0.4.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-11-12 15:06+0000\n"
+"POT-Creation-Date: 2024-11-20 16:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -781,7 +781,7 @@ msgid "{num} deleted."
 msgstr ""
 
 #. SQL Trigger String for PD Type: service
-#: ckanext/canada/tables/service.yaml:2348 ckanext/canada/view.py:707
+#: ckanext/canada/tables/service.yaml:2373 ckanext/canada/view.py:707
 msgid "Number required"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr ""
 #. SQL Trigger String for PD Type: ati
 #. SQL Trigger String for PD Type: service
 #: ckanext/canada/tables/ati.yaml:142 ckanext/canada/tables/ati.yaml:254
-#: ckanext/canada/tables/service.yaml:1532 ckanext/canada/tables/service.yaml:2345
+#: ckanext/canada/tables/service.yaml:1540 ckanext/canada/tables/service.yaml:2370
 msgid "This value must not be negative"
 msgstr ""
 
@@ -1358,54 +1358,64 @@ msgid "Service Identification Information & Metrics"
 msgstr ""
 
 #. SQL Trigger String for PD Type: service
-#: ckanext/canada/tables/service.yaml:1531
+#: ckanext/canada/tables/service.yaml:1539
 msgid "This field must be either a number, \"NA\", or \"ND\""
 msgstr ""
 
 #. SQL Trigger String for PD Type: service
-#: ckanext/canada/tables/service.yaml:1533 ckanext/canada/tables/service.yaml:2346
+#: ckanext/canada/tables/service.yaml:1541 ckanext/canada/tables/service.yaml:2371
 msgid "This field has a maximum length of {} characters."
 msgstr ""
 
 #. SQL Trigger String for PD Type: service
-#: ckanext/canada/tables/service.yaml:1534 ckanext/canada/tables/service.yaml:2347
+#: ckanext/canada/tables/service.yaml:1542 ckanext/canada/tables/service.yaml:2372
 msgid "Invalid choice: {}"
 msgstr ""
 
 #. SQL Trigger String for PD Type: service
-#: ckanext/canada/tables/service.yaml:1535 ckanext/canada/tables/service.yaml:2349
+#: ckanext/canada/tables/service.yaml:1543 ckanext/canada/tables/service.yaml:2374
 msgid "Invalid input syntax for type integer: {}"
 msgstr ""
 
 #. SQL Trigger String for PD Type: service
-#: ckanext/canada/tables/service.yaml:1536 ckanext/canada/tables/service.yaml:2350
+#: ckanext/canada/tables/service.yaml:1544 ckanext/canada/tables/service.yaml:2375
 msgid "This field is required due to a response in a different field."
 msgstr ""
 
 #. SQL Trigger String for PD Type: service
-#: ckanext/canada/tables/service.yaml:1537 ckanext/canada/tables/service.yaml:2351
+#: ckanext/canada/tables/service.yaml:1545 ckanext/canada/tables/service.yaml:2376
 msgid "This text must be provided in both languages"
 msgstr ""
 
+#. SQL Trigger String for PD Type: service
+#: ckanext/canada/tables/service.yaml:1546 ckanext/canada/tables/service.yaml:2377
+msgid "Comma is not allowed in Service ID Number field"
+msgstr ""
+
 #. SQL Constraint Error String for PD Type: service
-#: ckanext/canada/tables/service.yaml:1346
+#: ckanext/canada/tables/service.yaml:1351
 msgid ""
 "Cannot delete record(s) because the Fiscal Year, Service ID Number is "
 "referenced in at least one Service Standards & Performance Results record."
 msgstr ""
 
 #. Resource Title for PD Type: service
-#: ckanext/canada/tables/service.yaml:1611
+#: ckanext/canada/tables/service.yaml:1620
 msgid "Service Standards & Performance Results"
 msgstr ""
 
 #. SQL Trigger String for PD Type: service
-#: ckanext/canada/tables/service.yaml:1948 ckanext/canada/tables/service.yaml:2344
+#: ckanext/canada/tables/service.yaml:1967 ckanext/canada/tables/service.yaml:2369
 msgid "This field must be a single number between 0 and 1 representing a percentage."
 msgstr ""
 
+#. SQL Trigger String for PD Type: service
+#: ckanext/canada/tables/service.yaml:2378
+msgid "Comma is not allowed in Service Standard ID field"
+msgstr ""
+
 #. SQL Constraint Error String for PD Type: service
-#: ckanext/canada/tables/service.yaml:2252
+#: ckanext/canada/tables/service.yaml:2271
 msgid ""
 "Cannot create record because the Service ID Number does not exist in the "
 "Service Identification Information & Metrics resource for that fiscal year."

--- a/ckanext/canada/i18n/en/LC_MESSAGES/ckanext-canada.po
+++ b/ckanext/canada/i18n/en/LC_MESSAGES/ckanext-canada.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  CKAN\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-11-12 15:06+0000\n"
+"POT-Creation-Date: 2024-11-20 16:24+0000\n"
 "PO-Revision-Date: 2014-01-23 13:04+0000\n"
 "Last-Translator: Sean Hammond <sean.hammond@okfn.org>\n"
 "Language: en\n"
@@ -795,7 +795,7 @@ msgid "{num} deleted."
 msgstr ""
 
 #. SQL Trigger String for PD Type: service
-#: ckanext/canada/tables/service.yaml:2348 ckanext/canada/view.py:707
+#: ckanext/canada/tables/service.yaml:2373 ckanext/canada/view.py:707
 msgid "Number required"
 msgstr ""
 
@@ -969,8 +969,8 @@ msgstr ""
 #. SQL Trigger String for PD Type: ati
 #. SQL Trigger String for PD Type: service
 #: ckanext/canada/tables/ati.yaml:142 ckanext/canada/tables/ati.yaml:254
-#: ckanext/canada/tables/service.yaml:1532
-#: ckanext/canada/tables/service.yaml:2345
+#: ckanext/canada/tables/service.yaml:1540
+#: ckanext/canada/tables/service.yaml:2370
 msgid "This value must not be negative"
 msgstr ""
 
@@ -1386,42 +1386,48 @@ msgid "Service Identification Information & Metrics"
 msgstr ""
 
 #. SQL Trigger String for PD Type: service
-#: ckanext/canada/tables/service.yaml:1531
+#: ckanext/canada/tables/service.yaml:1539
 msgid "This field must be either a number, \"NA\", or \"ND\""
 msgstr ""
 
 #. SQL Trigger String for PD Type: service
-#: ckanext/canada/tables/service.yaml:1533
-#: ckanext/canada/tables/service.yaml:2346
+#: ckanext/canada/tables/service.yaml:1541
+#: ckanext/canada/tables/service.yaml:2371
 msgid "This field has a maximum length of {} characters."
 msgstr ""
 
 #. SQL Trigger String for PD Type: service
-#: ckanext/canada/tables/service.yaml:1534
-#: ckanext/canada/tables/service.yaml:2347
+#: ckanext/canada/tables/service.yaml:1542
+#: ckanext/canada/tables/service.yaml:2372
 msgid "Invalid choice: {}"
 msgstr ""
 
 #. SQL Trigger String for PD Type: service
-#: ckanext/canada/tables/service.yaml:1535
-#: ckanext/canada/tables/service.yaml:2349
+#: ckanext/canada/tables/service.yaml:1543
+#: ckanext/canada/tables/service.yaml:2374
 msgid "Invalid input syntax for type integer: {}"
 msgstr ""
 
 #. SQL Trigger String for PD Type: service
-#: ckanext/canada/tables/service.yaml:1536
-#: ckanext/canada/tables/service.yaml:2350
+#: ckanext/canada/tables/service.yaml:1544
+#: ckanext/canada/tables/service.yaml:2375
 msgid "This field is required due to a response in a different field."
 msgstr ""
 
 #. SQL Trigger String for PD Type: service
-#: ckanext/canada/tables/service.yaml:1537
-#: ckanext/canada/tables/service.yaml:2351
+#: ckanext/canada/tables/service.yaml:1545
+#: ckanext/canada/tables/service.yaml:2376
 msgid "This text must be provided in both languages"
 msgstr ""
 
+#. SQL Trigger String for PD Type: service
+#: ckanext/canada/tables/service.yaml:1546
+#: ckanext/canada/tables/service.yaml:2377
+msgid "Comma is not allowed in Service ID Number field"
+msgstr ""
+
 #. SQL Constraint Error String for PD Type: service
-#: ckanext/canada/tables/service.yaml:1346
+#: ckanext/canada/tables/service.yaml:1351
 msgid ""
 "Cannot delete record(s) because the Fiscal Year, Service ID Number is "
 "referenced in at least one Service Standards & Performance Results "
@@ -1429,20 +1435,25 @@ msgid ""
 msgstr ""
 
 #. Resource Title for PD Type: service
-#: ckanext/canada/tables/service.yaml:1611
+#: ckanext/canada/tables/service.yaml:1620
 msgid "Service Standards & Performance Results"
 msgstr ""
 
 #. SQL Trigger String for PD Type: service
-#: ckanext/canada/tables/service.yaml:1948
-#: ckanext/canada/tables/service.yaml:2344
+#: ckanext/canada/tables/service.yaml:1967
+#: ckanext/canada/tables/service.yaml:2369
 msgid ""
 "This field must be a single number between 0 and 1 representing a "
 "percentage."
 msgstr ""
 
+#. SQL Trigger String for PD Type: service
+#: ckanext/canada/tables/service.yaml:2378
+msgid "Comma is not allowed in Service Standard ID field"
+msgstr ""
+
 #. SQL Constraint Error String for PD Type: service
-#: ckanext/canada/tables/service.yaml:2252
+#: ckanext/canada/tables/service.yaml:2271
 msgid ""
 "Cannot create record because the Service ID Number does not exist in the "
 "Service Identification Information & Metrics resource for that fiscal "

--- a/ckanext/canada/i18n/fr/LC_MESSAGES/ckanext-canada.po
+++ b/ckanext/canada/i18n/fr/LC_MESSAGES/ckanext-canada.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-11-12 15:06+0000\n"
+"POT-Creation-Date: 2024-11-20 16:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr\n"
@@ -239,8 +239,9 @@ msgstr "Tâche inconnue "
 #: ckanext/canada/logic.py:547
 #, python-format
 msgid "No Portal Sync information found for package %s"
-msgstr "Aucune information de synchronisation du portail n'a été "
-"trouvée pour le jeu de données %s"
+msgstr ""
+"Aucune information de synchronisation du portail n'a été trouvée pour le "
+"jeu de données %s"
 
 #: ckanext/canada/plugins.py:709
 #: ckanext/canada/templates/scheming/package/snippets/package_form.html:25
@@ -844,7 +845,7 @@ msgid "{num} deleted."
 msgstr "{num} supprimé."
 
 #. SQL Trigger String for PD Type: service
-#: ckanext/canada/tables/service.yaml:2348 ckanext/canada/view.py:707
+#: ckanext/canada/tables/service.yaml:2373 ckanext/canada/view.py:707
 msgid "Number required"
 msgstr "Nombre requis"
 
@@ -1045,8 +1046,8 @@ msgstr "Veuillez entrer une valeur comprise entre 1 et 12"
 #. SQL Trigger String for PD Type: ati
 #. SQL Trigger String for PD Type: service
 #: ckanext/canada/tables/ati.yaml:142 ckanext/canada/tables/ati.yaml:254
-#: ckanext/canada/tables/service.yaml:1532
-#: ckanext/canada/tables/service.yaml:2345
+#: ckanext/canada/tables/service.yaml:1540
+#: ckanext/canada/tables/service.yaml:2370
 msgid "This value must not be negative"
 msgstr "Cette valeur ne doit être négative"
 
@@ -1535,42 +1536,48 @@ msgid "Service Identification Information & Metrics"
 msgstr "Information et paramètres sur l’identification des services"
 
 #. SQL Trigger String for PD Type: service
-#: ckanext/canada/tables/service.yaml:1531
+#: ckanext/canada/tables/service.yaml:1539
 msgid "This field must be either a number, \"NA\", or \"ND\""
 msgstr "Ce champ doit être un chiffre, \"NA\", ou \"ND\""
 
 #. SQL Trigger String for PD Type: service
-#: ckanext/canada/tables/service.yaml:1533
-#: ckanext/canada/tables/service.yaml:2346
+#: ckanext/canada/tables/service.yaml:1541
+#: ckanext/canada/tables/service.yaml:2371
 msgid "This field has a maximum length of {} characters."
 msgstr "Ce champ ne peut excéder une longueur maximale de {} caractères."
 
 #. SQL Trigger String for PD Type: service
-#: ckanext/canada/tables/service.yaml:1534
-#: ckanext/canada/tables/service.yaml:2347
+#: ckanext/canada/tables/service.yaml:1542
+#: ckanext/canada/tables/service.yaml:2372
 msgid "Invalid choice: {}"
 msgstr "Choix non valide : {}"
 
 #. SQL Trigger String for PD Type: service
-#: ckanext/canada/tables/service.yaml:1535
-#: ckanext/canada/tables/service.yaml:2349
+#: ckanext/canada/tables/service.yaml:1543
+#: ckanext/canada/tables/service.yaml:2374
 msgid "Invalid input syntax for type integer: {}"
 msgstr "Syntaxe d'entrée invalide pour le type entier : {}"
 
 #. SQL Trigger String for PD Type: service
-#: ckanext/canada/tables/service.yaml:1536
-#: ckanext/canada/tables/service.yaml:2350
+#: ckanext/canada/tables/service.yaml:1544
+#: ckanext/canada/tables/service.yaml:2375
 msgid "This field is required due to a response in a different field."
 msgstr "Ce champ est requis en raison d'une réponse présente dans un autre champ."
 
 #. SQL Trigger String for PD Type: service
-#: ckanext/canada/tables/service.yaml:1537
-#: ckanext/canada/tables/service.yaml:2351
+#: ckanext/canada/tables/service.yaml:1545
+#: ckanext/canada/tables/service.yaml:2376
 msgid "This text must be provided in both languages"
 msgstr "Ce texte doit être fourni dans les deux langues"
 
+#. SQL Trigger String for PD Type: service
+#: ckanext/canada/tables/service.yaml:1546
+#: ckanext/canada/tables/service.yaml:2377
+msgid "Comma is not allowed in Service ID Number field"
+msgstr "La virgule n’est pas autorisée dans le champ du Numéro d'identification du service"
+
 #. SQL Constraint Error String for PD Type: service
-#: ckanext/canada/tables/service.yaml:1346
+#: ckanext/canada/tables/service.yaml:1351
 msgid ""
 "Cannot delete record(s) because the Fiscal Year, Service ID Number is "
 "referenced in at least one Service Standards & Performance Results "
@@ -1581,13 +1588,13 @@ msgstr ""
 "\"Normes de service et résultats du rendement\""
 
 #. Resource Title for PD Type: service
-#: ckanext/canada/tables/service.yaml:1611
+#: ckanext/canada/tables/service.yaml:1620
 msgid "Service Standards & Performance Results"
 msgstr "Normes de service et résultats du rendement"
 
 #. SQL Trigger String for PD Type: service
-#: ckanext/canada/tables/service.yaml:1948
-#: ckanext/canada/tables/service.yaml:2344
+#: ckanext/canada/tables/service.yaml:1967
+#: ckanext/canada/tables/service.yaml:2369
 msgid ""
 "This field must be a single number between 0 and 1 representing a "
 "percentage."
@@ -1595,8 +1602,13 @@ msgstr ""
 "Ce champ doit inscrire un seul et unique chiffre entre 0 et 1 "
 "représentant un pourcentage"
 
+#. SQL Trigger String for PD Type: service
+#: ckanext/canada/tables/service.yaml:2378
+msgid "Comma is not allowed in Service Standard ID field"
+msgstr "La virgule n’est pas autorisée dans le champ du Numéro d'identification de la norme relative aux services"
+
 #. SQL Constraint Error String for PD Type: service
-#: ckanext/canada/tables/service.yaml:2252
+#: ckanext/canada/tables/service.yaml:2271
 msgid ""
 "Cannot create record because the Service ID Number does not exist in the "
 "Service Identification Information & Metrics resource for that fiscal "

--- a/ckanext/canada/tables/service.yaml
+++ b/ckanext/canada/tables/service.yaml
@@ -53,10 +53,15 @@ resources:
     obligation: Mandatory
     excel_required: true
     form_required: true
+    excel_error_formula: 'OR({default_formula},LEN({cell})-LEN(SUBSTITUTE({cell},",",""))>0)'
     format_type: Free text
     validation:
-      en: This field must not be empty.
-      fr: Ce champ ne doit pas être vide.
+      en: |
+        This field must not be empty.
+        This field cannot contain commas.
+      fr: |
+        Ce champ ne doit pas être vide.
+        Ce champ ne peut pas contenir de virgules.
     occurrence: Single
     datastore_type: text
 
@@ -1357,6 +1362,9 @@ resources:
         errors := errors || choice_error(NEW.fiscal_yr, {fiscal_yr}, 'fiscal_yr');
 
         errors := errors || required_error(NEW.service_id, 'service_id');
+        IF NEW.service_id LIKE '%,%' THEN
+          errors := errors || ARRAY[['service_id', {service_id_comma_error}]];
+        END IF;
 
         errors := errors || required_error(NEW.service_name_en, 'service_name_en');
         NEW.service_name_en := trim_lead_trailing(NEW.service_name_en);
@@ -1535,6 +1543,7 @@ resources:
     integer_type_error: 'Invalid input syntax for type integer: {}'
     conditional_required_error: This field is required due to a response in a different field.
     both_lang_error: This text must be provided in both languages
+    service_id_comma_error: Comma is not allowed in Service ID Number field
 
   examples:
     record:
@@ -1648,9 +1657,14 @@ resources:
     obligation: Mandatory
     excel_required: true
     form_required: true
+    excel_error_formula: 'OR({default_formula},LEN({cell})-LEN(SUBSTITUTE({cell},",",""))>0)'
     validation:
-      en: This field must not be empty.
-      fr: Ce champ ne doit pas être vide.
+      en: |
+        This field must not be empty.
+        This field cannot contain commas.
+      fr: |
+        Ce champ ne doit pas être vide.
+        Ce champ ne peut pas contenir de virgules.
     format_type: Free text
     occurrence: Single
     datastore_type: text
@@ -1726,9 +1740,14 @@ resources:
     obligation: Mandatory
     excel_required: true
     form_required: true
+    excel_error_formula: 'OR({default_formula},LEN({cell})-LEN(SUBSTITUTE({cell},",",""))>0)'
     validation:
-      en: This field must not be empty.
-      fr: Ce champ ne doit pas être vide.
+      en: |
+        This field must not be empty.
+        This field cannot contain commas.
+      fr: |
+        Ce champ ne doit pas être vide.
+        Ce champ ne peut pas contenir de virgules.
     format_type: Free text
     occurrence: Single
     datastore_type: text
@@ -2263,6 +2282,9 @@ resources:
         errors := errors || choice_error(NEW.fiscal_yr, {fiscal_yr}, 'fiscal_yr');
 
         errors := errors || required_error(NEW.service_id, 'service_id');
+        IF NEW.service_id LIKE '%,%' THEN
+          errors := errors || ARRAY[['service_id', {service_id_comma_error}]];
+        END IF;
 
         errors := errors || required_error(NEW.service_name_en, 'service_name_en');
         NEW.service_name_en := trim_lead_trailing(NEW.service_name_en);
@@ -2273,6 +2295,9 @@ resources:
         errors := errors || max_char_error(NEW.service_name_fr, 250, 'service_name_fr');
 
         errors := errors || required_error(NEW.service_standard_id, 'service_standard_id');
+        IF NEW.service_standard_id LIKE '%,%' THEN
+          errors := errors || ARRAY[['service_standard_id', {service_standard_id_comma_error}]];
+        END IF;
 
         errors := errors || required_error(NEW.service_standard_en, 'service_standard_en');
         NEW.service_standard_en := trim_lead_trailing(NEW.service_standard_en);
@@ -2349,6 +2374,8 @@ resources:
     integer_type_error: 'Invalid input syntax for type integer: {}'
     conditional_required_error: This field is required due to a response in a different field.
     both_lang_error: This text must be provided in both languages
+    service_id_comma_error: Comma is not allowed in Service ID Number field
+    service_standard_id_comma_error: Comma is not allowed in Service Standard ID field
 
   examples:
     record:

--- a/ckanext/canada/tests/test_service.py
+++ b/ckanext/canada/tests/test_service.py
@@ -36,6 +36,22 @@ class TestService(CanadaTestBase):
             records=[record])
 
 
+    def test_primary_key_commas(self):
+        """
+        Commas in primary keys should error
+        """
+        record = get_chromo('service')['examples']['record']
+        record['service_id'] = 'this,is,a,failure'
+        with pytest.raises(ValidationError) as ve:
+            self.lc.action.datastore_upsert(
+                resource_id=self.resource_id,
+                records=[record])
+        err = ve.value.error_dict
+        assert 'records' in err
+        assert 'service_id' in err['records'][0]
+        assert err['records'][0]['service_id'] == ['Comma is not allowed in Service ID Number field']
+
+
     def test_foreign_constraint(self):
         """
         Trying to delete a Service record when there are Standard records referencing it should raise an exception
@@ -361,6 +377,25 @@ class TestStdService(CanadaTestBase):
         self.lc.action.datastore_upsert(
             resource_id=self.resource_id,
             records=[record])
+
+
+    def test_primary_key_commas(self):
+        """
+        Commas in primary keys should error
+        """
+        record = get_chromo('service-std')['examples']['record']
+        record['service_id'] = 'this,is,a,failure'
+        record['service_standard_id'] = 'this,is,a,failure'
+        with pytest.raises(ValidationError) as ve:
+            self.lc.action.datastore_upsert(
+                resource_id=self.resource_id,
+                records=[record])
+        err = ve.value.error_dict
+        assert 'records' in err
+        assert 'service_id' in err['records'][0]
+        assert 'service_standard_id' in err['records'][0]
+        assert err['records'][0]['service_id'] == ['Comma is not allowed in Service ID Number field']
+        assert err['records'][0]['service_standard_id'] == ['Comma is not allowed in Service Standard ID field']
 
 
     def test_foreign_constraint(self):

--- a/ckanext/canada/tests/test_service.py
+++ b/ckanext/canada/tests/test_service.py
@@ -30,7 +30,7 @@ class TestService(CanadaTestBase):
         """
         Example data should load
         """
-        record = get_chromo('service')['examples']['record']
+        record = get_chromo('service')['examples']['record'].copy()
         self.lc.action.datastore_upsert(
             resource_id=self.resource_id,
             records=[record])
@@ -40,7 +40,7 @@ class TestService(CanadaTestBase):
         """
         Commas in primary keys should error
         """
-        record = get_chromo('service')['examples']['record']
+        record = get_chromo('service')['examples']['record'].copy()
         record['service_id'] = 'this,is,a,failure'
         with pytest.raises(ValidationError) as ve:
             self.lc.action.datastore_upsert(
@@ -56,11 +56,11 @@ class TestService(CanadaTestBase):
         """
         Trying to delete a Service record when there are Standard records referencing it should raise an exception
         """
-        record = get_chromo('service')['examples']['record']
+        record = get_chromo('service')['examples']['record'].copy()
         self.lc.action.datastore_upsert(
             resource_id=self.resource_id,
             records=[record])
-        record = get_chromo('service-std')['examples']['record']
+        record = get_chromo('service-std')['examples']['record'].copy()
         self.lc.action.datastore_upsert(
             resource_id=self.resource_cid,
             records=[record])
@@ -362,7 +362,7 @@ class TestStdService(CanadaTestBase):
 
 
     def _make_parent_record(self):
-        record = get_chromo('service')['examples']['record']
+        record = get_chromo('service')['examples']['record'].copy()
         self.lc.action.datastore_upsert(
             resource_id=self.resource_pid,
             records=[record])
@@ -373,7 +373,7 @@ class TestStdService(CanadaTestBase):
         Example data should load
         """
         self._make_parent_record()
-        record = get_chromo('service-std')['examples']['record']
+        record = get_chromo('service-std')['examples']['record'].copy()
         self.lc.action.datastore_upsert(
             resource_id=self.resource_id,
             records=[record])
@@ -383,7 +383,7 @@ class TestStdService(CanadaTestBase):
         """
         Commas in primary keys should error
         """
-        record = get_chromo('service-std')['examples']['record']
+        record = get_chromo('service-std')['examples']['record'].copy().copy()
         record['service_id'] = 'this,is,a,failure'
         record['service_standard_id'] = 'this,is,a,failure'
         with pytest.raises(ValidationError) as ve:
@@ -402,7 +402,7 @@ class TestStdService(CanadaTestBase):
         """
         Trying to create a Standard record referencing a nonexistent Service record should raise an exception
         """
-        record = get_chromo('service-std')['examples']['record']
+        record = get_chromo('service-std')['examples']['record'].copy()
         with pytest.raises(ValidationError) as ve:
             self.lc.action.datastore_upsert(
                 resource_id=self.resource_id,
@@ -460,7 +460,7 @@ class TestStdService(CanadaTestBase):
         Fields with both _en and _fr should require eachother
         """
         self._make_parent_record()
-        record = get_chromo('service-std')['examples']['record'].copy()
+        record = get_chromo('service-std')['examples']['record'].copy().copy()
 
         record['channel_comments_en'] = 'Not Blank'
         record['channel_comments_fr'] = None


### PR DESCRIPTION
fix(pd): service primary key commas;

- Cannot have commas in any of the primary keys for service.