### PR TITLE
Improve UX for Guess Mimetypes

### DIFF
--- a/changes/1606.bugfix
+++ b/changes/1606.bugfix
@@ -1,0 +1,1 @@
+Resource format validator will now fallback to `other` if the guessed mimetype is not in the list of Scheming choices.

--- a/changes/1606.changes
+++ b/changes/1606.changes
@@ -1,0 +1,1 @@
+Added `mrc` file format as a valid Resource format.

--- a/ckanext/canada/assets/internal/canada_internal.css
+++ b/ckanext/canada/assets/internal/canada_internal.css
@@ -831,3 +831,7 @@ body ul.xloader-log li.item.failure > i::after{
 ##  Recombinant Base CSS Overrides ##
 ##               END               ##
 #####################################*/
+
+input#field-resource-url{
+  padding-right: 100px !important;
+}

--- a/ckanext/canada/logic.py
+++ b/ckanext/canada/logic.py
@@ -356,9 +356,6 @@ def canada_guess_mimetype(context: Context, data_dict: DataDict) -> str:
                 for r in f['replaces']:
                     if mimetype.lower() == r.lower():
                         mimetype = f['value']
-        if mimetype not in set(_f['value'] for _f in fmt_choices):
-            # for UX, we always have a value here... (2025-09-02)
-            mimetype = 'unsupported'
 
     if not mimetype:
         # raise the ValidationError here so that the

--- a/ckanext/canada/logic.py
+++ b/ckanext/canada/logic.py
@@ -356,6 +356,9 @@ def canada_guess_mimetype(context: Context, data_dict: DataDict) -> str:
                 for r in f['replaces']:
                     if mimetype.lower() == r.lower():
                         mimetype = f['value']
+        if mimetype not in set(_f['value'] for _f in fmt_choices):
+            # for UX, we always have a value here... (2025-09-02)
+            mimetype = 'unsupported'
 
     if not mimetype:
         # raise the ValidationError here so that the

--- a/ckanext/canada/schemas/presets.yaml
+++ b/ckanext/canada/schemas/presets.yaml
@@ -3672,10 +3672,6 @@ presets:
         en: Unknown
         fr: Inconnu
       value: unknown
-    - label:
-        en: Unsupported
-        fr: Non pris en charge
-      value: unsupported
 
 # Field = Size.
 # {The [estimated] size of a distribution in kilobytes}

--- a/ckanext/canada/schemas/presets.yaml
+++ b/ckanext/canada/schemas/presets.yaml
@@ -3521,6 +3521,9 @@ presets:
     - label: MapInfo
       value: TAB
     - value: MAPX
+    - value: MRC
+      mimetype: application/marc
+      replaces: ["marc"]
     - value: MFX
       mimetype: application/mxf
     - value: MOV
@@ -3669,6 +3672,10 @@ presets:
         en: Unknown
         fr: Inconnu
       value: unknown
+    - label:
+        en: Unsupported
+        fr: Non pris en charge
+      value: unsupported
 
 # Field = Size.
 # {The [estimated] size of a distribution in kilobytes}

--- a/ckanext/canada/validators.py
+++ b/ckanext/canada/validators.py
@@ -30,6 +30,7 @@ import uuid
 from datetime import datetime
 
 from ckan.lib.helpers import date_str_to_datetime
+from ckanext.scheming.helpers import scheming_get_preset
 from ckanext.fluent.validators import fluent_text_output, LANG_SUFFIX
 from ckanext.security.resource_upload_validator import (
     validate_upload_type, validate_upload_presence
@@ -530,6 +531,7 @@ def canada_guess_resource_format(key: FlattenKey,
         return
 
     value = data[key]
+    mimetype = None
 
     # if it is empty, then do the initial guess.
     # we will guess all url types, unlike Core
@@ -579,6 +581,15 @@ def canada_guess_resource_format(key: FlattenKey,
                 #      set this to something...
                 # errors[key].append(e.error_dict['format'])
                 # raise StopOnError
+
+    if mimetype:
+        preset_field = scheming_get_preset('canada_resource_format')
+        fmt_choices = []
+        if preset_field and 'choices' in preset_field:
+            fmt_choices = preset_field['choices']
+        if mimetype not in set(_f['value'] for _f in fmt_choices):
+            # guessed mimetype not in Scheming choice list, use `other` for now
+            data[key] = 'other'
 
 
 def protect_registry_access(key: FlattenKey,


### PR DESCRIPTION
fix(logic): guess mimes;

- Add `mrc` format.
- Validator fallback to `other` for guessed mimetypes not in choices.
- Add some padding to resource url field.

___________

This has come up a few times now, in which a user updates their resource URL or filename which triggers the guess mimetype code again. If the guess mimetype comes up with a mimetype that is not in our choices list then Scheming Extension is gunna raise a validation error. So like how we have an `unkown` format for when we cannot guess the mimetype, we just always check if the guessed mimetype is in the Scheming choice list. If it is NOT, then set it to `other` so that it does not prevent users from updating their resources.