### PR TITLE
Remove Old API Key Visual

### DIFF
--- a/changes/1550.removal
+++ b/changes/1550.removal
@@ -1,0 +1,1 @@
+Removed the old API Key modal from the user profile template.

--- a/ckanext/canada/templates/user/read_base.html
+++ b/ckanext/canada/templates/user/read_base.html
@@ -64,32 +64,6 @@
           <div class="col-md-12 left-center text-break text-wrap"><strong>{{ _('Member Since') }}</strong></div>
           <div class="col-md-12 left-center text-break text-wrap">{{ h.render_datetime(user.created) }}</div>
         </div>
-        {% if is_myself and user.apikey %}
-          <div class="row mrgn-tp-md">
-            <div class="col-md-12 left-center">
-              <strong>{{ _('API Key') }} <span class="label" title="{{ _('This means only you can see this') }}">{{ _('Private') }}</span></strong>
-            </div>
-            <div class="col-md-12 left-center">
-              <a href="" data-bs-toggle="modal" data-bs-target="#api_modal">{{ _('Show API Key') }}</a>
-              <div class="modal" id="api_modal" tabindex="-1" role="dialog" aria-labelledby="api_modal_label" aria-hidden="true">
-                <div class="modal-dialog modal-dialog-centered" role="document">
-                  <div class="modal-content overlay-def">
-                    <header class="modal-header">
-                      <h2 class="modal-title" id="api_modal_label">{{ _('API Key') }}</h2>
-                      <button type="button" class="close mfp-close" data-bs-dismiss="modal" aria-label="{{ _('Close') }}"></button>
-                    </header>
-                    <div class="modal-body">
-                      <code>{{ user.apikey }}</code>
-                    </div>
-                    <div class="modal-footer">
-                      <button type="button" class="btn btn-sm btn-primary pull-left" data-bs-dismiss="modal">{{ _('Close') }}</button>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        {% endif %}
         {% if g.is_registry %}
           <div class="info mrgn-tp-md">
             {% if h.user_organizations(user) %}


### PR DESCRIPTION
removal(templates): api key;

- Remove old API Key from user info side section.

The old API Keys no longer work in 2.10, so we should not show them to the user to avoid any confusion.