### PR TITLE
Handle Portal Update Exceptions with Click

### DIFF
--- a/changes/1555.changes
+++ b/changes/1555.changes
@@ -1,0 +1,1 @@
+The Portal Update command will send correct exit codes when the worker pool fails.

--- a/ckanext/canada/cli.py
+++ b/ckanext/canada/cli.py
@@ -235,11 +235,18 @@ class PortalUpdater(object):
                         package_id, action, reason, error, \
                             failure_reason, failure_trace, \
                             do_update_sync_success_time = json.loads(result)
-                    except Exception as e:
+                    except Exception:
+                        error_stack = traceback.format_exc()
+                        append_log(None,
+                                   None,
+                                   'ERROR',
+                                   'Error when processing worker pool',
+                                   error_stack)
                         if self.verbose:
-                            print("Worker proccess failed on:")
-                            print(result)
-                        raise Exception(e)
+                            print('ERROR', 'Error when processing worker pool',
+                                  error_stack, file=sys.stderr)
+                        raise click.ClickException(
+                            "Worker proccess failed. See stderr or log file.")
                     _stats = next(stats)
                     print(job_ids, _stats, finished, package_id, action, reason)
                     if error:


### PR DESCRIPTION
feat(cli): click exit 1;

- Click exit code 1 for exceptions.

Need to raise the click exception so that the command gets the proper exit code in the terminal. We handle during the pool, but we do not handle if the worker pool fails to start. So this will handle that.