### PR TITLE
Sysadmin UI Default User Limit

### DIFF
--- a/changes/1681.changes
+++ b/changes/1681.changes
@@ -1,0 +1,1 @@
+Links to the User list index page will now default to a limit of 15. This is generally a sysadmin UI improvement.

--- a/ckanext/canada/templates/admin/base.html
+++ b/ckanext/canada/templates/admin/base.html
@@ -11,7 +11,7 @@
 {% block content_primary_nav %}
   {% if h.is_registry_domain() %}
     {{ h.build_nav_icon('canada.ckan_admin_index', _('Admins'), icon='user-plus') }}
-    {{ h.build_nav_icon('user.index', _('Users'), icon='user') }}
+    {{ h.build_nav_icon('user.index', _('Users'), limit=15, icon='user') }}
     {# {{ h.build_nav_icon('admin.trash', _('Trash'), icon='trash') }} #}
     {{ h.build_nav_icon('canada.ckanadmin_publish', _('Publish Records'), icon='cloud-upload') }}
     {{ h.build_nav_icon('canada.ckanadmin_job_queue', _('Job Queue'), icon='tasks') }}

--- a/ckanext/canada/templates/user/list.html
+++ b/ckanext/canada/templates/user/list.html
@@ -7,7 +7,7 @@
 {% block breadcrumb_content %}
   {% if h.is_registry_domain() %}
     {% if g.userobj and not g.userobj.sysadmin %}
-      {{ h.build_nav('user.index', _('Users')) }}
+      {{ h.build_nav('user.index', _('Users'), limit=15) }}
     {% else %}
       {{ super() }}
     {% endif %}

--- a/ckanext/canada/templates/user/list.html
+++ b/ckanext/canada/templates/user/list.html
@@ -36,7 +36,7 @@
     {% endif %}
     {% block users_list %}
       {% block users_search %}
-        {% snippet 'user/snippets/user_search.html', q=q %}
+        {% snippet 'user/snippets/user_search.html', q=q, limit=page.items_per_page or 15 %}
       {% endblock %}
       <table class="canada-width-full">
         <thead>
@@ -76,7 +76,7 @@
     {% endblock %}
     {% block page_pagination %}
       {% if page.pager %}
-        {{ page.pager(q=q or '') }}
+        {{ page.pager(q=q or '', limit=page.items_per_page or 15) }}
       {% endif %}
     {% endblock %}
   {% else %}

--- a/ckanext/canada/templates/user/read_base.html
+++ b/ckanext/canada/templates/user/read_base.html
@@ -2,7 +2,7 @@
 
 {% block breadcrumb_content %}
   {% if h.is_registry_domain() %}
-    {{ h.build_nav('user.index', _('Users')) }}
+    {{ h.build_nav('user.index', _('Users'), limit=15) }}
     {{ h.build_nav('user.read', user.display_name|truncate(35), id=user.name) }}
   {% endif %}
 {% endblock %}

--- a/ckanext/canada/templates/user/snippets/user_search.html
+++ b/ckanext/canada/templates/user/snippets/user_search.html
@@ -4,6 +4,7 @@
     <div class="input-group col-md-12">
       <div class="canada-search-field-wrapper">
         <input type="text" class="field form-control" id="field-user-search" autocomplete="off" name="q" value="{{ q }}" placeholder="{{ _('Search users...') }}">
+        <input type="hidden" name="limit" value="{{- limit or 15 -}}">
         <span class="input-group-btn">
           {% block search_input_button %}
           <button class="btn btn-primary btn-small" type="submit">


### PR DESCRIPTION
The sysadmin page takes way too long to load cuz of all the extra stuff we render for users (lock and unlock account stuff, publishing visibility etc). So put a default limit of 15 for the UI.