### PR TITLE
[Concept] Automated PD Compliance

### DIFF
--- a/ckanext/canada/assets/internal/canada_internal.css
+++ b/ckanext/canada/assets/internal/canada_internal.css
@@ -869,3 +869,59 @@ input#field-resource-url{
 ## REMOVE AFTER FULL PD DATATABLES QA ##
 ##               END                  ##
 ########################################*/
+
+/*##############################
+##  PD Compliance Dashboards  ##
+################################*/
+.pd-comp-summary-wrapper{
+  border: 2px solid #091c2d;
+  border-radius: 0 0 3px 3px;
+  margin-bottom: 25px;
+}
+/* TODO: write hover,active,focus states for details */
+body .pd-comp-summary-wrapper details,
+body .pd-comp-summary-wrapper summary{
+  margin: 0 !important;
+  padding: 0 !important;
+  display: block !important;
+  border: none !important;
+  outline: none !important;
+  text-decoration: none !important;
+  position: relative;
+}
+
+.pd-comp-summary-wrapper .pd-comp-summary-title{
+  display: block;
+  width: 100%;
+  min-height: 25px;
+  background-color: #091c2d;
+  color: #f7f7f7;
+  padding: 12px 36px 12px 24px;
+  font-weight: bold;
+  text-decoration: none !important;
+}
+
+.pd-comp-summary-wrapper details .pd-comp-summary-title::after{
+  content: '\f0fe';
+  position: absolute;
+  right: 24px;
+  top: 50%;
+  transform: translate(0, -50%);
+  display: block;
+  font-size: 36px;
+  line-height: 1;
+  font-family: 'FontAwesome';
+}
+
+.pd-comp-summary-wrapper details[open] .pd-comp-summary-title::after{
+  content: '\f146';
+}
+
+.pd-comp-summary-wrapper .pd-comp-summary-content{
+  padding: 10px;
+}
+/*##############################
+##             END            ##
+##  PD Compliance Dashboards  ##
+##             END            ##
+################################*/

--- a/ckanext/canada/schemas/organization.yaml
+++ b/ckanext/canada/schemas/organization.yaml
@@ -148,61 +148,90 @@ fields:
 # {Reporting requirements for the organization. If 'ATI Summaries' is checked then ati_email field is mandatory}
 - field_name: reporting_requirements
   label:
-    en: "Select reporting requirements for the organization"
-    fr: "Sélectionner les exigences en matière de rapports pour l'organisation"
+    en: Select reporting requirements for the organization
+    fr: Sélectionner les exigences en matière de rapports pour l'organisation
   choices:
+
   - label:
-      en: "Acts of Founded Wrongdoing"
-      fr: "Dossiers sur les actes répréhensibles fondés"
-    value: "wrongdoing"
+      en: 5th National Action Plan Tracker
+      fr: Outil de suivi pour le 5ᵉ Plan d'action national
+    value: nap5
+
   - label:
-      en: "Aggregated Contracts from -$10K to $10K"
-      fr: "Contrats agrégés de -10 000$ à 10 000$"
-    value: "contractsa"
+      en: 6th National Action Plan Tracker
+      fr: Outil de suivi pour le 6ᵉ Plan d'action national
+    value: nap6
+
   - label:
-      en: "ATI Summaries"
-      fr: "Accès à l'information sommaires complétés"
-    value: "ati"
+      en: Acts of Founded Wrongdoing"
+      fr: Dossiers sur les actes répréhensibles fondés
+    value: wrongdoing
+
   - label:
-      en: "Briefing Note Titles and Numbers"
-      fr: "Titres et numéros des notes d'information"
-    value: "briefingt"
+      en: Aggregated Contracts from -$10K to $10K
+      fr: Contrats agrégés de -10 000$ à 10 000$
+    value: contractsa
+
   - label:
-      en: "Contracts over 10K"
-      fr: "Contrats attribués de plus de 10 000 $"
-    value: "contracts"
+      en: AI Strategy Implementation Tracker
+      fr: Outil de suivi de la mise en oeuvre de la stratégie en matière d'IA
+    value: aistrategy
+
   - label:
-      en: "Departmental Audit Committee"
-      fr: "Comités ministériels d'audit"
-    value: "dac"
+      en: ATI Summaries
+      fr: Accès à l'information sommaires complétés
+    value: ati
+
   - label:
-      en: "Grants and Contributions"
-      fr: "Subventions et les contributions"
-    value: "grants"
+      en: Briefing Note Titles and Numbers
+      fr: Titres et numéros des notes d'information
+    value: briefingt
+
   - label:
-      en: "Hospitality Expenses"
-      fr: "Dépenses d'accueil"
-    value: "hospitalityq"
+      en: Contracts over 10K
+      fr: Contrats attribués de plus de 10 000 $
+    value: contracts
+
   - label:
-      en: "Position Reclassification"
-      fr: "Reclassifications de postes"
-    value: "reclassification"
+      en: Departmental Audit Committee
+      fr: Comités ministériels d'audit
+    value: dac
+
   - label:
-      en: "Question Period Notes"
-      fr: "Notes pour la période des questions"
-    value: "qpnotes"
+      en: Grants and Contributions
+      fr: Subventions et les contributions
+    value: grants
+
   - label:
-      en: "Travel Expenses"
-      fr: "Dépenses de voyage"
-    value: "travelq"
+      en: Hospitality Expenses
+      fr: Dépenses d'accueil
+    value: hospitalityq
+
   - label:
-      en: "Annual Travel, Hospitality and Conferences"
-      fr: "Dépenses annuelles de voyages, d'accueil, de conférences et d'événements"
-    value: "travela"
+      en: Position Reclassification
+      fr: Reclassifications de postes
+    value: reclassification
+
   - label:
-      en: "Use of Administrative Aircraft"
-      fr: "Utilisation des avions d'affaires"
-    value: "adminaircraft"
+      en: Question Period Notes
+      fr: Notes pour la période des questions
+    value: qpnotes
+
+  - label:
+      en: Travel Expenses
+      fr: Dépenses de voyage
+    value: travelq
+
+  - label:
+      en: Annual Travel, Hospitality and Conferences
+      fr: Dépenses annuelles de voyages, d'accueil, de conférences et d'événements
+    value: travela
+
+  - label:
+      en: Use of Administrative Aircraft
+      fr: Utilisation des avions d'affaires
+    value: adminaircraft
+
   form_snippet: multiple_checkbox.html
   display_snippet: multiple_choice.html
   validators: scheming_required scheming_multiple_choice protect_reporting_requirements ati_email_validate

--- a/ckanext/canada/schemas/organization.yaml
+++ b/ckanext/canada/schemas/organization.yaml
@@ -163,7 +163,7 @@ fields:
     value: nap6
 
   - label:
-      en: Acts of Founded Wrongdoing"
+      en: Acts of Founded Wrongdoing
       fr: Dossiers sur les actes répréhensibles fondés
     value: wrongdoing
 
@@ -216,6 +216,11 @@ fields:
       en: Question Period Notes
       fr: Notes pour la période des questions
     value: qpnotes
+
+  - label:
+      en: Service Identification Information & Metrics
+      fr: Renseignements sur l'identification des services, données volumétriques
+    value: service
 
   - label:
       en: Travel Expenses

--- a/ckanext/canada/tables/adminaircraft.yaml
+++ b/ckanext/canada/tables/adminaircraft.yaml
@@ -11,6 +11,7 @@ template_version: 3
 template_updated: 2025-01-10  # last qa confirmed: 2025-02-19
 
 portal_type: info
+# TODO: confirm frequency
 reporting_frequency: monthly
 
 resources:

--- a/ckanext/canada/tables/adminaircraft.yaml
+++ b/ckanext/canada/tables/adminaircraft.yaml
@@ -11,6 +11,7 @@ template_version: 3
 template_updated: 2025-01-10  # last qa confirmed: 2025-02-19
 
 portal_type: info
+reporting_frequency: monthly
 
 resources:
 - title: Proactive Publication - Use of Administrative Aircraft

--- a/ckanext/canada/tables/aistrategy.yaml
+++ b/ckanext/canada/tables/aistrategy.yaml
@@ -8,6 +8,7 @@ template_updated: 2025-08-04
 
 portal_type: info
 collection: pd
+# TODO: confirm frequency
 reporting_frequency: quarterly_f
 
 resources:

--- a/ckanext/canada/tables/aistrategy.yaml
+++ b/ckanext/canada/tables/aistrategy.yaml
@@ -8,6 +8,7 @@ template_updated: 2025-08-04
 
 portal_type: info
 collection: pd
+reporting_frequency: quarterly_f
 
 resources:
 - title: AI Strategy Implementation Tracker

--- a/ckanext/canada/tables/ati.yaml
+++ b/ckanext/canada/tables/ati.yaml
@@ -10,6 +10,7 @@ template_updated: 2021-04-19  # last qa confirmed: 2025-02-19
 
 portal_type: info
 collection: ati
+reporting_frequency: monthly
 
 resources:
 - title: ATI Summaries

--- a/ckanext/canada/tables/ati.yaml
+++ b/ckanext/canada/tables/ati.yaml
@@ -10,6 +10,7 @@ template_updated: 2021-04-19  # last qa confirmed: 2025-02-19
 
 portal_type: info
 collection: ati
+# TODO: confirm frequency
 reporting_frequency: monthly
 
 resources:

--- a/ckanext/canada/tables/briefingt.yaml
+++ b/ckanext/canada/tables/briefingt.yaml
@@ -10,6 +10,7 @@ template_updated: 2026-01-27  # last qa confirmed: 2025-02-19
 
 portal_type: info
 collection: briefingt
+reporting_frequency: monthly
 
 resources:
 - title: Proactive Publication - Briefing Note Titles and Numbers

--- a/ckanext/canada/tables/briefingt.yaml
+++ b/ckanext/canada/tables/briefingt.yaml
@@ -10,6 +10,7 @@ template_updated: 2026-01-27  # last qa confirmed: 2025-02-19
 
 portal_type: info
 collection: briefingt
+# TODO: confirm frequency
 reporting_frequency: monthly
 
 resources:

--- a/ckanext/canada/tables/contracts.yaml
+++ b/ckanext/canada/tables/contracts.yaml
@@ -28,6 +28,7 @@ template_updated: 2023-06-28  # last qa confirmed: 2025-02-19
 
 portal_type: info
 collection: pd
+# TODO: confirm frequency
 reporting_frequency: quarterly_f
 
 sidebar_extra_content:

--- a/ckanext/canada/tables/contracts.yaml
+++ b/ckanext/canada/tables/contracts.yaml
@@ -28,6 +28,7 @@ template_updated: 2023-06-28  # last qa confirmed: 2025-02-19
 
 portal_type: info
 collection: pd
+reporting_frequency: quarterly_f
 
 sidebar_extra_content:
   en: 'For information on the Proactive Publication of Contracts, refer to the [Guide to the Proactive Publication of Contracts](https://www.tbs-sct.canada.ca/pol/doc-eng.aspx?id=32763).'

--- a/ckanext/canada/tables/contractsa.yaml
+++ b/ckanext/canada/tables/contractsa.yaml
@@ -10,6 +10,7 @@ template_updated: 2023-06-28  # last qa confirmed: 2025-02-19
 
 portal_type: info
 collection: pd
+reporting_frequency: yearly
 
 resources:
 - title: Proactive Publication - Aggregated Contracts from -$10,000 to $10,000

--- a/ckanext/canada/tables/contractsa.yaml
+++ b/ckanext/canada/tables/contractsa.yaml
@@ -10,7 +10,8 @@ template_updated: 2023-06-28  # last qa confirmed: 2025-02-19
 
 portal_type: info
 collection: pd
-reporting_frequency: yearly
+# TODO: confirm frequency
+reporting_frequency: annually
 
 resources:
 - title: Proactive Publication - Aggregated Contracts from -$10,000 to $10,000

--- a/ckanext/canada/tables/dac.yaml
+++ b/ckanext/canada/tables/dac.yaml
@@ -9,6 +9,7 @@ template_updated: 2024-04-18  # last qa confirmed: 2025-02-19
 
 portal_type: info
 collection: pd
+# TODO: confirm frequency
 reporting_frequency: quarterly_f
 
 resources:

--- a/ckanext/canada/tables/dac.yaml
+++ b/ckanext/canada/tables/dac.yaml
@@ -9,6 +9,7 @@ template_updated: 2024-04-18  # last qa confirmed: 2025-02-19
 
 portal_type: info
 collection: pd
+reporting_frequency: quarterly_f
 
 resources:
 - title: Proactive Publication - Departmental Audit Committee

--- a/ckanext/canada/tables/grants.yaml
+++ b/ckanext/canada/tables/grants.yaml
@@ -13,6 +13,7 @@ template_warning:
 
 portal_type: info
 collection: pd
+reporting_frequency: quarterly_f
 
 resources:
 - title: Proactive Publication - Grants and Contributions

--- a/ckanext/canada/tables/grants.yaml
+++ b/ckanext/canada/tables/grants.yaml
@@ -13,6 +13,7 @@ template_warning:
 
 portal_type: info
 collection: pd
+# TODO: confirm frequency
 reporting_frequency: quarterly_f
 
 resources:

--- a/ckanext/canada/tables/hospitalityq.yaml
+++ b/ckanext/canada/tables/hospitalityq.yaml
@@ -14,6 +14,7 @@ template_updated: 2024-08-14  # last qa confirmed: 2025-02-19
 
 portal_type: info
 collection: pd
+# TODO: confirm frequency
 reporting_frequency: quarterly
 
 resources:

--- a/ckanext/canada/tables/hospitalityq.yaml
+++ b/ckanext/canada/tables/hospitalityq.yaml
@@ -14,7 +14,7 @@ template_updated: 2024-08-14  # last qa confirmed: 2025-02-19
 
 portal_type: info
 collection: pd
-
+reporting_frequency: quarterly
 
 resources:
 - title: Proactive Publication - Hospitality Expenses

--- a/ckanext/canada/tables/nap5.yaml
+++ b/ckanext/canada/tables/nap5.yaml
@@ -8,6 +8,7 @@ template_updated: 2022-12-07  # last qa confirmed: 2025-02-19
 
 portal_type: info
 collection: pd
+reporting_frequency: quarterly
 
 resources:
 - title: 5th National Action Plan on Open Government Tracker

--- a/ckanext/canada/tables/nap5.yaml
+++ b/ckanext/canada/tables/nap5.yaml
@@ -8,6 +8,7 @@ template_updated: 2022-12-07  # last qa confirmed: 2025-02-19
 
 portal_type: info
 collection: pd
+# TODO: confirm frequency
 reporting_frequency: quarterly
 
 resources:

--- a/ckanext/canada/tables/qpnotes.yaml
+++ b/ckanext/canada/tables/qpnotes.yaml
@@ -10,6 +10,8 @@ template_updated: 2025-01-10  # last qa confirmed: 2025-02-19
 
 portal_type: info
 collection: qpnotes
+# TODO: confirm frequency
+reporting_frequency: bi_annually
 
 resources:
 - title: Proactive Publication - Question Period Notes

--- a/ckanext/canada/tables/reclassification.yaml
+++ b/ckanext/canada/tables/reclassification.yaml
@@ -9,6 +9,8 @@ template_updated: 2024-08-14  # last qa confirmed: 2025-02-19
 
 portal_type: info
 collection: pd
+# TODO: confirm frequency
+reporting_frequency: quarterly_f
 
 resources:
 - title: Proactive Publication - Position Reclassification

--- a/ckanext/canada/tables/service.yaml
+++ b/ckanext/canada/tables/service.yaml
@@ -12,6 +12,8 @@ template_updated: 2025-08-11  # last qa confirmed: 2025-02-19
 
 portal_type: dataset
 collection: service
+# TODO: confirm frequency
+reporting_frequency: annually_f
 
 guide_link: http://www.gcpedia.gc.ca/wiki/GC_Service_Policy_Agenda
 

--- a/ckanext/canada/tables/travela.yaml
+++ b/ckanext/canada/tables/travela.yaml
@@ -13,6 +13,8 @@ template_updated: 2023-10-05  # last qa confirmed: 2025-02-19
 
 portal_type: info
 collection: pd
+# TODO: confirm frequency
+reporting_frequency: annually_f
 
 resources:
 - title: Proactive Publication - Annual Travel, Hospitality and Conferences

--- a/ckanext/canada/tables/travelq.yaml
+++ b/ckanext/canada/tables/travelq.yaml
@@ -14,7 +14,8 @@ template_updated: 2024-08-14  # last qa confirmed: 2025-02-19
 
 portal_type: info
 collection: pd
-
+# TODO: confirm frequency
+reporting_frequency: monthly
 
 resources:
 - title: Proactive Publication - Travel Expenses

--- a/ckanext/canada/tables/wrongdoing.yaml
+++ b/ckanext/canada/tables/wrongdoing.yaml
@@ -9,6 +9,8 @@ template_updated: 2023-10-05  # last qa confirmed: 2025-02-19
 
 portal_type: info
 collection: pd
+# TODO: confirm frequency
+reporting_frequency: quarterly_f
 
 resources:
 - title: Proactive Publication - Founded Wrongdoing

--- a/ckanext/canada/templates/organization/edit_base.html
+++ b/ckanext/canada/templates/organization/edit_base.html
@@ -30,6 +30,7 @@
     {% endif %}
     {% if h.check_access('organization_update', {'id': organization.id}) %}
       {{ h.build_nav_icon('organization.manage_members', _('Edit Members'), id=organization.name, icon='users') }}
+      {{ h.build_nav_icon('canada.pd_compliance_summary', _('Compliance'), id=organization.name, icon='certificate') }}
     {% elif h.check_access('view_org_members', {'id': organization.id}) %}
       {{ h.build_nav_icon('organization.members', _('View Members'), id=organization.name, icon='users') }}
     {% endif %}

--- a/ckanext/canada/templates/organization/pd_compliance.html
+++ b/ckanext/canada/templates/organization/pd_compliance.html
@@ -1,0 +1,70 @@
+{% extends "organization/edit_base.html" %}
+
+{% block subtitle %}{{ _('Proactive Disclosure Compliance') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
+
+{% block primary_content_inner %}
+  {%- set valid_types = h.recombinant_get_types() -%}
+  {%- set ns = namespace(genos={}) -%}
+  {% for t in group_dict.reporting_requirements %}
+    {% if t not in valid_types %}{% continue %}{% endif %}
+    {%- do ns.genos.update({t: h.recombinant_get_geno(t)}) -%}
+  {% endfor %}
+  <div class="row">
+    <div class="col-md-12">
+      {% if not group_dict.reporting_requirements %}
+        <div class="module-alert alert alert-info">
+          <p><strong>{{ h.get_translated(group_dict, 'title') }} {{ _('does not have any reporting requirements.') }}</strong></p>
+          <p>{{ _('If the organization should have reporting requirements, this can be modified by selecting reporting requirements when editing the organization.') }}</p>
+        </div>
+      {% else %}
+        {# TODO: output summary info??? #}
+        {% for t in group_dict.reporting_requirements %}
+          {% if t not in valid_types %}{% continue %}{% endif %}
+          {% set label = ns.genos[t].shortname or ns.genos[t].title %}
+          <div class="pd-comp-summary-wrapper">
+            <details>
+              <summary>
+                <span class="pd-comp-summary-title">{{ _(label) }}</span>
+              </summary>
+              <div class="pd-comp-summary-content">
+                <p>TODO: output stuff here...</p>
+              </div>
+            </details>
+          </div>
+        {% endfor %}
+      {% endif %}
+    </div>
+  </div>
+{% endblock %}
+
+{% block secondary_content %}
+  {{ super() }}
+  <div class="panel panel-info">
+    <div class="panel-heading">
+      <i class="fa fa-lg fa-info-circle"></i>&nbsp;{{ _('What is Proactive Disclosure Compliance?') }}
+    </div>
+    <div class="panel-body">
+        <p>{{ _("Your Organization is required to disclose data under certain data policies.") }}</p>
+        <p>{{ _("Use this page to view upcoming and past disclosure requirements for your organization.") }}</p>
+    </div>
+  </div>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script nonce="{{- h.get_inline_script_nonce() -}}">
+    window.addEventListener('load', function(){
+      $(document).ready(function(){
+        let select2Fields = $('[data-field-select2="True"]');
+        if( select2Fields.length > 0 ){
+          $(select2Fields).each(function(_index, _select2Field){
+            $(_select2Field).select2({
+              allowClear: true,
+              placeholder: "{{ _('Select a Proactive Disclosure...') }}",
+            });
+          });
+        }
+      });
+    });
+  </script>
+{% endblock %}

--- a/ckanext/canada/templates/organization/read_base.html
+++ b/ckanext/canada/templates/organization/read_base.html
@@ -23,6 +23,7 @@
   {% endif %}
   {% if h.check_access('organization_update', {'id': organization.id}) %}
     {{ h.build_nav_icon('organization.manage_members', _('Edit Members'), id=organization.name, icon='users') }}
+    {{ h.build_nav_icon('canada.pd_compliance_summary', _('Compliance'), id=organization.name, icon='certificate') }}
   {% elif h.check_access('view_org_members', {'id': organization.id}) %}
     {{ h.build_nav_icon('organization.members', _('View Members'), id=organization.name, icon='users') }}
   {% endif %}


### PR DESCRIPTION
So the idea is that we already have all of this organization metadata on what an org needs to complete. And we already have all of the PD schemas, and direct access to the datastore via the CKAN Registry. So we can, in theory, make compliance dashboards inside of CKAN with Recombinant & DataStore.

Some general ideas on what is needed:

- `reporting_frequency` key values for the PD genos;
- any missing PDs in the org `reporting_requirements`;
- view for org PD compliance, maybe select2 for PD type, then select reporting period based on `reporting_frequency` then show what has been reported. Put in edit links?
- when user logs in, should see if their org has any upcoming PDs that they are missing data for, including NILs. This might be costly when user logging in, so might need some background job and database table;
- some type of sysadmin view to show and download csv of PD compliance for a PD type