### PR TITLE
Resource View Embed Host List

### DIFF
--- a/changes/1679.a.changes
+++ b/changes/1679.a.changes
@@ -1,0 +1,1 @@
+The Resource View embed button/modal will now display which hostnames are allowed to embed our site contents. The embed button no longer displays on the Registry.

--- a/changes/1679.b.changes
+++ b/changes/1679.b.changes
@@ -1,0 +1,1 @@
+The Citation button now only displays on the public Portal, not on the Registry.

--- a/ckanext/canada/assets/public/canada_public.css
+++ b/ckanext/canada/assets/public/canada_public.css
@@ -1674,6 +1674,23 @@ body #timeout > .modal-dialog{
     width: 80% !important;
   }
 }
+body .modal.canada-resource-view-embed .modal-dialog{
+  display: inline-block;
+  text-align: left;
+  vertical-align: middle;
+  position: absolute;
+  top: 20%;
+  left: 50%;
+  transform: translate(-50%, 0);
+  max-width: 80%;
+}
+@media all and (max-width: 768px){
+  body .modal.canada-resource-view-embed .modal-dialog{
+    min-width: 80%;
+    max-width: 80%;
+    width: 80%;
+  }
+}
 /* BS4+ Fix. TODO: remove after upgrade to BS4+ */
 body .modal .modal-dialog .modal-content button.btn-close{
   background-color: transparent;

--- a/ckanext/canada/helpers.py
+++ b/ckanext/canada/helpers.py
@@ -1173,3 +1173,7 @@ def mail_to_with_params(email_address: str, name: str,
 
 def get_inline_script_nonce() -> str:
     return str(request.environ.get('CSP_NONCE', ''))
+
+
+def get_allowed_frame_hosts() -> Optional[list]:
+    return config.get('ckanext.canada.allowed_frame_hosts')

--- a/ckanext/canada/i18n/ckanext-canada.pot
+++ b/ckanext/canada/i18n/ckanext-canada.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-canada 0.4.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-03-19 17:41+0000\n"
+"POT-Creation-Date: 2026-06-09 14:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1412,12 +1412,12 @@ msgstr ""
 msgid "container_title"
 msgstr ""
 
-#: ckanext/canada/plugin/public_plugin.py:330
+#: ckanext/canada/plugin/public_plugin.py:331
 #: ckanext/canada/templates/package/read.html:186
 msgid "Previous"
 msgstr ""
 
-#: ckanext/canada/plugin/public_plugin.py:331
+#: ckanext/canada/plugin/public_plugin.py:332
 #: ckanext/canada/templates/package/read.html:202
 msgid "Next"
 msgstr ""
@@ -1577,12 +1577,12 @@ msgid "Access, upload and modify consultation reports for your organization"
 msgstr ""
 
 #. SQL Trigger String for PD Type: consultations
-#: ckanext/canada/tables/consultations.yaml:682
+#: ckanext/canada/tables/consultations.yaml:685
 msgid "If Status is set to: Not Going Forward, Publish Record must be set to No"
 msgstr ""
 
 #. SQL Trigger String for PD Type: consultations
-#: ckanext/canada/tables/consultations.yaml:683
+#: ckanext/canada/tables/consultations.yaml:686
 msgid "Comma is not allowed in Registration Number field"
 msgstr ""
 
@@ -3491,6 +3491,40 @@ msgstr ""
 #: ckanext/canada/templates/package/snippets/resource_item.html:110
 #: ckanext/canada/templates/package/snippets/resources.html:44
 msgid "Delete resource"
+msgstr ""
+
+#: ckanext/canada/templates/package/snippets/resource_view.html:19
+msgid "Embed"
+msgstr ""
+
+#: ckanext/canada/templates/package/snippets/resource_view.html:40
+msgid "Embed resource view"
+msgstr ""
+
+#: ckanext/canada/templates/package/snippets/resource_view.html:41
+msgid "Close"
+msgstr ""
+
+#: ckanext/canada/templates/package/snippets/resource_view.html:44
+msgid ""
+"You can copy and paste the embed code into a CMS or blog software that "
+"supports raw HTML"
+msgstr ""
+
+#: ckanext/canada/templates/package/snippets/resource_view.html:46
+msgid "Only certain websites are allowed to embed content from open.canada.ca:"
+msgstr ""
+
+#: ckanext/canada/templates/package/snippets/resource_view.html:51
+msgid "Width"
+msgstr ""
+
+#: ckanext/canada/templates/package/snippets/resource_view.html:54
+msgid "Height"
+msgstr ""
+
+#: ckanext/canada/templates/package/snippets/resource_view.html:57
+msgid "Code"
 msgstr ""
 
 #: ckanext/canada/templates/package/snippets/resources.html:35

--- a/ckanext/canada/i18n/en/LC_MESSAGES/ckanext-canada.po
+++ b/ckanext/canada/i18n/en/LC_MESSAGES/ckanext-canada.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  CKAN\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-03-19 17:41+0000\n"
+"POT-Creation-Date: 2026-06-09 14:38+0000\n"
 "PO-Revision-Date: 2014-01-23 13:04+0000\n"
 "Last-Translator: Sean Hammond <sean.hammond@okfn.org>\n"
 "Language: en\n"
@@ -1424,12 +1424,12 @@ msgstr ""
 msgid "container_title"
 msgstr ""
 
-#: ckanext/canada/plugin/public_plugin.py:330
+#: ckanext/canada/plugin/public_plugin.py:331
 #: ckanext/canada/templates/package/read.html:186
 msgid "Previous"
 msgstr ""
 
-#: ckanext/canada/plugin/public_plugin.py:331
+#: ckanext/canada/plugin/public_plugin.py:332
 #: ckanext/canada/templates/package/read.html:202
 msgid "Next"
 msgstr ""
@@ -1595,12 +1595,12 @@ msgid "Access, upload and modify consultation reports for your organization"
 msgstr ""
 
 #. SQL Trigger String for PD Type: consultations
-#: ckanext/canada/tables/consultations.yaml:682
+#: ckanext/canada/tables/consultations.yaml:685
 msgid "If Status is set to: Not Going Forward, Publish Record must be set to No"
 msgstr ""
 
 #. SQL Trigger String for PD Type: consultations
-#: ckanext/canada/tables/consultations.yaml:683
+#: ckanext/canada/tables/consultations.yaml:686
 msgid "Comma is not allowed in Registration Number field"
 msgstr ""
 
@@ -3551,6 +3551,40 @@ msgstr ""
 msgid "Delete resource"
 msgstr ""
 
+#: ckanext/canada/templates/package/snippets/resource_view.html:19
+msgid "Embed"
+msgstr ""
+
+#: ckanext/canada/templates/package/snippets/resource_view.html:40
+msgid "Embed resource view"
+msgstr ""
+
+#: ckanext/canada/templates/package/snippets/resource_view.html:41
+msgid "Close"
+msgstr ""
+
+#: ckanext/canada/templates/package/snippets/resource_view.html:44
+msgid ""
+"You can copy and paste the embed code into a CMS or blog software that "
+"supports raw HTML"
+msgstr ""
+
+#: ckanext/canada/templates/package/snippets/resource_view.html:46
+msgid "Only certain websites are allowed to embed content from open.canada.ca:"
+msgstr ""
+
+#: ckanext/canada/templates/package/snippets/resource_view.html:51
+msgid "Width"
+msgstr ""
+
+#: ckanext/canada/templates/package/snippets/resource_view.html:54
+msgid "Height"
+msgstr ""
+
+#: ckanext/canada/templates/package/snippets/resource_view.html:57
+msgid "Code"
+msgstr ""
+
 #: ckanext/canada/templates/package/snippets/resources.html:35
 msgid "DataStore"
 msgstr ""
@@ -3576,9 +3610,8 @@ msgid "Add new resource"
 msgstr ""
 
 #: ckanext/canada/templates/package/snippets/resources_list.html:33
-#, fuzzy
 msgid "Search resources..."
-msgstr "Search records..."
+msgstr ""
 
 #: ckanext/canada/templates/package/snippets/schemaorg.html:3
 msgid "Government of Canada Open Government Portal"

--- a/ckanext/canada/i18n/fr/LC_MESSAGES/ckanext-canada.po
+++ b/ckanext/canada/i18n/fr/LC_MESSAGES/ckanext-canada.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-03-19 17:41+0000\n"
+"POT-Creation-Date: 2026-06-09 14:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr\n"
@@ -1518,12 +1518,12 @@ msgstr "État de la suggestion"
 msgid "container_title"
 msgstr ""
 
-#: ckanext/canada/plugin/public_plugin.py:330
+#: ckanext/canada/plugin/public_plugin.py:331
 #: ckanext/canada/templates/package/read.html:186
 msgid "Previous"
 msgstr "Précédent"
 
-#: ckanext/canada/plugin/public_plugin.py:331
+#: ckanext/canada/plugin/public_plugin.py:332
 #: ckanext/canada/templates/package/read.html:202
 msgid "Next"
 msgstr "Suivant"
@@ -1702,14 +1702,14 @@ msgstr ""
 "pour votre organisation"
 
 #. SQL Trigger String for PD Type: consultations
-#: ckanext/canada/tables/consultations.yaml:682
+#: ckanext/canada/tables/consultations.yaml:685
 msgid "If Status is set to: Not Going Forward, Publish Record must be set to No"
 msgstr ""
 "Si le statut est établi à : Ne pas aller de l’avant, alors l’option de "
 "Publier le document doit être réglée à Non."
 
 #. SQL Trigger String for PD Type: consultations
-#: ckanext/canada/tables/consultations.yaml:683
+#: ckanext/canada/tables/consultations.yaml:686
 msgid "Comma is not allowed in Registration Number field"
 msgstr "La virgule n’est pas autorisée dans le champ du Numéro d’enregistrement"
 
@@ -3973,6 +3973,43 @@ msgstr "Etes-vous sûr de vouloir supprimer cette ressource?"
 #: ckanext/canada/templates/package/snippets/resources.html:44
 msgid "Delete resource"
 msgstr "Supprimer la ressource"
+
+#: ckanext/canada/templates/package/snippets/resource_view.html:19
+msgid "Embed"
+msgstr "Embarquer sur un site"
+
+#: ckanext/canada/templates/package/snippets/resource_view.html:40
+msgid "Embed resource view"
+msgstr "Incorporer cette visualisation de ressource"
+
+#: ckanext/canada/templates/package/snippets/resource_view.html:41
+msgid "Close"
+msgstr ""
+
+#: ckanext/canada/templates/package/snippets/resource_view.html:44
+msgid ""
+"You can copy and paste the embed code into a CMS or blog software that "
+"supports raw HTML"
+msgstr ""
+"Vous pouvez copier et coller le code intégré dans un système de gestion "
+"de contenu ou un logiciel de blogue qui prend en charge le HTML brut"
+
+#: ckanext/canada/templates/package/snippets/resource_view.html:46
+msgid "Only certain websites are allowed to embed content from open.canada.ca:"
+msgstr "Seuls certains sites Web sont autorisés à intégrer du "
+"contenu provenant de open.canada.ca :"
+
+#: ckanext/canada/templates/package/snippets/resource_view.html:51
+msgid "Width"
+msgstr "Largeur"
+
+#: ckanext/canada/templates/package/snippets/resource_view.html:54
+msgid "Height"
+msgstr "Hauteur"
+
+#: ckanext/canada/templates/package/snippets/resource_view.html:57
+msgid "Code"
+msgstr "Code"
 
 #: ckanext/canada/templates/package/snippets/resources.html:35
 msgid "DataStore"

--- a/ckanext/canada/plugin/config_declaration.yaml
+++ b/ckanext/canada/plugin/config_declaration.yaml
@@ -35,3 +35,11 @@ groups:
           Enables the improved DataTables and custom editor for
           Recombinant type resources.
         validators: boolean_validator
+      - key: ckanext.canada.allowed_frame_hosts
+        default: ['canada.ca', '*.canada.ca', '*.gc.ca']
+        description: |
+          A list of hostnames that are allowed to iFrame web content.
+          This is only used to display to end users, not to define values
+          in frame-ancestors.
+        required: false
+        type: list

--- a/ckanext/canada/plugin/theme_plugin.py
+++ b/ckanext/canada/plugin/theme_plugin.py
@@ -87,5 +87,6 @@ class CanadaThemePlugin(p.SingletonPlugin):
             'support_email_address',
             'get_inline_script_nonce',
             'obfuscate_to_code_points',
-            'mail_to'
+            'mail_to',
+            'get_allowed_frame_hosts',
         ])

--- a/ckanext/canada/templates/package/read_base.html
+++ b/ckanext/canada/templates/package/read_base.html
@@ -143,12 +143,8 @@
           {%- endif -%}
         </ul>
       </li>
-      {% if h.plugin_loaded('citeproc') and pkg.type not in h.recombinant_get_types() %}
-        <li class="list-group-item">
-          {% if h.show_citations_for(pkg.type or 'dataset') %}
-            {% snippet "snippets/citeproc_button.html", pkg_dict=pkg %}
-          {% endif %}
-        </li>
+      {% if h.plugin_loaded('citeproc') and pkg.type not in h.recombinant_get_types() and h.show_citations_for(pkg.type or 'dataset') %}
+          {% snippet "snippets/citeproc_button.html", pkg_dict=pkg, list=true, list_class='list-group-item' %}
       {% endif %}
       {% if pkg.collection == 'fgp' %}
         <li class="list-group-item">

--- a/ckanext/canada/templates/package/snippets/resource_view.html
+++ b/ckanext/canada/templates/package/snippets/resource_view.html
@@ -8,6 +8,19 @@
   {{ h.adobe_analytics_creator(organization=package.organization, package=package) }}
 {% endblock %}
 
+{% block resource_view_actions %}
+  {{ super() }}
+  {% if not h.is_registry_domain() %}
+    <a class="btn btn-default"
+        href="#embed-{{ resource_view['id'] }}"
+        data-module="resource-view-embed"
+        data-module-id="{{ resource_view['id'] }}"
+        data-module-url="{{ h.url_for('resource_view', id=package['name'], resource_id=resource['id'], view_id=resource_view['id'], qualified=true) }}">
+      <i class="fa fa-code"></i>&nbsp;{{ _("Embed") }}
+    </a>
+  {% endif %}
+{% endblock %}
+
 {% block description %}
 <p class="desc">
   {%- if h.lang() == 'fr' -%}
@@ -16,4 +29,34 @@
     {{ h.render_markdown(resource_view['description']) }}
   {%- endif -%}
 </p>
+{% endblock %}
+
+{% block resource_view_bottom %}
+  {% set allowed_hosts = ['canada.ca', '*.canada.ca', '*.gc.ca'] %}
+  <div id="embed-{{ resource_view['id'] }}" class="modal fade resource-view-embed canada-resource-view-embed">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3 class="modal-title">{{ _("Embed resource view") }}</h3>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ _('Close') }}"></button>
+        </div>
+        <div class="modal-body">
+          <p class="embed-content">{{ _("You can copy and paste the embed code into a CMS or blog software that supports raw HTML") }}</p>
+          <p class="embed-content">
+            {{ _("Only certain websites are allowed to embed content from open.canada.ca:") }}
+          <pre>{%- for h in allowed_hosts -%}{{- h -}}<br/>{%- endfor -%}</pre>
+          </p>
+          <div class="row">
+            <div class="col-md-6">
+              {{ form.input("width", label=_("Width"), value=700, classes=["control-full"]) }}
+            </div>
+            <div class="col-md-6">
+              {{ form.input("height", label=_("Height"), value=400, classes=["control-full"]) }}
+            </div>
+          </div>
+          {{ form.textarea("code", label=_("Code"), value="", classes=["pre"], rows=3) }}
+        </div>
+      </div>
+    </div>
+  </div>
 {% endblock %}

--- a/ckanext/canada/templates/package/snippets/resource_view.html
+++ b/ckanext/canada/templates/package/snippets/resource_view.html
@@ -32,7 +32,7 @@
 {% endblock %}
 
 {% block resource_view_bottom %}
-  {% set allowed_hosts = ['canada.ca', '*.canada.ca', '*.gc.ca'] %}
+  {% set allowed_hosts = h.get_allowed_frame_hosts() %}
   <div id="embed-{{ resource_view['id'] }}" class="modal fade resource-view-embed canada-resource-view-embed">
     <div class="modal-dialog">
       <div class="modal-content">
@@ -42,10 +42,12 @@
         </div>
         <div class="modal-body">
           <p class="embed-content">{{ _("You can copy and paste the embed code into a CMS or blog software that supports raw HTML") }}</p>
-          <p class="embed-content">
-            {{ _("Only certain websites are allowed to embed content from open.canada.ca:") }}
-          <pre>{%- for h in allowed_hosts -%}{{- h -}}<br/>{%- endfor -%}</pre>
-          </p>
+          {%- if allowed_hosts -%}
+            <p class="embed-content">
+              {{ _("Only certain websites are allowed to embed content from open.canada.ca:") }}
+            <ul>{%- for h in allowed_hosts -%}<li>{{- h -}}</li>{%- endfor -%}</ul>
+            </p>
+          {%- endif -%}
           <div class="row">
             <div class="col-md-6">
               {{ form.input("width", label=_("Width"), value=700, classes=["control-full"]) }}

--- a/ckanext/canada/templates/snippets/citeproc_button.html
+++ b/ckanext/canada/templates/snippets/citeproc_button.html
@@ -1,0 +1,7 @@
+{% ckan_extends %}
+
+{% block citeproc_button %}
+  {% if not h.is_registry_domain() %}
+    {{ super() }}
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
Bringing back the resource view embed button, adds a list into the modal to display which hosts are allowed to embed our site contents.