### PR TITLE
Service Inventory Changes (Copy & Max Chars)

### DIFF
--- a/changes/1540.changes
+++ b/changes/1540.changes
@@ -1,0 +1,1 @@
+Updated description copy for Service Inventory `Fiscal Year` fields. Updated maximum characters for `Service Name` fields from `250` to `350`.

--- a/ckanext/canada/tables/service.yaml
+++ b/ckanext/canada/tables/service.yaml
@@ -30,8 +30,14 @@ resources:
       en: Fiscal Year
       fr: Année financière
     description:
-      en: Identifies the fiscal year (April-March) for which service data is reported.
-      fr: Indique l'exercice financier (avril-mars) pour lequel les données sur les services sont déclarées.
+      en: >
+        Identifies the fiscal year (April 1 to March 31) during which service activities took place.
+        For example, records for fiscal year 2023-2024 should include applications received
+        from April 1, 2023, to March 31, 2024.
+      fr: >
+        Indique l'exercice financier (1 avril au 31 mars) durant lequel les activités du service ont eu lieu.
+        Par exemple, les données pour l’exercice financier 2023-2024 devrait inclure les demandes de service qui
+        ont été reçues entre le 1 avril 2023 et le 31 mars 2024.
     obligation: Mandatory
     excel_required: true
     form_required: true
@@ -81,16 +87,16 @@ resources:
     validation:
       en: |
         This field must not be empty.
-        This field has a maximum length of 250 characters.
+        This field has a maximum length of 350 characters.
       fr: |
         Ce champ ne doit pas être vide.
-        Ce champ ne peut excéder une longueur maximale de 250 caractères.
+        Ce champ ne peut excéder une longueur maximale de 350 caractères.
     occurrence: Single
     datastore_type: text
-    max_chars: 250
+    max_chars: 350
     form_attrs:
       style: "width: 100%; display: block"
-      maxlength: 250
+      maxlength: 350
 
   # DEP 1-5
   - datastore_id: service_name_fr
@@ -108,16 +114,16 @@ resources:
     validation:
       en: |
         This field must not be empty.
-        This field has a maximum length of 250 characters.
+        This field has a maximum length of 350 characters.
       fr: |
         Ce champ ne doit pas être vide.
-        Ce champ ne peut excéder une longueur maximale de 250 caractères.
+        Ce champ ne peut excéder une longueur maximale de 350 caractères.
     occurrence: Single
     datastore_type: text
-    max_chars: 250
+    max_chars: 350
     form_attrs:
       style: "width: 100%; display: block"
-      maxlength: 250
+      maxlength: 350
 
   # DEP 1-6
   - datastore_id: service_description_en
@@ -1633,8 +1639,14 @@ resources:
       en: Fiscal Year
       fr: Année financière
     description:
-      en: Identifies the fiscal year (April-March) for which service data is reported.
-      fr: Indique l'exercice financier (avril-mars) pour lequel les données sur les services sont déclarées.
+      en: >
+        Identifies the fiscal year (April 1 to March 31) during which service activities took place.
+        For example, records for fiscal year 2023-2024 should include applications received
+        from April 1, 2023, to March 31, 2024.
+      fr: >
+        Indique l'exercice financier (1 avril au 31 mars) durant lequel les activités du service ont eu lieu.
+        Par exemple, les données pour l’exercice financier 2023-2024 devrait inclure les demandes de service qui
+        ont été reçues entre le 1 avril 2023 et le 31 mars 2024.
     obligation: Mandatory
     excel_required: true
     form_required: true
@@ -1684,17 +1696,17 @@ resources:
     validation:
       en: |
         This field must not be empty.
-        This field has a maximum length of 250 characters.
+        This field has a maximum length of 350 characters.
       fr: |
         Ce champ ne doit pas être vide.
-        Ce champ ne peut excéder une longueur maximale de 250 caractères.
+        Ce champ ne peut excéder une longueur maximale de 350 caractères.
     format_type: Free text
     occurrence: Single
     datastore_type: text
-    max_chars: 250
+    max_chars: 350
     form_attrs:
       style: "width: 100%; display: block"
-      maxlength: 250
+      maxlength: 350
 
   # DEP 2-4
   - datastore_id: service_name_fr
@@ -1711,17 +1723,17 @@ resources:
     validation:
       en: |
         This field must not be empty.
-        This field has a maximum length of 250 characters.
+        This field has a maximum length of 350 characters.
       fr: |
         Ce champ ne doit pas être vide.
-        Ce champ ne peut excéder une longueur maximale de 250 caractères.
+        Ce champ ne peut excéder une longueur maximale de 350 caractères.
     format_type: Free text
     occurrence: Single
     datastore_type: text
-    max_chars: 250
+    max_chars: 350
     form_attrs:
       style: "width: 100%; display: block"
-      maxlength: 250
+      maxlength: 350
 
   # DEP 2-5
   - datastore_id: service_standard_id


### PR DESCRIPTION
feat(pd): service max chars and copy;

- Increased `Service Name` max chars to 350.
- Updated copy for `Fiscal Year` fields.