### PR TITLE
Check Registry Domain Instead of Internal Plugin Loaded

### DIFF
--- a/ckanext/canada/helpers.py
+++ b/ckanext/canada/helpers.py
@@ -58,6 +58,12 @@ GEO_MAP_TYPE_DEFAULT = 'static'
 RELEASE_DATE_FACET_STEP = 100
 
 
+def is_registry_domain() -> bool:
+    uri_parts = urlsplit(request.url)
+    subdomain = uri_parts.netloc.split('.')[0]
+    return 'registry' in subdomain
+
+
 def get_translated_t(data_dict: Dict[str, Any],
                      field: str) -> Tuple[str, bool]:
     '''
@@ -1018,7 +1024,8 @@ def ckan_to_cdts_breadcrumbs(breadcrumb_content: str) -> List[Dict[str, Any]]:
     """
     breadcrumb_html = BeautifulSoup(breadcrumb_content, 'html.parser')
     cdts_breadcrumbs = []
-    if g.is_registry:
+    is_registry = h.is_registry_domain()
+    if is_registry:
         cdts_breadcrumbs.append({
             'title': _('Registry Home'),
             'href': '/%s' % h.lang(),
@@ -1041,7 +1048,7 @@ def ckan_to_cdts_breadcrumbs(breadcrumb_content: str) -> List[Dict[str, Any]]:
         if anchor and anchor.get('title'):
             link['acronym'] = anchor.get('title')
 
-        if g.is_registry:
+        if is_registry:
             cdts_breadcrumbs.append(link)
         elif 'active' not in breadcrumb.get('class', []):
             cdts_breadcrumbs.append(link)

--- a/ckanext/canada/plugin/theme_plugin.py
+++ b/ckanext/canada/plugin/theme_plugin.py
@@ -2,8 +2,6 @@ from ckan.types import Callable, Any, Dict
 from ckan.common import CKANConfig
 
 import ckan.plugins as p
-from ckan.lib.app_globals import set_app_global
-from ckan.plugins.core import plugin_loaded
 
 from ckanext.canada import helpers
 
@@ -22,10 +20,6 @@ class CanadaThemePlugin(p.SingletonPlugin):
         p.toolkit.add_resource('../assets/datatables', 'canada_datatables')
         p.toolkit.add_resource('../assets/public', 'canada_public')
         p.toolkit.add_resource('../assets/invitation-manager', 'invitation_manager')
-        # type_ignore_reason: jinja2 versioning
-        set_app_global('is_registry',
-                       bool(plugin_loaded('canada_internal')))  # type: ignore
-
         config['ckan.favicon'] = helpers.cdts_asset('/assets/favicon.ico')
 
     # ITemplateHelpers
@@ -46,6 +40,7 @@ class CanadaThemePlugin(p.SingletonPlugin):
             'get_loader_status_badge',
             'validation_status',
             'is_user_locked',
+            'is_registry_domain',
             # Portal
             'user_organizations',
             'openness_score',

--- a/ckanext/canada/templates/admin/base.html
+++ b/ckanext/canada/templates/admin/base.html
@@ -1,7 +1,9 @@
 {% ckan_extends %}
 
+{% set is_registry = h.is_registry_domain() %}
+
 {% block breadcrumb_content %}
-  {% if g.is_registry %}
+  {% if is_registry %}
     {{ h.build_nav('admin.index', _('Admin')) }}
   {% else %}
     {{ super() }}
@@ -9,7 +11,7 @@
 {% endblock %}
 
 {% block content_primary_nav %}
-  {% if g.is_registry %}
+  {% if is_registry %}
     {{ h.build_nav_icon('canada.ckan_admin_index', _('Admins'), icon='user-plus') }}
     {{ h.build_nav_icon('user.index', _('Users'), icon='user') }}
     {{ h.build_nav_icon('admin.trash', _('Trash'), icon='trash') }}

--- a/ckanext/canada/templates/base.html
+++ b/ckanext/canada/templates/base.html
@@ -1,7 +1,9 @@
 {% ckan_extends %}
 
+{% set is_registry = h.is_registry_domain() %}
+
 {% block site_title %}
-  {% if g.is_registry %}
+  {% if is_registry %}
     <a href="{{ h.url_for('dataset.search') }}">{{ _('Open Data Registry') }}</a>
   {% else %}
     {{ super() }}
@@ -14,7 +16,7 @@
     <meta property="og:title" content="{{ self.title() }}">
   {% endblock %}
   {% block adobe_analytics_meta %}
-    {% if not g.is_registry %}
+    {% if not is_registry %}
       {% block adobe_analytics_title %}
         <meta property="dcterms:title" content="{{ self.title() }}" />
       {% endblock %}
@@ -54,7 +56,7 @@
 
 {%- block custom_styles -%}
   {% asset 'canada_public/css' %}
-  {% if g.is_registry %}
+  {% if is_registry %}
     {# Remove when WET v4.0.21 is out #}
     {% asset 'canada_internal/css' %}
   {% endif %}

--- a/ckanext/canada/templates/error_document_template.html
+++ b/ckanext/canada/templates/error_document_template.html
@@ -21,7 +21,7 @@
 {% endblock %}
 
 {% block primary %}
-  {% if g.is_registry %}
+  {% if h.is_registry_domain() %}
     <div class="row">
       <div class="col-md-12">
         <p>{{ content }}</p>

--- a/ckanext/canada/templates/home/quick_links.html
+++ b/ckanext/canada/templates/home/quick_links.html
@@ -52,6 +52,7 @@
 {% endmacro %}
 
 {% block primary_content %}
+  {{ h.is_registry_domain() }}
   <div class="row canada-page-main-wrapper" id="quick-links">
     <div class="col-md-12">
       <section>

--- a/ckanext/canada/templates/organization/edit_base.html
+++ b/ckanext/canada/templates/organization/edit_base.html
@@ -1,5 +1,6 @@
 {% ckan_extends %}
 
+{% set is_registry = h.is_registry_domain() %}
 {% set organization = group_dict if action != 'new' else {} %}
 {%- set translated_title = h.get_translated(organization, 'title') -%}
 {% set org_member_count = member_count %}
@@ -21,7 +22,7 @@
 {% endblock %}
 
 {% block content_primary_nav %}
-  {% if g.is_registry %}
+  {% if is_registry %}
     {% if h.check_access('group_update', {'id': organization.id}) %}
       {{ h.build_nav_icon('organization.edit', _('Edit Organization'), id=organization.name, icon='pencil-square') }}
     {% endif %}
@@ -49,7 +50,7 @@
 
 {% block scripts %}
   {{ super() }}
-  {% if g.is_registry %}
+  {% if is_registry %}
     {% asset 'canada_internal/organization_edit' %}
   {% endif %}
 {% endblock %}

--- a/ckanext/canada/templates/organization/manage_members.html
+++ b/ckanext/canada/templates/organization/manage_members.html
@@ -2,7 +2,7 @@
 
 {% block page_primary_action %}
   {{ super() }}
-  {% if g.is_registry %}
+  {% if h.is_registry_domain() %}
     {% if h.check_access('organization_update', {'id': organization.id}) %}
       {% link_for _('CSV'), named_route='canada.organization_member_dump', id=organization.id, class_='btn btn-primary', icon='download' %}
     {% endif %}

--- a/ckanext/canada/templates/organization/members.html
+++ b/ckanext/canada/templates/organization/members.html
@@ -27,7 +27,7 @@
 
 {% block page_primary_action %}
   {{ super() }}
-  {% if g.is_registry %}
+  {% if h.is_registry_domain() %}
     {% if h.check_access('organization_update', {'id': organization.id}) %}
       {% link_for _('CSV'), named_route='canada.organization_member_dump', id=organization.id, class_='btn btn-primary', icon='download' %}
     {% endif %}

--- a/ckanext/canada/templates/package/base.html
+++ b/ckanext/canada/templates/package/base.html
@@ -7,7 +7,7 @@
   {% set pkg_url = h.url_for(pkg.type ~ '.read', id=pkg.id if is_activity_archive else pkg.name, **({'activity_id': request.args['activity_id']} if 'activity_id' in request.args else {})) %}
   {% if action != 'new' and pkg %}
     {% set dataset = h.get_translated(pkg, 'title') %}
-    {% if g.is_registry and pkg.type in h.recombinant_get_types() %}
+    {% if h.is_registry_domain() and pkg.type in h.recombinant_get_types() %}
       {% set dataset = dataset ~ ' - ' ~ h.split_piped_bilingual_field(pkg.organization.title, h.lang()) %}
     {% endif %}
     <li{{ self.breadcrumb_content_selected() }}><a href="{{ pkg_url }}" title="{{ dataset }}">{{ dataset|truncate(80) }}</a></li>

--- a/ckanext/canada/templates/package/base_form_page.html
+++ b/ckanext/canada/templates/package/base_form_page.html
@@ -1,19 +1,21 @@
 {% ckan_extends %}
 
+{% set is_registry = h.is_registry_domain() %}
+
 {% block breadcrumb_content %}
-  {% if g.is_registry %}
+  {% if is_registry %}
     {{ h.build_nav('dataset.new', _('Create Dataset')) }}
   {% endif %}
 {% endblock %}
 
 {% block secondary_content %}
-  {% if not g.is_registry %}
+  {% if not is_registry %}
     {{ super() }}
   {% endif %}
 {% endblock %}
 
 {% block page_header %}
-  {% if not g.is_registry %}
+  {% if not is_registry %}
     {{ super() }}
   {% endif %}
 {% endblock %}

--- a/ckanext/canada/templates/package/new_resource.html
+++ b/ckanext/canada/templates/package/new_resource.html
@@ -1,5 +1,7 @@
 {% ckan_extends %}
 
+{% set is_registry = h.is_registry_domain() %}
+
 {% block primary_content %}
   <div class="row mrgn-tp-md canada-page-main-wrapper">
     <div class="col-md-12">
@@ -10,7 +12,7 @@
 
 {% block form %}
   {% set max_resource_count = h.max_resources_per_dataset() %}
-  {% if g.is_registry and max_resource_count and pkg_dict.resources|length >= max_resource_count %}
+  {% if is_registry and max_resource_count and pkg_dict.resources|length >= max_resource_count %}
     <div class="row">
       <div class="col-md-12 canada-flash-messages">
         <div>
@@ -30,7 +32,7 @@
 {% endblock %}
 
 {% block scripts %}
-  {% if g.is_registry %}
+  {% if is_registry %}
     <script type="text/javascript" src="{{ h.url_for_static('/registry_resource_edit.js') }}" ></script>
     {% asset 'canada_internal/guess_mimetype' %}
   {% endif %}
@@ -39,7 +41,7 @@
 
 {% block custom_styles %}
   {{ super() }}
-  {% if g.is_registry %}
+  {% if is_registry %}
     {% asset 'vendor/select2-css' %}
   {% endif %}
 {% endblock %}

--- a/ckanext/canada/templates/package/new_resource_not_draft.html
+++ b/ckanext/canada/templates/package/new_resource_not_draft.html
@@ -2,7 +2,7 @@
 
 {% block form %}
   {% set max_resource_count = h.max_resources_per_dataset() %}
-  {% if g.is_registry and max_resource_count and pkg_dict.resources|length >= max_resource_count %}
+  {% if h.is_registry_domain() and max_resource_count and pkg_dict.resources|length >= max_resource_count %}
     <div class="row">
       <div class="col-md-12 canada-flash-messages">
         <div>

--- a/ckanext/canada/templates/package/read.html
+++ b/ckanext/canada/templates/package/read.html
@@ -1,7 +1,7 @@
 {% ckan_extends %}
 
+{% set is_registry = h.is_registry_domain() %}
 {% set client_lang = h.lang() %}
-
 {% set title, machine_translated = h.get_translated_t(pkg_dict, 'title') %}
 
 {%- block subtitle -%}
@@ -25,7 +25,7 @@
   {% endif %}
   <div class="module">
     {% block internal_actions %}
-      {% if g.is_registry %}
+      {% if is_registry %}
         {% set max_resource_count = h.max_resources_per_dataset() %}
         {% if max_resource_count and pkg.resources|length >= max_resource_count %}
           <div class="row">
@@ -219,7 +219,7 @@
       {% endif %}
     {% endblock %}
     {% block more_like_this %}
-      {% if not g.is_registry %}
+      {% if not is_registry %}
         {% if h.adv_search_url() %}
           <section class="panel panel-primary">
             <header class="panel-heading">
@@ -231,13 +231,13 @@
       {% endif %}
     {% endblock %}
     {% block package_rate %}
-      {% if not g.is_registry %}
+      {% if not is_registry %}
         <a id="rate"></a>
         <div id="voting-wrapper" data-ajax-replace="/{{ h.lang() }}/vote?uuid={{ pkg_dict.id }}"></div>
       {% endif %}
     {% endblock %}
     {% block package_feedback %}
-      {% if not g.is_registry %}
+      {% if not is_registry %}
         <a id="feedback"></a>
         <section class="indent-large">
           <div id="feedback-wrapper" data-ajax-replace="/{{ h.lang() }}/feedback?uuid={{ pkg_dict.id }}"></div>
@@ -249,7 +249,7 @@
 
 {% block links %}
   {{ super() }}
-  {% if not g.is_registry %}
+  {% if not is_registry %}
     <script>
     window.imConfigPath = "/invitation-manager/";
     </script>
@@ -259,7 +259,7 @@
 {% block scripts %}
   {% asset 'canada_public/more_like_this' %}
   {% asset 'canada_public/voting_fix' %}
-  {% if not g.is_registry %}
+  {% if not is_registry %}
     {% asset 'invitation_manager/js' %}
   {% endif %}
   {{ super() }}
@@ -267,7 +267,7 @@
 
 {% block custom_styles %}
   {{ super() }}
-  {% if not g.is_registry %}
+  {% if not is_registry %}
     {% asset 'invitation_manager/css' %}
   {% endif %}
 {% endblock %}

--- a/ckanext/canada/templates/package/read_base.html
+++ b/ckanext/canada/templates/package/read_base.html
@@ -1,5 +1,6 @@
 {% ckan_extends %}
 
+{% set is_registry = h.is_registry_domain() %}
 {% set pkg = pkg_dict %}
 {% set client_lang = h.lang() %}
 {% set schema = h.scheming_get_dataset_schema(pkg.type) %}
@@ -10,7 +11,7 @@
 
 {%- block subtitle -%}
   {% set title, mt = h.get_translated_t(pkg, 'title') %}
-  {% if g.is_registry and pkg.type in h.recombinant_get_types() %}
+  {% if is_registry and pkg.type in h.recombinant_get_types() %}
     {{ (title or pkg.name) ~ ' - ' ~ h.split_piped_bilingual_field(pkg.organization.title, h.lang()) | trim }}
   {% else %}
     {{ (title or pkg.name) | trim }}
@@ -18,7 +19,7 @@
 {%- endblock -%}
 
 {% block content_primary_nav %}
-  {% if g.is_registry %}
+  {% if is_registry %}
     {% set dataset_label = _('Dataset') %}
     {% if pkg.type in h.recombinant_get_types() %}
       {% set dataset_label = _(pkg.title) ~ ' - ' ~ h.split_piped_bilingual_field(pkg.organization.title, h.lang()) %}

--- a/ckanext/canada/templates/package/resource_read.html
+++ b/ckanext/canada/templates/package/resource_read.html
@@ -1,5 +1,7 @@
 {% ckan_extends %}
 
+{% set is_registry = h.is_registry_domain() %}
+
 {% block adobe_analytics_creator %}
   {{ h.adobe_analytics_creator(organization=pkg.organization, package=pkg) }}
 {% endblock %}
@@ -14,7 +16,7 @@
     <div class="col-md-12">
       {# _site_messaging is handled by aliases in nginx to SMB #}
       {# has to be below title for a11y H3 after H1 #}
-      {% if g.is_registry %}
+      {% if is_registry %}
         <div data-ajax-replace="/static/_site_messaging/header_od_registry.{{ h.lang() }}"></div>
       {% else %}
         <div data-ajax-replace="/data/static/_site_messaging/header_od_ckan.{{ h.lang() }}"></div>
@@ -25,7 +27,7 @@
 
 {% block resource_actions %}
   {% set extra_classes = '' %}
-  {% if not g.is_registry or not h.check_access('package_update', {'id':pkg.id }) %}
+  {% if not is_registry or not h.check_access('package_update', {'id':pkg.id }) %}
     {% set extra_classes = 'resource-actions-toolbar-portal' %}
   {% endif %}
   <div class="resource-actions-toolbar {{ extra_classes }}">{{ super() }}</div>
@@ -41,7 +43,7 @@
 {% endblock %}
 
 {% block resource_content %}
-  {% if g.is_registry and 'is_resource_supported_by_xloader' in h and h.is_resource_supported_by_xloader(res) %}
+  {% if h.is_registry_domain() and 'is_resource_supported_by_xloader' in h and h.is_resource_supported_by_xloader(res) %}
     {% set xloader_info = h.xloader_status(res.id) %}
     {% if res.validation_status in ('failure', 'error', 'deprecated_report') %}
       <div class="canada-flash-messages"><div class="flash-messages"><div class="alert alert-dismissible fade show alert-danger">

--- a/ckanext/canada/templates/package/search.html
+++ b/ckanext/canada/templates/package/search.html
@@ -6,13 +6,15 @@
 
   {% ckan_extends %}
 
+  {% set is_registry = h.is_registry_domain() %}
+
   {%- block api_access_info -%}{%- endblock -%}
 
   {% block page_primary_action %}{% endblock %}
 
   {% block subtitle %}{{ _('Search Datasets') }}{% endblock %}
   {% block breadcrumb_content %}
-    {% if g.is_registry %}
+    {% if is_registry %}
       <li class="active">{{ h.nav_link(_('Datasets'), named_route='dataset.search', highlight_actions = 'new index') }}</li>
     {% else %}
       <li>{% link_for _('Search Open Government'), named_route='dataset_search' %}</li>
@@ -26,7 +28,7 @@
     </div>
     {% snippet 'snippets/dataset_facets.html', show_org_facet=true, search_facets=search_facets, facet_titles=facet_titles %}
     {% block extra_facets %}
-      {% if g.is_registry %}
+      {% if is_registry %}
         {{ h.snippet('snippets/publish_facet.html', search_facets=search_facets, facet_ranges=facet_ranges) }}
       {% endif %}
     {% endblock %}

--- a/ckanext/canada/templates/package/snippets/resource_info.html
+++ b/ckanext/canada/templates/package/snippets/resource_info.html
@@ -14,7 +14,7 @@
           <dd>{{ h.scheming_choices_label(h.scheming_get_preset('canada_resource_format').choices, res.format) }}</dd>
         </dl>
       </div>
-      {% if g.is_registry %}
+      {% if h.is_registry_domain() %}
         <div class="mrgn-bttm-md">
           {{- h.get_validation_badge(res)|safe -}}
           <div class="clearfix"></div>

--- a/ckanext/canada/templates/package/snippets/resource_item.html
+++ b/ckanext/canada/templates/package/snippets/resource_item.html
@@ -1,8 +1,9 @@
 {% ckan_extends %}
 
+{% set is_registry = h.is_registry_domain() %}
 {% set url_action = 'resource.edit' if url_is_edit and can_edit else 'resource.read' %}
 {% set url = h.url_for('dataset_' + url_action, id=pkg.name, resource_id=res.id) %}
-{% if g.is_registry and 'is_resource_supported_by_xloader' in h %}
+{% if is_registry and 'is_resource_supported_by_xloader' in h %}
   {% set is_xloader_supported = h.is_resource_supported_by_xloader(res) %}
   {% set xloader_info = h.xloader_status(res.id) %}
 {% endif %}
@@ -53,7 +54,7 @@
 {% endblock %}
 
 {% block resource_item_description %}
-  {% if g.is_registry and is_xloader_supported %}
+  {% if is_registry and is_xloader_supported %}
     <div class="canada-resource-list-badges">
       {% if res.validation_status in ('success', 'unkown') %}
         {{- h.get_validation_badge(res, in_listing=True)|safe -}}
@@ -114,7 +115,7 @@
       </ul>
     </div>
   {% endif %}
-  {% if g.is_registry and is_xloader_supported %}
+  {% if is_registry and is_xloader_supported %}
     {% if res.validation_status in ('failure', 'error', 'deprecated_report') %}
       <div class="canada-resource-list-validation-info"><p><i aria-hidden="true" class="fas fa-exclamation-triangle"></i>&nbsp;{{ _('Resource data has failed validation.') }}<a href="{{ h.url_for('validation.read', id=pkg.name, resource_id=res.id) }}" class="btn btn-sm btn-danger">{{ _('View Report') }}</a></p></div>
     {% endif %}

--- a/ckanext/canada/templates/package/snippets/resources.html
+++ b/ckanext/canada/templates/package/snippets/resources.html
@@ -1,5 +1,7 @@
 {% ckan_extends %}
 
+{% set is_registry = h.is_registry_domain() %}
+
 {% block resources %}
   <section class="panel panel-default resources-side-section">
     {% block resources_inner %}
@@ -23,7 +25,7 @@
               {% set is_active = 'active' if active == resource.id else '' %}
               <li id="{{ collapse_id }}" class="nav-item justify-content-between position-relative {{ is_active }} {{ collapse_class }}">
                 <a class="resources-side-section-item-link" tabindex="{{ -1 if is_active else 0 }}" href="{{ 'javascript:void(0);' if is_active else url }}" title="{{ h.resource_display_name(resource) }}">{{ h.resource_display_name(resource)|truncate(45) }}</a>
-                {% if g.is_registry and can_edit and not is_activity_archive %}
+                {% if is_registry and can_edit and not is_activity_archive %}
                   {% set validation_badge = h.get_validation_badge(resource)|safe %}
                   <div class="dropdown position-absolute end-0 me-2">
                     <button class="btn btn-light btn-sm dropdown-toggle" type="button" id="dropdownRes{{ loop.index }}" data-bs-toggle="dropdown" aria-expanded="false"><i class="fa fa-wrench" aria-hidden="true"></i></button>

--- a/ckanext/canada/templates/package/snippets/resources_list.html
+++ b/ckanext/canada/templates/package/snippets/resources_list.html
@@ -10,7 +10,7 @@
         </a>
       </div>
     {% endif %}
-    {% if g.is_registry and h.check_access('package_update', {'id': pkg.id}) %}
+    {% if h.is_registry_domain() and h.check_access('package_update', {'id': pkg.id}) %}
       <div class="pull-right mrgn-bttm-md {{ 'mrgn-lft-md' if fgp_url else '' }}">
         <a href="{{ h.url_for(pkg.type ~ '_resource.new', id=pkg.id) }}" class="btn btn-light btn-sm">
           <i class="fa fa-plus" aria-hidden="true"></i>&nbsp;{{ _('Add new resource') }}

--- a/ckanext/canada/templates/package/snippets/share_widget.html
+++ b/ckanext/canada/templates/package/snippets/share_widget.html
@@ -1,5 +1,5 @@
 {% block share_widget %}
-  {% if not g.is_registry %}
+  {% if not h.is_registry_domain() %}
     <div class="wet-boew-share span-5 margin-bottom-none" data-wet-boew='{"sites":["facebook","google", "twitter"]}'></div>
     <div class="clear"></div>
   {% endif %}

--- a/ckanext/canada/templates/package/snippets/socialmedia.html
+++ b/ckanext/canada/templates/package/snippets/socialmedia.html
@@ -1,5 +1,5 @@
 {% block ds_socialmedia %}
-  {% if not g.is_registry %}
+  {% if not h.is_registry_domain() %}
     <div class="panel panel-primary">
       {% set pkg = pkg_dict %}
       <div class="panel-heading"><div class="panel-title">{{ _('Have your say') }}</div></div>

--- a/ckanext/canada/templates/page.html
+++ b/ckanext/canada/templates/page.html
@@ -1,5 +1,7 @@
 {% ckan_extends %}
 
+{% set is_registry = h.is_registry_domain() %}
+
 {% block page %}
   {%- block header %}
     {% macro breadcrumb_content() %}
@@ -10,7 +12,7 @@
   {% block toolbar %}{% endblock %}
   {% set lang = h.lang() %}
   {% block content %}
-    {% if g.is_registry %}
+    {% if is_registry %}
       {% if g.userobj and h.get_timeout_length() %}
         <div class="modal fade" id="timeout" tabindex="-1" role="dialog" aria-labelledby="modalLabel" aria-hidden="true">
           <div class="modal-dialog modal-dialog-centered" role="document">
@@ -50,7 +52,7 @@
         {% endblock flash %}
         <main role="main" property="mainContentOfPage" class="container">
           {% block page_title %}
-            {% if g.is_registry %}
+            {% if is_registry %}
               <div id="ie_warning" class="alert alert-warning" style="display: none">
                 <p>{{ _('Internet Explorer is no longer being supported within the Open Government Registry. Some features will not work as expected, including publication of records. Please use MS Edge or Google Chrome, or contact <a href="mailto:open-ouvert@tbs-sct.gc.ca">open-ouvert@tbs-sct.gc.ca</a> for additional support.') | safe }}</p>
               </div>
@@ -68,7 +70,7 @@
               <div class="col-md-12">
                 {# _site_messaging is handled by aliases in nginx to SMB #}
                 {# has to be below title for a11y H3 after H1 #}
-                {% if g.is_registry %}
+                {% if is_registry %}
                   <div data-ajax-replace="/static/_site_messaging/header_od_registry.{{ h.lang() }}"></div>
                 {% else %}
                   <div data-ajax-replace="/data/static/_site_messaging/header_od_ckan.{{ h.lang() }}"></div>
@@ -135,12 +137,12 @@
   {% snippet 'snippets/cdts/footer_scripts.html' %}
   {% asset 'canada_public/analytics' %}
   {% block google_analytics_footer %}
-    {% if g.is_registry %}
+    {% if is_registry %}
       {% asset 'canada_internal/analytics' %}
     {% endif %}
   {%- endblock -%}
   {{ super() }}
-  {% if g.is_registry %}
+  {% if is_registry %}
     {%- block session_timeout -%}
       {% if g.userobj and h.get_timeout_length() %}
         <script>

--- a/ckanext/canada/templates/scheming/package/read.html
+++ b/ckanext/canada/templates/scheming/package/read.html
@@ -19,7 +19,7 @@
   <ul class="nav nav-pills">
     {% if h.check_access('package_update', {'id':pkg.id }) %}
       {% block actions_content_inner %}
-        {% if g.is_registry %}
+        {% if h.is_registry_domain() %}
           {# restore the original Edit button replaced on the public site #}
           {{ super.super() }}
         {% else %}

--- a/ckanext/canada/templates/snippets/cdts/footer_scripts.html
+++ b/ckanext/canada/templates/snippets/cdts/footer_scripts.html
@@ -2,7 +2,7 @@
 <script>
   document.write(
     wet.builder.refFooter({
-      {% if g.is_registry %}
+      {% if h.is_registry_domain() %}
         "isApplication": true,
       {% else %}
         "isApplication": false,

--- a/ckanext/canada/templates/snippets/cdts/head_scripts.html
+++ b/ckanext/canada/templates/snippets/cdts/head_scripts.html
@@ -4,7 +4,7 @@
 <script>
   document.write(
     wet.builder.refTop({
-      {% if g.is_registry %}
+      {% if h.is_registry_domain() %}
         "isApplication": true,
       {% else %}
         "isApplication": false,

--- a/ckanext/canada/templates/snippets/cdts/header.html
+++ b/ckanext/canada/templates/snippets/cdts/header.html
@@ -13,7 +13,7 @@
 <script>
   let appTop = document.getElementById("app-top");
   if( appTop ){
-    {% if g.is_registry %}
+    {% if h.is_registry_domain() %}
       const menuLinks = [
         {% if g.userobj %}
           {

--- a/ckanext/canada/templates/snippets/dataset_facets.html
+++ b/ckanext/canada/templates/snippets/dataset_facets.html
@@ -1,4 +1,6 @@
-{% if g.is_registry %}
+{% set is_registry = h.is_registry_domain() %}
+
+{% if is_registry %}
   {% set type_choices = [
     {'value': 'dataset', 'label': _('Open Data')},
     {'value': 'dialogue', 'label': _('Open Dialogue')},
@@ -20,7 +22,7 @@
   extras=extras,
   search_facets=search_facets %}
 
-{% if g.is_registry and 'status' in request.args or ('portal_type') in request.args.items() %}
+{% if is_registry and 'status' in request.args or ('portal_type') in request.args.items() %}
   {% snippet 'snippets/facet_list.html',
     title=facet_titles['status'],
     name='status',
@@ -29,7 +31,7 @@
     search_facets=search_facets %}
 {% endif %}
 
-{% if g.is_registry %}
+{% if is_registry %}
   {% set collection_choices = h.scheming_get_preset('canada_collection').choices + [{'value': 'pd', 'label': _('Proactive Publication')}] %}
   {% for t in h.recombinant_get_types() %}
     {% do collection_choices.append({'value': t, 'label': _(h.recombinant_get_chromo(t).title)}) %}
@@ -46,7 +48,7 @@
   unlimit=is_registry,
   search_facets=search_facets %}
 
-{% if not g.is_registry %}
+{% if not is_registry %}
   {% snippet 'snippets/facet_list.html',
     title=facet_titles['jurisdiction'],
     name='jurisdiction',
@@ -72,7 +74,7 @@
   search_facets=search_facets %}
 {% endif %}
 
-{% if g.is_registry %}
+{% if is_registry %}
   {% if facet_titles.collection|length != 1 or 'fgp' not in facet_titles.collection %}
     {# Hide subject on maps search #}
     {% snippet 'snippets/facet_list.html',

--- a/ckanext/canada/templates/snippets/search_form.html
+++ b/ckanext/canada/templates/snippets/search_form.html
@@ -9,7 +9,7 @@
 <form class="form-inline mrgn-bttm-lg" role="form" method="get" data-module="select-switch">
   {% block search_input %}
     {% block search_input_label %}
-      {% if g.is_registry %}
+      {% if h.is_registry_domain() %}
         <label for="search_field" class="wb-inv">{{ _('Search Datasets') }}</label>
       {% else %}
         {% if h.show_openinfo_facets() %}

--- a/ckanext/canada/templates/user/dashboard_datasets.html
+++ b/ckanext/canada/templates/user/dashboard_datasets.html
@@ -1,7 +1,7 @@
 {% ckan_extends %}
 
 {% block page_primary_action %}
-  {% if not g.is_registry %}
+  {% if not h.is_registry_domain() %}
     {{ super() }}
   {% endif %}
 {% endblock %}

--- a/ckanext/canada/templates/user/list.html
+++ b/ckanext/canada/templates/user/list.html
@@ -4,8 +4,10 @@
   {% extends 'page.html' %}
 {% endif %}
 
+{% set is_registry = h.is_registry_domain() %}
+
 {% block breadcrumb_content %}
-  {% if g.is_registry %}
+  {% if is_registry %}
     {% if g.userobj and not g.userobj.sysadmin %}
       {{ h.build_nav('user.index', _('Users')) }}
     {% else %}
@@ -17,7 +19,7 @@
 {% endblock %}
 
 {% block subtitle %}
-  {% if g.is_registry %}
+  {% if is_registry %}
     {% if g.userobj and not g.userobj.sysadmin %}
       {{ _('Users') }}
     {% else %}
@@ -29,7 +31,7 @@
 {% endblock %}
 
 {% block primary_content_inner %}
-  {% if g.is_registry %}
+  {% if is_registry %}
     <h2 class="wb-inv">{{ _('Users') }}</h2>
     {% if g.userobj and g.userobj.sysadmin %}
       <a class="btn btn-default mrgn-bttm-lg" href="{{ h.url_for('user.register') }}">{{ _('Create an Account') }}</a>
@@ -85,7 +87,7 @@
 {% endblock %}
 
 {% block secondary_content %}
-  {% if g.is_registry %}
+  {% if is_registry %}
     <section class="panel panel-info">
       <header class="panel-heading">
         <h3 class="panel-title">
@@ -106,7 +108,7 @@
 {% endblock %}
 
 {% block scripts %}
-  {% if g.is_registry %}
+  {% if is_registry %}
     {% snippet 'snippets/cdts/footer_scripts.html' %}
     {% asset 'canada_public/analytics' %}
     {% asset 'canada_internal/user_lock' %}

--- a/ckanext/canada/templates/user/login.html
+++ b/ckanext/canada/templates/user/login.html
@@ -1,7 +1,9 @@
 {% ckan_extends %}
 
+{% set is_registry = h.is_registry_domain() %}
+
 {% block primary_content %}
-  {% if g.is_registry %}
+  {% if is_registry %}
     <div class="mrgn-bttm-lg">
       {% trans %}login welcome text{% endtrans %}
       {% trans %}password reset alert{% endtrans %}
@@ -13,7 +15,7 @@
 {% endblock %}
 
 {% block secondary_content %}
-  {% if g.is_registry %}
+  {% if is_registry %}
     {% set reset_link = h.url_for('user.request_reset') %}
     {% set name_reset_link = h.url_for('canada.recover_username') %}
     <div class="panel panel-info">

--- a/ckanext/canada/templates/user/new.html
+++ b/ckanext/canada/templates/user/new.html
@@ -1,19 +1,21 @@
 {% ckan_extends %}
 
+{% set is_registry = h.is_registry_domain() %}
+
 {% block subtitle %}
-  {% if g.is_registry %}
+  {% if is_registry %}
     {% block page_heading %}{{ _('Request an Account') }}{% endblock %}
   {% endif %}
 {% endblock %}
 
 {% block breadcrumb_content %}
-  {% if g.is_registry %}
+  {% if is_registry %}
     <li class="active">{{ h.nav_link(_('Registration'), 'user.register') }}</li>
   {% endif %}
 {% endblock %}
 
 {% block primary_content %}
-  {% if g.is_registry %}
+  {% if is_registry %}
     <div class="row col-md-12 mrgn-tp-lg canada-page-main-wrapper">
       {{ form | safe }}
     </div>
@@ -27,7 +29,7 @@
 {% endblock %}
 
 {% block secondary_content %}
-  {% if g.is_registry %}
+  {% if is_registry %}
     <div class="panel panel-info">
       <div class="panel-heading">{{ _('Why Sign Up?') }}</div>
       <div class="panel-body">
@@ -45,7 +47,7 @@
 
 {% block custom_styles %}
   {{ super() }}
-  {% if g.is_registry %}
+  {% if is_registry %}
     <link rel="stylesheet" href="{{ h.url_for_static('base/vendor/select2/select2.css') }}" />
     <link rel="stylesheet" href="{{ h.url_for_static('base/vendor/select2/select2-bootstrap.css') }}" />
   {% endif %}

--- a/ckanext/canada/templates/user/new_user_form.html
+++ b/ckanext/canada/templates/user/new_user_form.html
@@ -1,4 +1,4 @@
-{% if g.is_registry %}
+{% if h.is_registry_domain() %}
   {% import 'macros/form.html' as form %}
   <form id="user-register-form" role="form" action="" method="post" enctype="multipart/form-data">
     {{ h.csrf_input() }}

--- a/ckanext/canada/templates/user/perform_reset.html
+++ b/ckanext/canada/templates/user/perform_reset.html
@@ -1,7 +1,7 @@
 {% ckan_extends %}
 
 {% block primary_content %}
-  {% if g.is_registry %}
+  {% if h.is_registry_domain() %}
     <div class="row mrgn-bttm-lg mrgn-tp-md canada-page-main-wrapper">
       <div class="col-md-12">
         <section class="alert alert-info">

--- a/ckanext/canada/templates/user/read.html
+++ b/ckanext/canada/templates/user/read.html
@@ -1,12 +1,14 @@
 {% ckan_extends %}
 
+{% set is_registry = h.is_registry_domain() %}
+
 {% block subtitle %}
   {{ user.display_name }}
 {% endblock %}
 
 {% block page_heading %}
   {{ super.super() }}
-  {% if g.is_registry %}
+  {% if is_registry %}
     {% if g.userobj and g.userobj.sysadmin %}
       {% if h.is_user_locked(user_name=user['name']) %}
         &nbsp;<span class="text-warning"><span title="{{ _('Unlock account') }}" aria-label="{{ _('Unlock account') }}" tabindex="0" role="button" class="fa fa-lock canada-security-unlock" data-user="{{ user['name'] }}" data-error="{{ _('Unable to unlock user account.') }}"></span></span>
@@ -34,7 +36,7 @@
 {%- endblock -%}
 
 {% block scripts %}
-  {% if g.is_registry %}
+  {% if is_registry %}
     {% asset 'canada_internal/user_lock' %}
   {% endif %}
   {{ super() }}

--- a/ckanext/canada/templates/user/read_base.html
+++ b/ckanext/canada/templates/user/read_base.html
@@ -1,7 +1,9 @@
 {% ckan_extends %}
 
+{% set is_registry = h.is_registry_domain() %}
+
 {% block breadcrumb_content %}
-  {% if g.is_registry %}
+  {% if is_registry %}
     {{ h.build_nav('user.index', _('Users')) }}
     {{ h.build_nav('user.read', user.display_name|truncate(35), id=user.name) }}
   {% endif %}
@@ -67,7 +69,7 @@
           <div class="col-md-12 left-center text-break text-wrap"><strong>{{ _('Member Since') }}</strong></div>
           <div class="col-md-12 left-center text-break text-wrap">{{ h.render_datetime(user.created) }}</div>
         </div>
-        {% if g.is_registry %}
+        {% if is_registry %}
           <div class="info mrgn-tp-md">
             {% if h.user_organizations(user) %}
             <dl>

--- a/ckanext/canada/view.py
+++ b/ckanext/canada/view.py
@@ -281,7 +281,7 @@ canada_views.add_url_rule(
 
 @canada_views.route('/recover-username', methods=['GET', 'POST'])
 def recover_username():
-    if not g.is_registry or not h.plugin_loaded('gcnotify'):
+    if not h.is_registry_domain() or not h.plugin_loaded('gcnotify'):
         # we only want this route on the Registry, and the email template
         # is monkey patched in GC Notify so we need that loaded
         return abort(404)
@@ -341,9 +341,10 @@ def recover_username():
 
 
 def canada_search(package_type: str):
-    if g.is_registry and not g.user:
+    is_registry = h.is_registry_domain()
+    if is_registry and not g.user:
         return abort(403)
-    if not g.is_registry and package_type in h.recombinant_get_types():
+    if not is_registry and package_type in h.recombinant_get_types():
         return h.redirect_to('dataset.search', package_type='dataset')
     return dataset_search(package_type)
 
@@ -801,7 +802,7 @@ def _clean_check_type_errors(post_data: Dict[str, Any],
 
 @canada_views.route('/', methods=['GET'])
 def home():
-    if not g.is_registry:
+    if not h.is_registry_domain():
         return h.redirect_to('dataset.search')
     if not g.user:
         return h.redirect_to('user.login')
@@ -816,7 +817,7 @@ def home():
 
 @canada_views.route('/links', methods=['GET'])
 def links():
-    if not g.is_registry:
+    if not h.is_registry_domain():
         return h.redirect_to('dataset.search')
     return render('home/quick_links.html',
                   extra_vars={'is_sysadmin': is_sysadmin(g.user)})
@@ -889,7 +890,7 @@ def ckanadmin_job_queue():
 
 @canada_views.route('/help', methods=['GET'])
 def view_help():
-    if not g.is_registry:
+    if not h.is_registry_domain():
         return abort(404)
     return render('help.html', extra_vars={})
 


### PR DESCRIPTION
feat(dev): is registry global;

- Moved app global to request context helper.

@wardi I THINK this works how we want to set up our CKAN. So instead of checking for canada_internal to be loaded, just checking the request URI subdomain. As we are still gunna have users login and use the "Registry" via that domain, and the "Public" portal will still be at `open.canada.ca/data/`. But now just both `registry.open.canada.ca` and `open.canada.ca/data/` will do proxy passes to the same uWSGI App in NGINX, so one CKAN instance/config. And we already have some NGINX configs to redirect user login from `/data/` to `registry.open` so I think this makes sense to do?

PS - the helper does `'registry' in subdomain` to support our test and staging environs.