### PR TITLE
OPEN-3925: Remove the unused quiet option for Search from the makefile

### DIFF
--- a/bin/pd/Makefile
+++ b/bin/pd/Makefile
@@ -202,7 +202,7 @@ upload-briefingt: $(workdir)/filtered/briefingt.csv $(workdir)/filtered/briefing
 .PHONY: rebuild-briefingt
 rebuild-briefingt: $(workdir)/filtered/briefingt.csv $(workdir)/filtered/briefingt-nil.csv
 	@$(echo_date) Rebuilding Briefing Note Titles...
-	@$(oc_search) import_data_csv --csv "$(workdir)/filtered/briefingt.csv" --search briefingt --quiet
+	@$(oc_search) import_data_csv --csv "$(workdir)/filtered/briefingt.csv" --search briefingt
 
 $(workdir)/briefingt.csv:
 	$(ckan_command) -c $(registry_ini) $(combine) briefingt -d $(workdir)
@@ -237,7 +237,7 @@ upload-qpnotes: $(workdir)/filtered/qpnotes.csv $(workdir)/filtered/qpnotes-nil.
 .PHONY: rebuild-qpnotes
 rebuild-qpnotes: $(workdir)/filtered/qpnotes.csv $(workdir)/filtered/qpnotes-nil.csv
 	@$(echo_date) Rebuilding Question Period Notes...
-	@$(oc_search) import_data_csv --csv "$(workdir)/filtered/qpnotes.csv" --search qpnotes --quiet
+	@$(oc_search) import_data_csv --csv "$(workdir)/filtered/qpnotes.csv" --search qpnotes
 	@$(oc_search) import_data_csv --csv "$(workdir)/filtered/qpnotes-nil.csv" --search qpnotes --nothing_to_report
 
 $(workdir)/qpnotes.csv:
@@ -272,7 +272,7 @@ upload-contracts: $(workdir)/filtered/contracts.csv $(workdir)/filtered/contract
 rebuild-contracts: $(workdir)/filtered/contracts.csv $(workdir)/filtered/contracts-nil.csv
 	@$(echo_date) Rebuilding Contracts...
 	@$(oc_search) contracts_amendments --contracts $(workdir)/filtered/contracts.csv --amendments $(workdir)/filtered/contract-amendments.csv --tmpdir $(workdir)
-	@$(oc_search) import_data_csv --csv "$(workdir)/filtered/contract-amendments.csv" --search contracts --quiet
+	@$(oc_search) import_data_csv --csv "$(workdir)/filtered/contract-amendments.csv" --search contracts
 
 $(workdir)/contracts.csv:
 	$(ckan_command) -c $(registry_ini) $(combine) contracts -d $(workdir)
@@ -424,8 +424,8 @@ rebuild-grants: $(workdir)/filtered/grants.csv $(workdir)/filtered/grants-nil.cs
 	mkdir -p $(workdir)/amendments
 	$(registry_python) $(fdir)/amendment_delta_records.py \
 	"$(workdir)/filtered/grants.csv" "$(workdir)/amendments/grants.csv"
-	@$(oc_search) import_data_csv --csv "$(workdir)/amendments/grants.csv" --search grants --quiet
-	@$(oc_search) import_data_csv --csv "$(workdir)/filtered/grants-nil.csv" --search grants --quiet --nothing_to_report
+	@$(oc_search) import_data_csv --csv "$(workdir)/amendments/grants.csv" --search grants
+	@$(oc_search) import_data_csv --csv "$(workdir)/filtered/grants-nil.csv" --search grants --nothing_to_report
 
 $(workdir)/grants.csv:
 	$(ckan_command) -c $(registry_ini) $(combine) grants -d $(workdir)
@@ -464,8 +464,8 @@ upload-hospitalityq: $(workdir)/filtered/hospitalityq.csv $(workdir)/filtered/ho
 .PHONY: rebuild-hospitalityq
 rebuild-hospitalityq: $(workdir)/filtered/hospitalityq.csv $(workdir)/filtered/hospitalityq-nil.csv
 	@$(echo_date) Rebuilding Hospitality Expenses...
-	@$(oc_search) import_data_csv --csv "$(workdir)/filtered/hospitalityq.csv" --search hospitalityq --quiet
-	@$(oc_search) import_data_csv --csv "$(workdir)/filtered/hospitalityq-nil.csv" --search hospitalityq --quiet --nothing_to_report
+	@$(oc_search) import_data_csv --csv "$(workdir)/filtered/hospitalityq.csv" --search hospitalityq
+	@$(oc_search) import_data_csv --csv "$(workdir)/filtered/hospitalityq-nil.csv" --search hospitalityq --nothing_to_report
 
 $(workdir)/hospitalityq.csv:
 	$(ckan_command) -c $(registry_ini) $(combine) hospitalityq -d $(workdir)
@@ -498,7 +498,7 @@ upload-travelq: $(workdir)/filtered/travelq.csv $(workdir)/filtered/travelq-nil.
 .PHONY: rebuild-travelq
 rebuild-travelq: $(workdir)/filtered/travelq.csv $(workdir)/filtered/travelq-nil.csv
 	@$(echo_date) Rebuilding Travel Expenses...
-	@$(oc_search) import_data_csv --csv "$(workdir)/filtered/travelq.csv" --search travelq --quiet
+	@$(oc_search) import_data_csv --csv "$(workdir)/filtered/travelq.csv" --search travelq
 	@$(oc_search) import_data_csv --csv "$(workdir)/filtered/travelq-nil.csv" --search travelq --nothing_to_report
 
 $(workdir)/travelq.csv:

--- a/changes/1565.changes
+++ b/changes/1565.changes
@@ -1,0 +1,1 @@
+Remove the unused --quiet option for Search csv import from the PD Makefile


### PR DESCRIPTION
Search import data import employs quiet logging by default now. Removing the redundant quiet option from the PD makefile.