### PR TITLE
User Opt-in Feature w/ PD DataTable as First One

### DIFF
--- a/changes/1686.feature
+++ b/changes/1686.feature
@@ -1,0 +1,1 @@
+Users can now opt-in to the new PD DataTable on the Registry. Adds a general `canada-user-opt-in-feature` JS module, along with User validation for the opt-in features.

--- a/ckanext/canada/assets/datatables/pd_datatables.js
+++ b/ckanext/canada/assets/datatables/pd_datatables.js
@@ -60,7 +60,10 @@ function load_pd_datatable(CKAN_MODULE){
   const chromoFields = CKAN_MODULE.options.chromo_fields;
   const isEditable = CKAN_MODULE.options.is_editable;
   const tableStyles = CKAN_MODULE.options.table_styles;
-  const EDITOR = pd_datatables__EDITOR;
+
+  // TODO: Disable Editor - enable Table Editor when ready...
+  // const EDITOR = pd_datatables__EDITOR;
+  const EDITOR = false;
 
   const selectAllLabel = _('Select All');
   const colSearchLabel = _('Search:');
@@ -167,6 +170,10 @@ function load_pd_datatable(CKAN_MODULE){
   let isCompactView = typeof tableState != 'undefined' && typeof tableState.compact_view != 'undefined' ? tableState.compact_view : true;
   let isFullScreen = is_page_fullscreen();
   let isEditMode = typeof tableState != 'undefined' && typeof tableState.edit_view != 'undefined' ? tableState.edit_view : false;
+
+  // TODO: Disable Editor - enable Table Editor when ready...
+  isEditMode = false;
+
   if( isEditMode ){
     $('.pd-datable-instructions').css({'display': 'none'});
   }
@@ -2002,18 +2009,29 @@ function load_pd_datatable(CKAN_MODULE){
         _data.selected = this.api().rows({selected: true})[0];
         _data.compact_view = isCompactView;
         _data.edit_view = isEditMode;
+
+        // TODO: Disable Editor - enable Table Editor when ready...
+        _data.edit_view = false;
+
         _data.editing_rows = editingRows;
         // TODO: save filledRows, erroredRows, requiredRows??? need to save the field values too???
         let localInstanceSelected = typeof tableState != 'undefined' ? tableState.selected : _data.selected;
         tableState = _data;
         tableState.selected = localInstanceSelected;
         tableState.edit_view = isEditMode;
+
+        // TODO: Disable Editor - enable Table Editor when ready...
+        tableState.edit_view = false;
+
         tableState.editing_rows = editingRows;
       },
       stateLoadParams: function(_settings, _data){
         let localInstanceSelected = typeof tableState != 'undefined' ? tableState.selected : _data.selected;
         tableState = _data;
         tableState.selected = localInstanceSelected;
+
+        // TODO: Disable Editor - enable Table Editor when ready...
+        tableState.edit_view = false;
       },
       buttons: get_available_buttons(),
     });

--- a/ckanext/canada/assets/modules/user_opt_in.js
+++ b/ckanext/canada/assets/modules/user_opt_in.js
@@ -58,10 +58,7 @@ function _load_user_opt_in(CKAN_MODULE){
           if( _data.responseJSON ){  // we have response JSON
             if( _data.responseJSON.success ){  // successful patch
               if(
-                _data.responseJSON.result.plugin_extras &&
-                typeof _data.responseJSON.result.plugin_extras == 'object' &&
-                ! Array.isArray(_data.responseJSON.result.plugin_extras) &&
-                _data.responseJSON.result.plugin_extras[featureKey] == featureValue
+                _data.responseJSON.result[featureKey] == featureValue
               ){
                 if( pageRedirect && pageRedirect.startsWith('#') ){
                   window.location.hash = pageRedirect.replace('#', '');

--- a/ckanext/canada/assets/modules/user_opt_in.js
+++ b/ckanext/canada/assets/modules/user_opt_in.js
@@ -1,0 +1,92 @@
+this.ckan.module('canada-user-opt-in-feature', function($){
+  return {
+    /* options object can be extended using data-module-* attributes */
+    options: {
+      csrf_name: null,
+      csrf_value: null,
+      page_redirect: null,
+      label: null,
+      button_label: null,
+      user_id: null,
+      feature_key: null,
+      feature_value: true,
+    },
+    initialize: function (){
+      _load_user_opt_in(this);
+    }
+  };
+});
+
+function _load_user_opt_in(CKAN_MODULE){
+  const _ = CKAN_MODULE._;
+  const csrfTokenName = CKAN_MODULE.options.csrf_name;
+  const csrfTokenValue = CKAN_MODULE.options.csrf_value;
+  const pageRedirect = CKAN_MODULE.options.page_redirect;
+  const label = CKAN_MODULE.options.label;
+  const buttonLabel = CKAN_MODULE.options.button_label;
+  const userID = CKAN_MODULE.options.user_id;
+  const featureKey = CKAN_MODULE.options.feature_key;
+  const featureValue = CKAN_MODULE.options.feature_value;
+
+  let postData = {'id': userID};
+  postData[featureKey] = featureValue;
+  postData[csrfTokenName] = csrfTokenValue;
+
+  let container = $('[data-module="canada-user-opt-in-feature"][data-module-feature_key="' + featureKey + '"]');
+  let htmlContent = '<div class="alert alert-warning"><p>' + label + '</p><p><a role="button" class="btn btn-primary btn-small" href="javascript:void(0);">' + buttonLabel + '</a></p></div>';
+
+  function _render_failure(_consoleMessage, _message, _type){
+    console.warn(_consoleMessage);
+    $(container).find('#uoif_failure_message').remove();
+    $(container).append('<div id="uoif_failure_message" class="alert alert-dismissible show alert-' + _type + '"><p>' + _message + '</p></div>');
+  }
+
+  if( $(container).children('.alert').length == 0 ){
+    $(container).append(htmlContent);
+    let button = $(container).find('a.btn');
+    if( button.length > 0 ){
+      $(button).off('click.optInFeature');
+      $(button).on('click.optInFeature', function(_event){
+        $(button).addClass('disabled');
+        $(button).attr('disabled', 'disabled');
+        $.ajax({
+        'url': '/api/action/user_patch',
+        'type': 'POST',
+        'dataType': 'JSON',
+        'data': postData,
+        'complete': function(_data){
+          if( _data.responseJSON ){  // we have response JSON
+            if( _data.responseJSON.success ){  // successful patch
+              if(
+                _data.responseJSON.result.plugin_extras &&
+                typeof _data.responseJSON.result.plugin_extras == 'object' &&
+                ! Array.isArray(_data.responseJSON.result.plugin_extras) &&
+                _data.responseJSON.result.plugin_extras[featureKey] == featureValue
+              ){
+                if( pageRedirect && pageRedirect.startsWith('#') ){
+                  window.location.hash = pageRedirect.replace('#', '');
+                  window.location.reload();
+                  return;
+                }else if( pageRedirect ){
+                  window.location.href = pageRedirect;
+                  return;
+                }
+                window.location.reload();
+                return;
+              }else{  // unexpected return dict
+                _render_failure('Opt-in Feature — Unexpected response data.', _('Failed to change user settings'), 'danger');
+                console.warn(_data.responseJSON);
+              }
+            }else{  // validation error
+              _render_failure('Opt-in Feature — ValidationError exception was raised.', _('Failed to change user settings'), 'danger');
+              console.warn(_data.responseJSON);
+            }
+          }else{  // fully flopped ajax request
+            _render_failure('Opt-in Feature — Failed to gather a JSON response.', _('Failed to change user settings'), 'danger');
+          }
+        }
+      });
+      });
+    }
+  }
+}

--- a/ckanext/canada/assets/modules/webassets.yml
+++ b/ckanext/canada/assets/modules/webassets.yml
@@ -1,0 +1,7 @@
+main_js:
+  contents:
+    - user_opt_in.js
+  extra:
+    preload:
+      - base/main  # need ckan JS and jQuery
+  output: canada_modules/%(version)s_user_opt_in.js

--- a/ckanext/canada/helpers.py
+++ b/ckanext/canada/helpers.py
@@ -531,8 +531,13 @@ def get_pd_datatable(resource_name: str,
                         for fk_ci, fk_cc in enumerate(fk['child_columns']))
 
     # TODO: DEPRECATED: REMOVE AFTER FULL PD DATATABLES QA
-    snippet = 'pd_datatable.html' if config.get(
-        'ckanext.canada.enable_pd_datatable_editor') else 'pd_datatable_depr.html'
+    try:
+        user_dict = get_action('user_show')({'ignore_auth': True}, {'id': g.user})
+    except (ObjectNotFound, RuntimeError):
+        user_dict = {}
+    enable_new_template = user_dict.get('opt_in_features__pd_datatables', config.get(
+        'ckanext.canada.enable_pd_datatable_editor'))
+    snippet = 'pd_datatable.html' if enable_new_template else 'pd_datatable_depr.html'
 
     return h.snippet('snippets/%s' % snippet,
                      resource_name=resource_name,

--- a/ckanext/canada/helpers.py
+++ b/ckanext/canada/helpers.py
@@ -1180,5 +1180,6 @@ def get_inline_script_nonce() -> str:
     return str(request.environ.get('CSP_NONCE', ''))
 
 
-def get_allowed_frame_hosts() -> Optional[list]:
+# type_ignore_reason: incomplete typing
+def get_allowed_frame_hosts() -> Optional[list]:  # type: ignore
     return config.get('ckanext.canada.allowed_frame_hosts')

--- a/ckanext/canada/i18n/ckanext-canada.pot
+++ b/ckanext/canada/i18n/ckanext-canada.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-canada 0.4.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-17 12:48-0400\n"
+"POT-Creation-Date: 2026-07-09 13:09-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -134,105 +134,105 @@ msgstr ""
 msgid "Treasury Board of Canada Secretariat"
 msgstr ""
 
-#: ckanext/canada/helpers.py:711 ckanext/canada/strings.py:14
+#: ckanext/canada/helpers.py:716 ckanext/canada/strings.py:14
 #: ckanext/canada/view.py:1517
 msgid "Members not found"
 msgstr ""
 
-#: ckanext/canada/helpers.py:846
+#: ckanext/canada/helpers.py:851
 msgid "Data awaiting load to DataStore"
 msgstr ""
 
-#: ckanext/canada/helpers.py:847
+#: ckanext/canada/helpers.py:852
 msgid "Loading data into DataStore"
 msgstr ""
 
-#: ckanext/canada/helpers.py:848
+#: ckanext/canada/helpers.py:853
 msgid "Data loaded into DataStore"
 msgstr ""
 
-#: ckanext/canada/helpers.py:849
+#: ckanext/canada/helpers.py:854
 msgid "Failed to load data into DataStore"
 msgstr ""
 
-#: ckanext/canada/helpers.py:850
+#: ckanext/canada/helpers.py:855
 msgid "Data available in DataStore"
 msgstr ""
 
-#: ckanext/canada/helpers.py:851
+#: ckanext/canada/helpers.py:856
 msgid "Resource not active in DataStore"
 msgstr ""
 
-#: ckanext/canada/helpers.py:852
+#: ckanext/canada/helpers.py:857
 msgid "DataStore status unknown"
 msgstr ""
 
-#: ckanext/canada/helpers.py:931 ckanext/canada/templates/home/quick_links.html:65
+#: ckanext/canada/helpers.py:936 ckanext/canada/templates/home/quick_links.html:65
 #: ckanext/canada/templates/package/snippets/package_type_label.html:16
 #: ckanext/canada/templates/scheming/package/snippets/package_form.html:28
-#: ckanext/canada/templates/snippets/cdts/header.html:31
+#: ckanext/canada/templates/snippets/cdts/header.html:33
 #: ckanext/canada/templates/snippets/dataset_facets.html:3
 #: ckanext/canada/templates/snippets/dataset_facets.html:10
 msgid "Open Data"
 msgstr ""
 
-#: ckanext/canada/helpers.py:932 ckanext/canada/templates/home/quick_links.html:82
+#: ckanext/canada/helpers.py:937 ckanext/canada/templates/home/quick_links.html:82
 #: ckanext/canada/templates/package/snippets/package_type_label.html:22
 #: ckanext/canada/templates/scheming/package/snippets/package_form.html:30
-#: ckanext/canada/templates/snippets/cdts/header.html:56
+#: ckanext/canada/templates/snippets/cdts/header.html:57
 #: ckanext/canada/templates/snippets/dataset_facets.html:5
 #: ckanext/canada/templates/snippets/dataset_facets.html:11
 msgid "Open Information"
 msgstr ""
 
-#: ckanext/canada/helpers.py:944
+#: ckanext/canada/helpers.py:949
 #: ckanext/canada/templates/snippets/dataset_facets.html:27
 msgid "Request sent to data owner - awaiting response"
 msgstr ""
 
-#: ckanext/canada/helpers.py:948
+#: ckanext/canada/helpers.py:953
 #: ckanext/canada/templates/snippets/publish_facet.html:44
 msgid "Pending"
 msgstr ""
 
-#: ckanext/canada/helpers.py:949 ckanext/canada/templates/package/read.html:48
+#: ckanext/canada/helpers.py:954 ckanext/canada/templates/package/read.html:48
 #: ckanext/canada/templates/snippets/package_item.html:21
 #: ckanext/canada/templates/snippets/publish_facet.html:44
 msgid "Draft"
 msgstr ""
 
-#: ckanext/canada/helpers.py:966 ckanext/canada/templates/home/quick_links.html:152
+#: ckanext/canada/helpers.py:971 ckanext/canada/templates/home/quick_links.html:152
 #: ckanext/canada/templates/package/snippets/package_type_label.html:20
 #: ckanext/canada/templates/package/snippets/package_type_label.html:26
-#: ckanext/canada/templates/snippets/cdts/header.html:74
+#: ckanext/canada/templates/snippets/cdts/header.html:75
 #: ckanext/canada/templates/snippets/dataset_facets.html:33
 msgid "Proactive Publication"
 msgstr ""
 
-#: ckanext/canada/helpers.py:995
+#: ckanext/canada/helpers.py:1000
 #: ckanext/canada/templates/snippets/publish_facet.html:25
 msgid "Published"
 msgstr ""
 
-#: ckanext/canada/helpers.py:997
+#: ckanext/canada/helpers.py:1002
 #: ckanext/canada/templates/snippets/publish_facet.html:34
 msgid "Scheduled"
 msgstr ""
 
-#: ckanext/canada/helpers.py:1037
+#: ckanext/canada/helpers.py:1042
 msgid "Registry Home"
 msgstr ""
 
-#: ckanext/canada/helpers.py:1042
+#: ckanext/canada/helpers.py:1047
 msgid "Open Government"
 msgstr ""
 
-#: ckanext/canada/helpers.py:1045
+#: ckanext/canada/helpers.py:1050
 #: ckanext/canada/templates/admin/publish_search.html:19
 #: ckanext/canada/templates/home/quick_links.html:123
 #: ckanext/canada/templates/organization/snippets/organization_search.html:8
 #: ckanext/canada/templates/package/snippets/resources_list.html:36
-#: ckanext/canada/templates/snippets/cdts/header.html:167
+#: ckanext/canada/templates/snippets/cdts/header.html:174
 #: ckanext/canada/templates/snippets/search_form.html:45
 #: ckanext/canada/templates/user/snippets/user_search.html:11
 msgid "Search"
@@ -1052,7 +1052,7 @@ msgstr ""
 #: ckanext/canada/templates/package/edit.html:8
 #: ckanext/canada/templates/package/resource_edit.html:3
 #: ckanext/canada/templates/package/resource_edit_base.html:7
-#: ckanext/canada/templates/snippets/pd_datatable_depr.html:20
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:31
 #: ckanext/canada/view.py:1195
 msgid "Edit"
 msgstr ""
@@ -1103,253 +1103,259 @@ msgstr ""
 msgid "User %r not authorized to view members of %s"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:65
-#: ckanext/canada/templates/snippets/pd_datatable_depr.html:79
+#: ckanext/canada/assets/datatables/pd_datatables.js:68
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:90
 msgid "Select All"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:66
+#: ckanext/canada/assets/datatables/pd_datatables.js:69
 msgid "Search:"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:67
+#: ckanext/canada/assets/datatables/pd_datatables.js:70
 msgid "Sorting by:"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:68
+#: ckanext/canada/assets/datatables/pd_datatables.js:71
 msgid "Ascending"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:69
+#: ckanext/canada/assets/datatables/pd_datatables.js:72
 msgid "Descending"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:70
+#: ckanext/canada/assets/datatables/pd_datatables.js:73
 msgid "Any"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:71
+#: ckanext/canada/assets/datatables/pd_datatables.js:74
 msgid "less"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:72
+#: ckanext/canada/assets/datatables/pd_datatables.js:75
 msgid "Row"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:73
+#: ckanext/canada/assets/datatables/pd_datatables.js:76
 msgid "New"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:74
+#: ckanext/canada/assets/datatables/pd_datatables.js:77
 msgid "Updated"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:75
+#: ckanext/canada/assets/datatables/pd_datatables.js:78
 msgid "Jump to page"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:76
+#: ckanext/canada/assets/datatables/pd_datatables.js:79
 msgid "Reset Table"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:77
+#: ckanext/canada/assets/datatables/pd_datatables.js:80
 msgid "Fullscreen"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:78
+#: ckanext/canada/assets/datatables/pd_datatables.js:81
 msgid "Exit Fullscreen"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:79
+#: ckanext/canada/assets/datatables/pd_datatables.js:82
 msgid "Exit Edit Mode"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:80
+#: ckanext/canada/assets/datatables/pd_datatables.js:83
 msgid "Full Table"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:81
+#: ckanext/canada/assets/datatables/pd_datatables.js:84
 msgid "Compact Table"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:82
+#: ckanext/canada/assets/datatables/pd_datatables.js:85
 msgid "Edit Online"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:83
+#: ckanext/canada/assets/datatables/pd_datatables.js:86
 msgid "Add new record in Table"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:84
+#: ckanext/canada/assets/datatables/pd_datatables.js:87
 msgid "Edit<span class=\"pd-datatbales-btn-count\"></span> in Table"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:85
+#: ckanext/canada/assets/datatables/pd_datatables.js:88
 msgid "Record is valid"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:86
+#: ckanext/canada/assets/datatables/pd_datatables.js:89
 msgid "Some fields have validation errors"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:87
+#: ckanext/canada/assets/datatables/pd_datatables.js:90
 msgid "Some fields are required"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:88
+#: ckanext/canada/assets/datatables/pd_datatables.js:91
 msgid "Detailed error summary"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:89
+#: ckanext/canada/assets/datatables/pd_datatables.js:92
 msgid "Field errors"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:90
+#: ckanext/canada/assets/datatables/pd_datatables.js:93
 msgid ""
 "You have unsaved records in the table. Do you want to discard your changes or"
 " continue editing?"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:91
+#: ckanext/canada/assets/datatables/pd_datatables.js:94
 msgid "Validating records"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:92
+#: ckanext/canada/assets/datatables/pd_datatables.js:95
 msgid "Saving records to the system"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:94
+#: ckanext/canada/assets/datatables/pd_datatables.js:97
 msgid "Records saved to the system."
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:95
+#: ckanext/canada/assets/datatables/pd_datatables.js:98
 msgid "Would you like to add more records, or preview them in the table?"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:96
+#: ckanext/canada/assets/datatables/pd_datatables.js:99
 msgid "Add more records"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:97
+#: ckanext/canada/assets/datatables/pd_datatables.js:100
 msgid "Preview records"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:98
+#: ckanext/canada/assets/datatables/pd_datatables.js:101
 msgid ""
 "Your records did not save because one or more of them have errors. Fix the "
 "errors and save again to finalize your records."
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:99
+#: ckanext/canada/assets/datatables/pd_datatables.js:102
 msgid "Could not save the records due to the following error: "
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:100
+#: ckanext/canada/assets/datatables/pd_datatables.js:103
 msgid ""
 "Your records did not save. Try saving again. If the issue persist please "
 "contact support with Support ID: "
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:101
+#: ckanext/canada/assets/datatables/pd_datatables.js:104
 msgid ""
 "Your records did not save. Try saving again. If the issue persist please "
 "contact support."
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:102
+#: ckanext/canada/assets/datatables/pd_datatables.js:105
 msgid "{PRIM_IDS} already used in this Editor Table."
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:103
+#: ckanext/canada/assets/datatables/pd_datatables.js:106
 msgid " record(s)"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:104
+#: ckanext/canada/assets/datatables/pd_datatables.js:107
 msgid "Legend:"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:105
+#: ckanext/canada/assets/datatables/pd_datatables.js:108
 msgid "Valid"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:106
+#: ckanext/canada/assets/datatables/pd_datatables.js:109
 #: ckanext/canada/templates/error_document_template.html:18
 msgid "Error"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:107
+#: ckanext/canada/assets/datatables/pd_datatables.js:110
 msgid "Required"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:108
+#: ckanext/canada/assets/datatables/pd_datatables.js:111
 msgid "Error: Could not query records. Please try again."
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:109
+#: ckanext/canada/assets/datatables/pd_datatables.js:112
 msgid "Error: Could not generate Excel template. Please try again."
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:110
+#: ckanext/canada/assets/datatables/pd_datatables.js:113
 msgid "Edit<span class=\"pd-datatbales-btn-count\"></span> in Excel"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:111
+#: ckanext/canada/assets/datatables/pd_datatables.js:114
 msgid "Exporting{COUNT} record(s) to an Excel Template"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:112
+#: ckanext/canada/assets/datatables/pd_datatables.js:115
 msgid "Delete<span class=\"pd-datatbales-btn-count\"></span>"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:113
+#: ckanext/canada/assets/datatables/pd_datatables.js:116
 msgid "Save<span class=\"pd-datatbales-btn-count\"></span>"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:116
+#: ckanext/canada/assets/datatables/pd_datatables.js:119
 msgid "No data available in table"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:117
+#: ckanext/canada/assets/datatables/pd_datatables.js:120
 msgid "Showing _START_ to _END_ of _TOTAL_ entries"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:118
+#: ckanext/canada/assets/datatables/pd_datatables.js:121
 msgid "Showing 0 to 0 of 0 entries"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:119
+#: ckanext/canada/assets/datatables/pd_datatables.js:122
 msgid "(filtered from _MAX_ total entries)"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:122
+#: ckanext/canada/assets/datatables/pd_datatables.js:125
 msgid "_MENU_ Show number of entries"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:123
+#: ckanext/canada/assets/datatables/pd_datatables.js:126
 #: ckanext/canada/templates/package/snippets/data_api_button.html:2
 msgid "Loading..."
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:125
+#: ckanext/canada/assets/datatables/pd_datatables.js:128
 msgid "Full Text Search"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:126
+#: ckanext/canada/assets/datatables/pd_datatables.js:129
 msgid "No matching records found"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:134
+#: ckanext/canada/assets/datatables/pd_datatables.js:137
 msgid "Order by this column"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:135
+#: ckanext/canada/assets/datatables/pd_datatables.js:138
 msgid "Reverse order this column"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:439
-#: ckanext/canada/assets/datatables/pd_datatables.js:487
-#: ckanext/canada/assets/datatables/pd_datatables.js:503
+#: ckanext/canada/assets/datatables/pd_datatables.js:446
+#: ckanext/canada/assets/datatables/pd_datatables.js:494
+#: ckanext/canada/assets/datatables/pd_datatables.js:510
 msgid ": "
+msgstr ""
+
+#: ckanext/canada/assets/modules/user_opt_in.js:77
+#: ckanext/canada/assets/modules/user_opt_in.js:81
+#: ckanext/canada/assets/modules/user_opt_in.js:85
+msgid "Failed to change user settings"
 msgstr ""
 
 #: ckanext/canada/plugin/public_plugin.py:151
@@ -1407,17 +1413,17 @@ msgstr ""
 msgid "Suggestion Status"
 msgstr ""
 
-#: ckanext/canada/plugin/public_plugin.py:257
-#: ckanext/canada/plugin/public_plugin.py:264
+#: ckanext/canada/plugin/public_plugin.py:259
+#: ckanext/canada/plugin/public_plugin.py:266
 msgid "container_title"
 msgstr ""
 
-#: ckanext/canada/plugin/public_plugin.py:331
+#: ckanext/canada/plugin/public_plugin.py:333
 #: ckanext/canada/templates/package/read.html:194
 msgid "Previous"
 msgstr ""
 
-#: ckanext/canada/plugin/public_plugin.py:332
+#: ckanext/canada/plugin/public_plugin.py:334
 #: ckanext/canada/templates/package/read.html:210
 msgid "Next"
 msgstr ""
@@ -2495,7 +2501,7 @@ msgid "Load more"
 msgstr ""
 
 #: ckanext/canada/templates/admin/base.html:5
-#: ckanext/canada/templates/snippets/cdts/header.html:215
+#: ckanext/canada/templates/snippets/cdts/header.html:222
 msgid "Admin"
 msgstr ""
 
@@ -2700,7 +2706,7 @@ msgstr ""
 
 #: ckanext/canada/templates/home/quick_links.html:71
 #: ckanext/canada/templates/package/new.html:7
-#: ckanext/canada/templates/snippets/cdts/header.html:36
+#: ckanext/canada/templates/snippets/cdts/header.html:38
 msgid "Create an Open Data Record"
 msgstr ""
 
@@ -2719,7 +2725,7 @@ msgid "Add information about government programs, activities and publications."
 msgstr ""
 
 #: ckanext/canada/templates/home/quick_links.html:96
-#: ckanext/canada/templates/snippets/cdts/header.html:65
+#: ckanext/canada/templates/snippets/cdts/header.html:66
 msgid "Algorithmic Impact Assessment"
 msgstr ""
 
@@ -2728,7 +2734,7 @@ msgid "Access, add or modify Algorithmic Impact Assessment."
 msgstr ""
 
 #: ckanext/canada/templates/home/quick_links.html:104
-#: ckanext/canada/templates/snippets/cdts/header.html:69
+#: ckanext/canada/templates/snippets/cdts/header.html:70
 msgid "Institutional Accessibility plans"
 msgstr ""
 
@@ -2738,13 +2744,13 @@ msgstr ""
 
 #: ckanext/canada/templates/home/quick_links.html:110
 #: ckanext/canada/templates/package/snippets/package_type_label.html:24
-#: ckanext/canada/templates/snippets/cdts/header.html:152
+#: ckanext/canada/templates/snippets/cdts/header.html:159
 #: ckanext/canada/templates/snippets/dataset_facets.html:4
 msgid "Open Dialogue"
 msgstr ""
 
 #: ckanext/canada/templates/home/quick_links.html:117
-#: ckanext/canada/templates/snippets/cdts/header.html:161
+#: ckanext/canada/templates/snippets/cdts/header.html:168
 msgid "Consultations master dataset"
 msgstr ""
 
@@ -2779,7 +2785,7 @@ msgid "View the list of members linked to your organization."
 msgstr ""
 
 #: ckanext/canada/templates/home/quick_links.html:170
-#: ckanext/canada/templates/snippets/cdts/header.html:123
+#: ckanext/canada/templates/snippets/cdts/header.html:124
 msgid "Reports Tabled in Parliament"
 msgstr ""
 
@@ -2792,7 +2798,7 @@ msgid "Briefing packages"
 msgstr ""
 
 #: ckanext/canada/templates/home/quick_links.html:185
-#: ckanext/canada/templates/snippets/cdts/header.html:135
+#: ckanext/canada/templates/snippets/cdts/header.html:136
 msgid "New or incoming ministers"
 msgstr ""
 
@@ -2803,7 +2809,7 @@ msgid ""
 msgstr ""
 
 #: ckanext/canada/templates/home/quick_links.html:193
-#: ckanext/canada/templates/snippets/cdts/header.html:139
+#: ckanext/canada/templates/snippets/cdts/header.html:140
 msgid "New or incoming deputy heads"
 msgstr ""
 
@@ -2814,7 +2820,7 @@ msgid ""
 msgstr ""
 
 #: ckanext/canada/templates/home/quick_links.html:201
-#: ckanext/canada/templates/snippets/cdts/header.html:143
+#: ckanext/canada/templates/snippets/cdts/header.html:144
 msgid "Parliamentary Committee appearances for ministers"
 msgstr ""
 
@@ -2825,7 +2831,7 @@ msgid ""
 msgstr ""
 
 #: ckanext/canada/templates/home/quick_links.html:209
-#: ckanext/canada/templates/snippets/cdts/header.html:147
+#: ckanext/canada/templates/snippets/cdts/header.html:148
 msgid "Parliamentary Committee appearances for deputy heads"
 msgstr ""
 
@@ -2877,7 +2883,7 @@ msgstr ""
 #: ckanext/canada/templates/organization/index.html:26
 #: ckanext/canada/templates/organization/members.html:10
 #: ckanext/canada/templates/organization/read_base.html:7
-#: ckanext/canada/templates/snippets/cdts/header.html:171
+#: ckanext/canada/templates/snippets/cdts/header.html:178
 #: ckanext/canada/templates/user/read.html:28
 #: ckanext/canada/templates/user/read_base.html:17
 #: ckanext/canada/templates/user/read_base.html:76
@@ -3478,7 +3484,7 @@ msgid "Explore"
 msgstr ""
 
 #: ckanext/canada/templates/package/snippets/resource_item.html:79
-#: ckanext/canada/templates/snippets/pd_datatable_depr.html:14
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:17
 msgid "Preview"
 msgstr ""
 
@@ -4004,49 +4010,76 @@ msgstr ""
 msgid "Resource Formats:"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable.html:46
-msgid "Interactive Table"
+#: ckanext/canada/templates/snippets/pd_datatable.html:45
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:13
+msgid "feedback"
 msgstr ""
 
 #: ckanext/canada/templates/snippets/pd_datatable.html:49
+msgid "Interactive Table"
+msgstr ""
+
+#: ckanext/canada/templates/snippets/pd_datatable.html:57
+#, python-format
+msgid ""
+"The new table interface will become the default experience. Try the updated "
+"interface and share your %(feedback)s to help shape future improvements."
+msgstr ""
+
+#: ckanext/canada/templates/snippets/pd_datatable.html:58
+msgid "Revert to older table interface"
+msgstr ""
+
+#: ckanext/canada/templates/snippets/pd_datatable.html:61
 msgid "Keyboard controls"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable.html:51
+#: ckanext/canada/templates/snippets/pd_datatable.html:63
 msgid ""
 "Hold <pre>SHIFT</pre> key while clicking on sort controls for multi-column "
 "sorting"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable.html:52
+#: ckanext/canada/templates/snippets/pd_datatable.html:64
 msgid ""
 "Press <pre>ALT + K</pre> keys to enter KeyTable mode, allowing you to "
 "navigate the table with arrow keys"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable.html:54
+#: ckanext/canada/templates/snippets/pd_datatable.html:66
 msgid "Press <pre>SPACE</pre> key to select a row"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable.html:55
+#: ckanext/canada/templates/snippets/pd_datatable.html:67
 msgid "Press <pre>E</pre> key to expand a row (Compact Table mode only)"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable.html:56
+#: ckanext/canada/templates/snippets/pd_datatable.html:68
 msgid "Press <pre>ESC</pre> key to exit KeyTable mode"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable.html:65
-#: ckanext/canada/templates/snippets/pd_datatable.html:76
-#: ckanext/canada/templates/snippets/pd_datatable_depr.html:18
+#: ckanext/canada/templates/snippets/pd_datatable.html:77
+#: ckanext/canada/templates/snippets/pd_datatable.html:88
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:29
 msgid "Select"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable_depr.html:173
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:24
+#, python-format
+msgid ""
+"A new table experience is now available! Try the updated interface and share "
+"your %(feedback)s to help shape future improvements."
+msgstr ""
+
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:25
+msgid "Enable new table interface"
+msgstr ""
+
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:184
 msgid "Edit in Excel"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable_depr.html:207
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:218
 msgid "Delete records"
 msgstr ""
 
@@ -4105,34 +4138,34 @@ msgid ""
 " activity."
 msgstr ""
 
-#: ckanext/canada/templates/snippets/cdts/header.html:21
-#: ckanext/canada/templates/snippets/cdts/header.html:26
+#: ckanext/canada/templates/snippets/cdts/header.html:23
+#: ckanext/canada/templates/snippets/cdts/header.html:28
 msgid "Home"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/cdts/header.html:61
+#: ckanext/canada/templates/snippets/cdts/header.html:62
 msgid "Create an Open Information Record"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/cdts/header.html:176
+#: ckanext/canada/templates/snippets/cdts/header.html:183
 msgid "FAQ"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/cdts/header.html:207
+#: ckanext/canada/templates/snippets/cdts/header.html:214
 #: ckanext/canada/templates/user/dashboard.html:9
 #: ckanext/canada/templates/user/dashboard_datasets.html:19
 msgid "Dashboard"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/cdts/header.html:223
+#: ckanext/canada/templates/snippets/cdts/header.html:230
 msgid "Get Help"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/cdts/header.html:244
+#: ckanext/canada/templates/snippets/cdts/header.html:251
 msgid "Signed in as"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/cdts/header.html:244
+#: ckanext/canada/templates/snippets/cdts/header.html:251
 msgid "View profile"
 msgstr ""
 

--- a/ckanext/canada/i18n/ckanext-canada.pot
+++ b/ckanext/canada/i18n/ckanext-canada.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-canada 0.4.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-09 13:09-0400\n"
+"POT-Creation-Date: 2026-07-10 10:24-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3484,7 +3484,7 @@ msgid "Explore"
 msgstr ""
 
 #: ckanext/canada/templates/package/snippets/resource_item.html:79
-#: ckanext/canada/templates/snippets/pd_datatable_depr.html:17
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:14
 msgid "Preview"
 msgstr ""
 
@@ -4010,20 +4010,16 @@ msgstr ""
 msgid "Resource Formats:"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable.html:45
-#: ckanext/canada/templates/snippets/pd_datatable_depr.html:13
-msgid "feedback"
-msgstr ""
-
-#: ckanext/canada/templates/snippets/pd_datatable.html:49
+#: ckanext/canada/templates/snippets/pd_datatable.html:46
 msgid "Interactive Table"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable.html:57
+#: ckanext/canada/templates/snippets/pd_datatable.html:54
 #, python-format
 msgid ""
 "The new table interface will become the default experience. Try the updated "
-"interface and share your %(feedback)s to help shape future improvements."
+"interface and share your <a href='mailto:%(email)s'>feedback</a> to help "
+"shape future improvements."
 msgstr ""
 
 #: ckanext/canada/templates/snippets/pd_datatable.html:58
@@ -4064,11 +4060,12 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable_depr.html:24
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:21
 #, python-format
 msgid ""
 "A new table experience is now available! Try the updated interface and share "
-"your %(feedback)s to help shape future improvements."
+"your <a href='mailto:%(email)s'>feedback</a> to help shape future "
+"improvements."
 msgstr ""
 
 #: ckanext/canada/templates/snippets/pd_datatable_depr.html:25

--- a/ckanext/canada/i18n/ckanext-canada.pot
+++ b/ckanext/canada/i18n/ckanext-canada.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-canada 0.4.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-10 10:24-0400\n"
+"POT-Creation-Date: 2026-07-10 14:12-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -238,24 +238,24 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: ckanext/canada/logic.py:364
+#: ckanext/canada/logic.py:365
 msgid "Could not determine a resource format. Please supply a format."
 msgstr ""
 
-#: ckanext/canada/logic.py:554
+#: ckanext/canada/logic.py:555
 msgid "Unknown Job"
 msgstr ""
 
-#: ckanext/canada/logic.py:561
+#: ckanext/canada/logic.py:562
 msgid "Entire Site"
 msgstr ""
 
-#: ckanext/canada/logic.py:674
+#: ckanext/canada/logic.py:675
 #, python-format
 msgid "No Portal Sync information found for package %s"
 msgstr ""
 
-#: ckanext/canada/logic.py:763
+#: ckanext/canada/logic.py:764
 msgid ""
 "Invalid request. Full text search is not supported for data with more than {}"
 " rows."
@@ -1352,9 +1352,9 @@ msgstr ""
 msgid ": "
 msgstr ""
 
-#: ckanext/canada/assets/modules/user_opt_in.js:77
-#: ckanext/canada/assets/modules/user_opt_in.js:81
-#: ckanext/canada/assets/modules/user_opt_in.js:85
+#: ckanext/canada/assets/modules/user_opt_in.js:74
+#: ckanext/canada/assets/modules/user_opt_in.js:78
+#: ckanext/canada/assets/modules/user_opt_in.js:82
 msgid "Failed to change user settings"
 msgstr ""
 
@@ -4011,7 +4011,7 @@ msgid "Resource Formats:"
 msgstr ""
 
 #: ckanext/canada/templates/snippets/pd_datatable.html:46
-msgid "Interactive Table"
+msgid "Interactive Table (beta version)"
 msgstr ""
 
 #: ckanext/canada/templates/snippets/pd_datatable.html:54

--- a/ckanext/canada/i18n/en/LC_MESSAGES/ckanext-canada.po
+++ b/ckanext/canada/i18n/en/LC_MESSAGES/ckanext-canada.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  CKAN\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-17 12:48-0400\n"
+"POT-Creation-Date: 2026-07-09 13:09-0400\n"
 "PO-Revision-Date: 2014-01-23 13:04+0000\n"
 "Last-Translator: Sean Hammond <sean.hammond@okfn.org>\n"
 "Language: en\n"
@@ -137,108 +137,108 @@ msgstr ""
 msgid "Treasury Board of Canada Secretariat"
 msgstr ""
 
-#: ckanext/canada/helpers.py:711 ckanext/canada/strings.py:14
+#: ckanext/canada/helpers.py:716 ckanext/canada/strings.py:14
 #: ckanext/canada/view.py:1517
 msgid "Members not found"
 msgstr ""
 
-#: ckanext/canada/helpers.py:846
+#: ckanext/canada/helpers.py:851
 msgid "Data awaiting load to DataStore"
 msgstr ""
 
-#: ckanext/canada/helpers.py:847
+#: ckanext/canada/helpers.py:852
 msgid "Loading data into DataStore"
 msgstr ""
 
-#: ckanext/canada/helpers.py:848
+#: ckanext/canada/helpers.py:853
 msgid "Data loaded into DataStore"
 msgstr ""
 
-#: ckanext/canada/helpers.py:849
+#: ckanext/canada/helpers.py:854
 msgid "Failed to load data into DataStore"
 msgstr ""
 
-#: ckanext/canada/helpers.py:850
+#: ckanext/canada/helpers.py:855
 msgid "Data available in DataStore"
 msgstr ""
 
-#: ckanext/canada/helpers.py:851
+#: ckanext/canada/helpers.py:856
 msgid "Resource not active in DataStore"
 msgstr ""
 
-#: ckanext/canada/helpers.py:852
+#: ckanext/canada/helpers.py:857
 msgid "DataStore status unknown"
 msgstr ""
 
-#: ckanext/canada/helpers.py:931
+#: ckanext/canada/helpers.py:936
 #: ckanext/canada/templates/home/quick_links.html:65
 #: ckanext/canada/templates/package/snippets/package_type_label.html:16
 #: ckanext/canada/templates/scheming/package/snippets/package_form.html:28
-#: ckanext/canada/templates/snippets/cdts/header.html:31
+#: ckanext/canada/templates/snippets/cdts/header.html:33
 #: ckanext/canada/templates/snippets/dataset_facets.html:3
 #: ckanext/canada/templates/snippets/dataset_facets.html:10
 msgid "Open Data"
 msgstr ""
 
-#: ckanext/canada/helpers.py:932
+#: ckanext/canada/helpers.py:937
 #: ckanext/canada/templates/home/quick_links.html:82
 #: ckanext/canada/templates/package/snippets/package_type_label.html:22
 #: ckanext/canada/templates/scheming/package/snippets/package_form.html:30
-#: ckanext/canada/templates/snippets/cdts/header.html:56
+#: ckanext/canada/templates/snippets/cdts/header.html:57
 #: ckanext/canada/templates/snippets/dataset_facets.html:5
 #: ckanext/canada/templates/snippets/dataset_facets.html:11
 msgid "Open Information"
 msgstr ""
 
-#: ckanext/canada/helpers.py:944
+#: ckanext/canada/helpers.py:949
 #: ckanext/canada/templates/snippets/dataset_facets.html:27
 msgid "Request sent to data owner - awaiting response"
 msgstr ""
 
-#: ckanext/canada/helpers.py:948
+#: ckanext/canada/helpers.py:953
 #: ckanext/canada/templates/snippets/publish_facet.html:44
 msgid "Pending"
 msgstr ""
 
-#: ckanext/canada/helpers.py:949 ckanext/canada/templates/package/read.html:48
+#: ckanext/canada/helpers.py:954 ckanext/canada/templates/package/read.html:48
 #: ckanext/canada/templates/snippets/package_item.html:21
 #: ckanext/canada/templates/snippets/publish_facet.html:44
 msgid "Draft"
 msgstr ""
 
-#: ckanext/canada/helpers.py:966
+#: ckanext/canada/helpers.py:971
 #: ckanext/canada/templates/home/quick_links.html:152
 #: ckanext/canada/templates/package/snippets/package_type_label.html:20
 #: ckanext/canada/templates/package/snippets/package_type_label.html:26
-#: ckanext/canada/templates/snippets/cdts/header.html:74
+#: ckanext/canada/templates/snippets/cdts/header.html:75
 #: ckanext/canada/templates/snippets/dataset_facets.html:33
 msgid "Proactive Publication"
 msgstr ""
 
-#: ckanext/canada/helpers.py:995
+#: ckanext/canada/helpers.py:1000
 #: ckanext/canada/templates/snippets/publish_facet.html:25
 msgid "Published"
 msgstr ""
 
-#: ckanext/canada/helpers.py:997
+#: ckanext/canada/helpers.py:1002
 #: ckanext/canada/templates/snippets/publish_facet.html:34
 msgid "Scheduled"
 msgstr ""
 
-#: ckanext/canada/helpers.py:1037
+#: ckanext/canada/helpers.py:1042
 msgid "Registry Home"
 msgstr ""
 
-#: ckanext/canada/helpers.py:1042
+#: ckanext/canada/helpers.py:1047
 msgid "Open Government"
 msgstr ""
 
-#: ckanext/canada/helpers.py:1045
+#: ckanext/canada/helpers.py:1050
 #: ckanext/canada/templates/admin/publish_search.html:19
 #: ckanext/canada/templates/home/quick_links.html:123
 #: ckanext/canada/templates/organization/snippets/organization_search.html:8
 #: ckanext/canada/templates/package/snippets/resources_list.html:36
-#: ckanext/canada/templates/snippets/cdts/header.html:167
+#: ckanext/canada/templates/snippets/cdts/header.html:174
 #: ckanext/canada/templates/snippets/search_form.html:45
 #: ckanext/canada/templates/user/snippets/user_search.html:11
 msgid "Search"
@@ -1064,7 +1064,7 @@ msgstr ""
 #: ckanext/canada/templates/package/edit.html:8
 #: ckanext/canada/templates/package/resource_edit.html:3
 #: ckanext/canada/templates/package/resource_edit_base.html:7
-#: ckanext/canada/templates/snippets/pd_datatable_depr.html:20
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:31
 #: ckanext/canada/view.py:1195
 msgid "Edit"
 msgstr ""
@@ -1115,253 +1115,259 @@ msgstr ""
 msgid "User %r not authorized to view members of %s"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:65
-#: ckanext/canada/templates/snippets/pd_datatable_depr.html:79
+#: ckanext/canada/assets/datatables/pd_datatables.js:68
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:90
 msgid "Select All"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:66
+#: ckanext/canada/assets/datatables/pd_datatables.js:69
 msgid "Search:"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:67
+#: ckanext/canada/assets/datatables/pd_datatables.js:70
 msgid "Sorting by:"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:68
+#: ckanext/canada/assets/datatables/pd_datatables.js:71
 msgid "Ascending"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:69
+#: ckanext/canada/assets/datatables/pd_datatables.js:72
 msgid "Descending"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:70
+#: ckanext/canada/assets/datatables/pd_datatables.js:73
 msgid "Any"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:71
+#: ckanext/canada/assets/datatables/pd_datatables.js:74
 msgid "less"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:72
+#: ckanext/canada/assets/datatables/pd_datatables.js:75
 msgid "Row"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:73
+#: ckanext/canada/assets/datatables/pd_datatables.js:76
 msgid "New"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:74
+#: ckanext/canada/assets/datatables/pd_datatables.js:77
 msgid "Updated"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:75
+#: ckanext/canada/assets/datatables/pd_datatables.js:78
 msgid "Jump to page"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:76
+#: ckanext/canada/assets/datatables/pd_datatables.js:79
 msgid "Reset Table"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:77
+#: ckanext/canada/assets/datatables/pd_datatables.js:80
 msgid "Fullscreen"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:78
+#: ckanext/canada/assets/datatables/pd_datatables.js:81
 msgid "Exit Fullscreen"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:79
+#: ckanext/canada/assets/datatables/pd_datatables.js:82
 msgid "Exit Edit Mode"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:80
+#: ckanext/canada/assets/datatables/pd_datatables.js:83
 msgid "Full Table"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:81
+#: ckanext/canada/assets/datatables/pd_datatables.js:84
 msgid "Compact Table"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:82
+#: ckanext/canada/assets/datatables/pd_datatables.js:85
 msgid "Edit Online"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:83
+#: ckanext/canada/assets/datatables/pd_datatables.js:86
 msgid "Add new record in Table"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:84
+#: ckanext/canada/assets/datatables/pd_datatables.js:87
 msgid "Edit<span class=\"pd-datatbales-btn-count\"></span> in Table"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:85
+#: ckanext/canada/assets/datatables/pd_datatables.js:88
 msgid "Record is valid"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:86
+#: ckanext/canada/assets/datatables/pd_datatables.js:89
 msgid "Some fields have validation errors"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:87
+#: ckanext/canada/assets/datatables/pd_datatables.js:90
 msgid "Some fields are required"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:88
+#: ckanext/canada/assets/datatables/pd_datatables.js:91
 msgid "Detailed error summary"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:89
+#: ckanext/canada/assets/datatables/pd_datatables.js:92
 msgid "Field errors"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:90
+#: ckanext/canada/assets/datatables/pd_datatables.js:93
 msgid ""
 "You have unsaved records in the table. Do you want to discard your "
 "changes or continue editing?"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:91
+#: ckanext/canada/assets/datatables/pd_datatables.js:94
 msgid "Validating records"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:92
+#: ckanext/canada/assets/datatables/pd_datatables.js:95
 msgid "Saving records to the system"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:94
+#: ckanext/canada/assets/datatables/pd_datatables.js:97
 msgid "Records saved to the system."
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:95
+#: ckanext/canada/assets/datatables/pd_datatables.js:98
 msgid "Would you like to add more records, or preview them in the table?"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:96
+#: ckanext/canada/assets/datatables/pd_datatables.js:99
 msgid "Add more records"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:97
+#: ckanext/canada/assets/datatables/pd_datatables.js:100
 msgid "Preview records"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:98
+#: ckanext/canada/assets/datatables/pd_datatables.js:101
 msgid ""
 "Your records did not save because one or more of them have errors. Fix "
 "the errors and save again to finalize your records."
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:99
+#: ckanext/canada/assets/datatables/pd_datatables.js:102
 msgid "Could not save the records due to the following error: "
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:100
+#: ckanext/canada/assets/datatables/pd_datatables.js:103
 msgid ""
 "Your records did not save. Try saving again. If the issue persist please "
 "contact support with Support ID: "
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:101
+#: ckanext/canada/assets/datatables/pd_datatables.js:104
 msgid ""
 "Your records did not save. Try saving again. If the issue persist please "
 "contact support."
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:102
+#: ckanext/canada/assets/datatables/pd_datatables.js:105
 msgid "{PRIM_IDS} already used in this Editor Table."
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:103
+#: ckanext/canada/assets/datatables/pd_datatables.js:106
 msgid " record(s)"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:104
+#: ckanext/canada/assets/datatables/pd_datatables.js:107
 msgid "Legend:"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:105
+#: ckanext/canada/assets/datatables/pd_datatables.js:108
 msgid "Valid"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:106
+#: ckanext/canada/assets/datatables/pd_datatables.js:109
 #: ckanext/canada/templates/error_document_template.html:18
 msgid "Error"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:107
+#: ckanext/canada/assets/datatables/pd_datatables.js:110
 msgid "Required"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:108
+#: ckanext/canada/assets/datatables/pd_datatables.js:111
 msgid "Error: Could not query records. Please try again."
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:109
+#: ckanext/canada/assets/datatables/pd_datatables.js:112
 msgid "Error: Could not generate Excel template. Please try again."
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:110
+#: ckanext/canada/assets/datatables/pd_datatables.js:113
 msgid "Edit<span class=\"pd-datatbales-btn-count\"></span> in Excel"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:111
+#: ckanext/canada/assets/datatables/pd_datatables.js:114
 msgid "Exporting{COUNT} record(s) to an Excel Template"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:112
+#: ckanext/canada/assets/datatables/pd_datatables.js:115
 msgid "Delete<span class=\"pd-datatbales-btn-count\"></span>"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:113
+#: ckanext/canada/assets/datatables/pd_datatables.js:116
 msgid "Save<span class=\"pd-datatbales-btn-count\"></span>"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:116
+#: ckanext/canada/assets/datatables/pd_datatables.js:119
 msgid "No data available in table"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:117
+#: ckanext/canada/assets/datatables/pd_datatables.js:120
 msgid "Showing _START_ to _END_ of _TOTAL_ entries"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:118
+#: ckanext/canada/assets/datatables/pd_datatables.js:121
 msgid "Showing 0 to 0 of 0 entries"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:119
+#: ckanext/canada/assets/datatables/pd_datatables.js:122
 msgid "(filtered from _MAX_ total entries)"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:122
+#: ckanext/canada/assets/datatables/pd_datatables.js:125
 msgid "_MENU_ Show number of entries"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:123
+#: ckanext/canada/assets/datatables/pd_datatables.js:126
 #: ckanext/canada/templates/package/snippets/data_api_button.html:2
 msgid "Loading..."
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:125
+#: ckanext/canada/assets/datatables/pd_datatables.js:128
 msgid "Full Text Search"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:126
+#: ckanext/canada/assets/datatables/pd_datatables.js:129
 msgid "No matching records found"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:134
+#: ckanext/canada/assets/datatables/pd_datatables.js:137
 msgid "Order by this column"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:135
+#: ckanext/canada/assets/datatables/pd_datatables.js:138
 msgid "Reverse order this column"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:439
-#: ckanext/canada/assets/datatables/pd_datatables.js:487
-#: ckanext/canada/assets/datatables/pd_datatables.js:503
+#: ckanext/canada/assets/datatables/pd_datatables.js:446
+#: ckanext/canada/assets/datatables/pd_datatables.js:494
+#: ckanext/canada/assets/datatables/pd_datatables.js:510
 msgid ": "
+msgstr ""
+
+#: ckanext/canada/assets/modules/user_opt_in.js:77
+#: ckanext/canada/assets/modules/user_opt_in.js:81
+#: ckanext/canada/assets/modules/user_opt_in.js:85
+msgid "Failed to change user settings"
 msgstr ""
 
 #: ckanext/canada/plugin/public_plugin.py:151
@@ -1419,17 +1425,17 @@ msgstr ""
 msgid "Suggestion Status"
 msgstr ""
 
-#: ckanext/canada/plugin/public_plugin.py:257
-#: ckanext/canada/plugin/public_plugin.py:264
+#: ckanext/canada/plugin/public_plugin.py:259
+#: ckanext/canada/plugin/public_plugin.py:266
 msgid "container_title"
 msgstr ""
 
-#: ckanext/canada/plugin/public_plugin.py:331
+#: ckanext/canada/plugin/public_plugin.py:333
 #: ckanext/canada/templates/package/read.html:194
 msgid "Previous"
 msgstr ""
 
-#: ckanext/canada/plugin/public_plugin.py:332
+#: ckanext/canada/plugin/public_plugin.py:334
 #: ckanext/canada/templates/package/read.html:210
 msgid "Next"
 msgstr ""
@@ -2536,7 +2542,7 @@ msgid "Load more"
 msgstr ""
 
 #: ckanext/canada/templates/admin/base.html:5
-#: ckanext/canada/templates/snippets/cdts/header.html:215
+#: ckanext/canada/templates/snippets/cdts/header.html:222
 msgid "Admin"
 msgstr ""
 
@@ -2746,7 +2752,7 @@ msgstr ""
 
 #: ckanext/canada/templates/home/quick_links.html:71
 #: ckanext/canada/templates/package/new.html:7
-#: ckanext/canada/templates/snippets/cdts/header.html:36
+#: ckanext/canada/templates/snippets/cdts/header.html:38
 msgid "Create an Open Data Record"
 msgstr ""
 
@@ -2765,7 +2771,7 @@ msgid "Add information about government programs, activities and publications."
 msgstr ""
 
 #: ckanext/canada/templates/home/quick_links.html:96
-#: ckanext/canada/templates/snippets/cdts/header.html:65
+#: ckanext/canada/templates/snippets/cdts/header.html:66
 msgid "Algorithmic Impact Assessment"
 msgstr ""
 
@@ -2774,7 +2780,7 @@ msgid "Access, add or modify Algorithmic Impact Assessment."
 msgstr ""
 
 #: ckanext/canada/templates/home/quick_links.html:104
-#: ckanext/canada/templates/snippets/cdts/header.html:69
+#: ckanext/canada/templates/snippets/cdts/header.html:70
 msgid "Institutional Accessibility plans"
 msgstr ""
 
@@ -2784,13 +2790,13 @@ msgstr ""
 
 #: ckanext/canada/templates/home/quick_links.html:110
 #: ckanext/canada/templates/package/snippets/package_type_label.html:24
-#: ckanext/canada/templates/snippets/cdts/header.html:152
+#: ckanext/canada/templates/snippets/cdts/header.html:159
 #: ckanext/canada/templates/snippets/dataset_facets.html:4
 msgid "Open Dialogue"
 msgstr ""
 
 #: ckanext/canada/templates/home/quick_links.html:117
-#: ckanext/canada/templates/snippets/cdts/header.html:161
+#: ckanext/canada/templates/snippets/cdts/header.html:168
 msgid "Consultations master dataset"
 msgstr ""
 
@@ -2825,7 +2831,7 @@ msgid "View the list of members linked to your organization."
 msgstr ""
 
 #: ckanext/canada/templates/home/quick_links.html:170
-#: ckanext/canada/templates/snippets/cdts/header.html:123
+#: ckanext/canada/templates/snippets/cdts/header.html:124
 msgid "Reports Tabled in Parliament"
 msgstr ""
 
@@ -2838,7 +2844,7 @@ msgid "Briefing packages"
 msgstr ""
 
 #: ckanext/canada/templates/home/quick_links.html:185
-#: ckanext/canada/templates/snippets/cdts/header.html:135
+#: ckanext/canada/templates/snippets/cdts/header.html:136
 msgid "New or incoming ministers"
 msgstr ""
 
@@ -2849,7 +2855,7 @@ msgid ""
 msgstr ""
 
 #: ckanext/canada/templates/home/quick_links.html:193
-#: ckanext/canada/templates/snippets/cdts/header.html:139
+#: ckanext/canada/templates/snippets/cdts/header.html:140
 msgid "New or incoming deputy heads"
 msgstr ""
 
@@ -2860,7 +2866,7 @@ msgid ""
 msgstr ""
 
 #: ckanext/canada/templates/home/quick_links.html:201
-#: ckanext/canada/templates/snippets/cdts/header.html:143
+#: ckanext/canada/templates/snippets/cdts/header.html:144
 msgid "Parliamentary Committee appearances for ministers"
 msgstr ""
 
@@ -2871,7 +2877,7 @@ msgid ""
 msgstr ""
 
 #: ckanext/canada/templates/home/quick_links.html:209
-#: ckanext/canada/templates/snippets/cdts/header.html:147
+#: ckanext/canada/templates/snippets/cdts/header.html:148
 msgid "Parliamentary Committee appearances for deputy heads"
 msgstr ""
 
@@ -2923,7 +2929,7 @@ msgstr ""
 #: ckanext/canada/templates/organization/index.html:26
 #: ckanext/canada/templates/organization/members.html:10
 #: ckanext/canada/templates/organization/read_base.html:7
-#: ckanext/canada/templates/snippets/cdts/header.html:171
+#: ckanext/canada/templates/snippets/cdts/header.html:178
 #: ckanext/canada/templates/user/read.html:28
 #: ckanext/canada/templates/user/read_base.html:17
 #: ckanext/canada/templates/user/read_base.html:76
@@ -3536,7 +3542,7 @@ msgid "Explore"
 msgstr ""
 
 #: ckanext/canada/templates/package/snippets/resource_item.html:79
-#: ckanext/canada/templates/snippets/pd_datatable_depr.html:14
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:17
 msgid "Preview"
 msgstr ""
 
@@ -4070,49 +4076,77 @@ msgstr ""
 msgid "Resource Formats:"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable.html:46
-msgid "Interactive Table"
+#: ckanext/canada/templates/snippets/pd_datatable.html:45
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:13
+msgid "feedback"
 msgstr ""
 
 #: ckanext/canada/templates/snippets/pd_datatable.html:49
+msgid "Interactive Table"
+msgstr ""
+
+#: ckanext/canada/templates/snippets/pd_datatable.html:57
+#, python-format
+msgid ""
+"The new table interface will become the default experience. Try the "
+"updated interface and share your %(feedback)s to help shape future "
+"improvements."
+msgstr ""
+
+#: ckanext/canada/templates/snippets/pd_datatable.html:58
+msgid "Revert to older table interface"
+msgstr ""
+
+#: ckanext/canada/templates/snippets/pd_datatable.html:61
 msgid "Keyboard controls"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable.html:51
+#: ckanext/canada/templates/snippets/pd_datatable.html:63
 msgid ""
 "Hold <pre>SHIFT</pre> key while clicking on sort controls for multi-"
 "column sorting"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable.html:52
+#: ckanext/canada/templates/snippets/pd_datatable.html:64
 msgid ""
 "Press <pre>ALT + K</pre> keys to enter KeyTable mode, allowing you to "
 "navigate the table with arrow keys"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable.html:54
+#: ckanext/canada/templates/snippets/pd_datatable.html:66
 msgid "Press <pre>SPACE</pre> key to select a row"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable.html:55
+#: ckanext/canada/templates/snippets/pd_datatable.html:67
 msgid "Press <pre>E</pre> key to expand a row (Compact Table mode only)"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable.html:56
+#: ckanext/canada/templates/snippets/pd_datatable.html:68
 msgid "Press <pre>ESC</pre> key to exit KeyTable mode"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable.html:65
-#: ckanext/canada/templates/snippets/pd_datatable.html:76
-#: ckanext/canada/templates/snippets/pd_datatable_depr.html:18
+#: ckanext/canada/templates/snippets/pd_datatable.html:77
+#: ckanext/canada/templates/snippets/pd_datatable.html:88
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:29
 msgid "Select"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable_depr.html:173
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:24
+#, python-format
+msgid ""
+"A new table experience is now available! Try the updated interface and "
+"share your %(feedback)s to help shape future improvements."
+msgstr ""
+
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:25
+msgid "Enable new table interface"
+msgstr ""
+
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:184
 msgid "Edit in Excel"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable_depr.html:207
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:218
 msgid "Delete records"
 msgstr ""
 
@@ -4171,34 +4205,34 @@ msgid ""
 "DataStore activity."
 msgstr ""
 
-#: ckanext/canada/templates/snippets/cdts/header.html:21
-#: ckanext/canada/templates/snippets/cdts/header.html:26
+#: ckanext/canada/templates/snippets/cdts/header.html:23
+#: ckanext/canada/templates/snippets/cdts/header.html:28
 msgid "Home"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/cdts/header.html:61
+#: ckanext/canada/templates/snippets/cdts/header.html:62
 msgid "Create an Open Information Record"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/cdts/header.html:176
+#: ckanext/canada/templates/snippets/cdts/header.html:183
 msgid "FAQ"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/cdts/header.html:207
+#: ckanext/canada/templates/snippets/cdts/header.html:214
 #: ckanext/canada/templates/user/dashboard.html:9
 #: ckanext/canada/templates/user/dashboard_datasets.html:19
 msgid "Dashboard"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/cdts/header.html:223
+#: ckanext/canada/templates/snippets/cdts/header.html:230
 msgid "Get Help"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/cdts/header.html:244
+#: ckanext/canada/templates/snippets/cdts/header.html:251
 msgid "Signed in as"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/cdts/header.html:244
+#: ckanext/canada/templates/snippets/cdts/header.html:251
 msgid "View profile"
 msgstr ""
 

--- a/ckanext/canada/i18n/en/LC_MESSAGES/ckanext-canada.po
+++ b/ckanext/canada/i18n/en/LC_MESSAGES/ckanext-canada.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  CKAN\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-09 13:09-0400\n"
+"POT-Creation-Date: 2026-07-10 10:24-0400\n"
 "PO-Revision-Date: 2014-01-23 13:04+0000\n"
 "Last-Translator: Sean Hammond <sean.hammond@okfn.org>\n"
 "Language: en\n"
@@ -3542,7 +3542,7 @@ msgid "Explore"
 msgstr ""
 
 #: ckanext/canada/templates/package/snippets/resource_item.html:79
-#: ckanext/canada/templates/snippets/pd_datatable_depr.html:17
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:14
 msgid "Preview"
 msgstr ""
 
@@ -4076,21 +4076,16 @@ msgstr ""
 msgid "Resource Formats:"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable.html:45
-#: ckanext/canada/templates/snippets/pd_datatable_depr.html:13
-msgid "feedback"
-msgstr ""
-
-#: ckanext/canada/templates/snippets/pd_datatable.html:49
+#: ckanext/canada/templates/snippets/pd_datatable.html:46
 msgid "Interactive Table"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable.html:57
+#: ckanext/canada/templates/snippets/pd_datatable.html:54
 #, python-format
 msgid ""
 "The new table interface will become the default experience. Try the "
-"updated interface and share your %(feedback)s to help shape future "
-"improvements."
+"updated interface and share your <a href='mailto:%(email)s'>feedback</a> "
+"to help shape future improvements."
 msgstr ""
 
 #: ckanext/canada/templates/snippets/pd_datatable.html:58
@@ -4131,11 +4126,12 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable_depr.html:24
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:21
 #, python-format
 msgid ""
 "A new table experience is now available! Try the updated interface and "
-"share your %(feedback)s to help shape future improvements."
+"share your <a href='mailto:%(email)s'>feedback</a> to help shape future "
+"improvements."
 msgstr ""
 
 #: ckanext/canada/templates/snippets/pd_datatable_depr.html:25
@@ -5004,4 +5000,3 @@ msgstr ""
 
 #~ msgid "Maintainer"
 #~ msgstr ""
-

--- a/ckanext/canada/i18n/en/LC_MESSAGES/ckanext-canada.po
+++ b/ckanext/canada/i18n/en/LC_MESSAGES/ckanext-canada.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  CKAN\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-10 10:24-0400\n"
+"POT-Creation-Date: 2026-07-10 14:12-0400\n"
 "PO-Revision-Date: 2014-01-23 13:04+0000\n"
 "Last-Translator: Sean Hammond <sean.hammond@okfn.org>\n"
 "Language: en\n"
@@ -244,24 +244,24 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: ckanext/canada/logic.py:364
+#: ckanext/canada/logic.py:365
 msgid "Could not determine a resource format. Please supply a format."
 msgstr ""
 
-#: ckanext/canada/logic.py:554
+#: ckanext/canada/logic.py:555
 msgid "Unknown Job"
 msgstr ""
 
-#: ckanext/canada/logic.py:561
+#: ckanext/canada/logic.py:562
 msgid "Entire Site"
 msgstr ""
 
-#: ckanext/canada/logic.py:674
+#: ckanext/canada/logic.py:675
 #, python-format
 msgid "No Portal Sync information found for package %s"
 msgstr "No Portal Sync information found for dataset %s"
 
-#: ckanext/canada/logic.py:763
+#: ckanext/canada/logic.py:764
 msgid ""
 "Invalid request. Full text search is not supported for data with more "
 "than {} rows."
@@ -1364,9 +1364,9 @@ msgstr ""
 msgid ": "
 msgstr ""
 
-#: ckanext/canada/assets/modules/user_opt_in.js:77
-#: ckanext/canada/assets/modules/user_opt_in.js:81
-#: ckanext/canada/assets/modules/user_opt_in.js:85
+#: ckanext/canada/assets/modules/user_opt_in.js:74
+#: ckanext/canada/assets/modules/user_opt_in.js:78
+#: ckanext/canada/assets/modules/user_opt_in.js:82
 msgid "Failed to change user settings"
 msgstr ""
 
@@ -4077,7 +4077,7 @@ msgid "Resource Formats:"
 msgstr ""
 
 #: ckanext/canada/templates/snippets/pd_datatable.html:46
-msgid "Interactive Table"
+msgid "Interactive Table (beta version)"
 msgstr ""
 
 #: ckanext/canada/templates/snippets/pd_datatable.html:54
@@ -5000,3 +5000,4 @@ msgstr ""
 
 #~ msgid "Maintainer"
 #~ msgstr ""
+

--- a/ckanext/canada/i18n/fr/LC_MESSAGES/ckanext-canada.po
+++ b/ckanext/canada/i18n/fr/LC_MESSAGES/ckanext-canada.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-10 10:24-0400\n"
+"POT-Creation-Date: 2026-07-10 14:12-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr\n"
@@ -266,28 +266,28 @@ msgstr "Gouvernement ouvert"
 msgid "Search"
 msgstr "Rechercher"
 
-#: ckanext/canada/logic.py:364
+#: ckanext/canada/logic.py:365
 msgid "Could not determine a resource format. Please supply a format."
 msgstr ""
 "Il est impossible de déterminer le format de la ressource. Veuillez "
 "indiquer un format."
 
-#: ckanext/canada/logic.py:554
+#: ckanext/canada/logic.py:555
 msgid "Unknown Job"
 msgstr "Tâche inconnue "
 
-#: ckanext/canada/logic.py:561
+#: ckanext/canada/logic.py:562
 msgid "Entire Site"
 msgstr ""
 
-#: ckanext/canada/logic.py:674
+#: ckanext/canada/logic.py:675
 #, python-format
 msgid "No Portal Sync information found for package %s"
 msgstr ""
 "Aucune information de synchronisation du portail n'a été trouvée pour le "
 "jeu de données %s"
 
-#: ckanext/canada/logic.py:763
+#: ckanext/canada/logic.py:764
 msgid ""
 "Invalid request. Full text search is not supported for data with more "
 "than {} rows."
@@ -1256,7 +1256,7 @@ msgstr ""
 
 #: ckanext/canada/assets/datatables/pd_datatables.js:79
 msgid "Reset Table"
-msgstr ""
+msgstr "Réinitialiser le tableau"
 
 #: ckanext/canada/assets/datatables/pd_datatables.js:80
 msgid "Fullscreen"
@@ -1272,15 +1272,15 @@ msgstr ""
 
 #: ckanext/canada/assets/datatables/pd_datatables.js:83
 msgid "Full Table"
-msgstr ""
+msgstr "Tableau complet"
 
 #: ckanext/canada/assets/datatables/pd_datatables.js:84
 msgid "Compact Table"
-msgstr ""
+msgstr "Tableau compact"
 
 #: ckanext/canada/assets/datatables/pd_datatables.js:85
 msgid "Edit Online"
-msgstr ""
+msgstr "Modifier en ligne"
 
 #: ckanext/canada/assets/datatables/pd_datatables.js:86
 msgid "Add new record in Table"
@@ -1397,7 +1397,7 @@ msgstr ""
 
 #: ckanext/canada/assets/datatables/pd_datatables.js:113
 msgid "Edit<span class=\"pd-datatbales-btn-count\"></span> in Excel"
-msgstr ""
+msgstr "Modifier<span class=\"pd-datatbales-btn-count\"></span> dans Excel"
 
 #: ckanext/canada/assets/datatables/pd_datatables.js:114
 msgid "Exporting{COUNT} record(s) to an Excel Template"
@@ -1405,7 +1405,7 @@ msgstr ""
 
 #: ckanext/canada/assets/datatables/pd_datatables.js:115
 msgid "Delete<span class=\"pd-datatbales-btn-count\"></span>"
-msgstr ""
+msgstr "Supprimer<span class=\"pd-datatbales-btn-count\"></span>"
 
 #: ckanext/canada/assets/datatables/pd_datatables.js:116
 msgid "Save<span class=\"pd-datatbales-btn-count\"></span>"
@@ -1429,7 +1429,7 @@ msgstr ""
 
 #: ckanext/canada/assets/datatables/pd_datatables.js:125
 msgid "_MENU_ Show number of entries"
-msgstr ""
+msgstr "_MENU_ Afficher le nombre d'entrées"
 
 #: ckanext/canada/assets/datatables/pd_datatables.js:126
 #: ckanext/canada/templates/package/snippets/data_api_button.html:2
@@ -1438,7 +1438,7 @@ msgstr "Chargement..."
 
 #: ckanext/canada/assets/datatables/pd_datatables.js:128
 msgid "Full Text Search"
-msgstr ""
+msgstr "La recherche en texte intégral"
 
 #: ckanext/canada/assets/datatables/pd_datatables.js:129
 msgid "No matching records found"
@@ -1458,9 +1458,9 @@ msgstr ""
 msgid ": "
 msgstr " : "
 
-#: ckanext/canada/assets/modules/user_opt_in.js:77
-#: ckanext/canada/assets/modules/user_opt_in.js:81
-#: ckanext/canada/assets/modules/user_opt_in.js:85
+#: ckanext/canada/assets/modules/user_opt_in.js:74
+#: ckanext/canada/assets/modules/user_opt_in.js:78
+#: ckanext/canada/assets/modules/user_opt_in.js:82
 msgid "Failed to change user settings"
 msgstr ""
 
@@ -4539,10 +4539,11 @@ msgid "Resource Formats:"
 msgstr "Formats des ressources :"
 
 #: ckanext/canada/templates/snippets/pd_datatable.html:46
-msgid "Interactive Table"
-msgstr ""
+msgid "Interactive Table (beta version)"
+msgstr "Tableau interactif (version bêta)"
 
 #: ckanext/canada/templates/snippets/pd_datatable.html:54
+#, python-format
 msgid ""
 "The new table interface will become the default experience. Try the "
 "updated interface and share your <a href='mailto:%(email)s'>feedback</a> "
@@ -4558,31 +4559,38 @@ msgstr "Retourner à l’ancienne interface des tableaux"
 
 #: ckanext/canada/templates/snippets/pd_datatable.html:61
 msgid "Keyboard controls"
-msgstr ""
+msgstr "Commandes du clavier"
 
 #: ckanext/canada/templates/snippets/pd_datatable.html:63
 msgid ""
 "Hold <pre>SHIFT</pre> key while clicking on sort controls for multi-"
 "column sorting"
 msgstr ""
+"Maintenez la touche <pre>SHIFT</pre> enfoncée tout en cliquant sur les "
+"commandes de tri pour trier plusieurs colonnes."
 
 #: ckanext/canada/templates/snippets/pd_datatable.html:64
 msgid ""
 "Press <pre>ALT + K</pre> keys to enter KeyTable mode, allowing you to "
 "navigate the table with arrow keys"
 msgstr ""
+"Appuyez sur les touches <pre>ALT + K</pre> pour passer en mode « KeyTable"
+" », ce qui vous permet de naviguer dans le tableau avec les touches "
+"fléchées"
 
 #: ckanext/canada/templates/snippets/pd_datatable.html:66
 msgid "Press <pre>SPACE</pre> key to select a row"
-msgstr ""
+msgstr "Appuyez sur la touche <pre>SPACE</pre> pour sélectionner une ligne."
 
 #: ckanext/canada/templates/snippets/pd_datatable.html:67
 msgid "Press <pre>E</pre> key to expand a row (Compact Table mode only)"
 msgstr ""
+"Appuyez sur la touche <pre>E</pre> pour agrandir une rangée (mode Tableau"
+" compact seulement)."
 
 #: ckanext/canada/templates/snippets/pd_datatable.html:68
 msgid "Press <pre>ESC</pre> key to exit KeyTable mode"
-msgstr ""
+msgstr "Appuyez sur la touche <pre>ESC</pre> pour quitter le mode « KeyTable »"
 
 #: ckanext/canada/templates/snippets/pd_datatable.html:77
 #: ckanext/canada/templates/snippets/pd_datatable.html:88

--- a/ckanext/canada/i18n/fr/LC_MESSAGES/ckanext-canada.po
+++ b/ckanext/canada/i18n/fr/LC_MESSAGES/ckanext-canada.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-17 12:48-0400\n"
+"POT-Creation-Date: 2026-07-09 13:09-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr\n"
@@ -158,109 +158,109 @@ msgstr "Numéro d’entreprise non valide"
 msgid "Treasury Board of Canada Secretariat"
 msgstr "Secrétariat du Conseil du Trésor du Canada"
 
-#: ckanext/canada/helpers.py:711 ckanext/canada/strings.py:14
+#: ckanext/canada/helpers.py:716 ckanext/canada/strings.py:14
 #: ckanext/canada/view.py:1517
 msgid "Members not found"
 msgstr "Membres non trouvés"
 
-#: ckanext/canada/helpers.py:846
+#: ckanext/canada/helpers.py:851
 msgid "Data awaiting load to DataStore"
 msgstr "Le versement des données dans DataStore est en attente"
 
-#: ckanext/canada/helpers.py:847
+#: ckanext/canada/helpers.py:852
 msgid "Loading data into DataStore"
 msgstr "Le versement des données dans DataStore est en cours"
 
-#: ckanext/canada/helpers.py:848
+#: ckanext/canada/helpers.py:853
 msgid "Data loaded into DataStore"
 msgstr "Les données ont été versées dans DataStore"
 
-#: ckanext/canada/helpers.py:849
+#: ckanext/canada/helpers.py:854
 msgid "Failed to load data into DataStore"
 msgstr "Les données n'ont pas été versées dans DataStore"
 
-#: ckanext/canada/helpers.py:850
+#: ckanext/canada/helpers.py:855
 msgid "Data available in DataStore"
 msgstr "Les données sont disponibles dans DataStore"
 
-#: ckanext/canada/helpers.py:851
+#: ckanext/canada/helpers.py:856
 msgid "Resource not active in DataStore"
 msgstr "La ressource est inactive dans DataStore"
 
-#: ckanext/canada/helpers.py:852
+#: ckanext/canada/helpers.py:857
 msgid "DataStore status unknown"
 msgstr "L'état de DataStore est inconnu"
 
 # Search facets
-#: ckanext/canada/helpers.py:931
+#: ckanext/canada/helpers.py:936
 #: ckanext/canada/templates/home/quick_links.html:65
 #: ckanext/canada/templates/package/snippets/package_type_label.html:16
 #: ckanext/canada/templates/scheming/package/snippets/package_form.html:28
-#: ckanext/canada/templates/snippets/cdts/header.html:31
+#: ckanext/canada/templates/snippets/cdts/header.html:33
 #: ckanext/canada/templates/snippets/dataset_facets.html:3
 #: ckanext/canada/templates/snippets/dataset_facets.html:10
 msgid "Open Data"
 msgstr "Données ouvertes"
 
-#: ckanext/canada/helpers.py:932
+#: ckanext/canada/helpers.py:937
 #: ckanext/canada/templates/home/quick_links.html:82
 #: ckanext/canada/templates/package/snippets/package_type_label.html:22
 #: ckanext/canada/templates/scheming/package/snippets/package_form.html:30
-#: ckanext/canada/templates/snippets/cdts/header.html:56
+#: ckanext/canada/templates/snippets/cdts/header.html:57
 #: ckanext/canada/templates/snippets/dataset_facets.html:5
 #: ckanext/canada/templates/snippets/dataset_facets.html:11
 msgid "Open Information"
 msgstr "Information ouverte"
 
-#: ckanext/canada/helpers.py:944
+#: ckanext/canada/helpers.py:949
 #: ckanext/canada/templates/snippets/dataset_facets.html:27
 msgid "Request sent to data owner - awaiting response"
 msgstr "Demande envoyée au propriétaire des données, en attente de réponse"
 
-#: ckanext/canada/helpers.py:948
+#: ckanext/canada/helpers.py:953
 #: ckanext/canada/templates/snippets/publish_facet.html:44
 msgid "Pending"
 msgstr "En attente"
 
-#: ckanext/canada/helpers.py:949 ckanext/canada/templates/package/read.html:48
+#: ckanext/canada/helpers.py:954 ckanext/canada/templates/package/read.html:48
 #: ckanext/canada/templates/snippets/package_item.html:21
 #: ckanext/canada/templates/snippets/publish_facet.html:44
 msgid "Draft"
 msgstr "Ébauche"
 
-#: ckanext/canada/helpers.py:966
+#: ckanext/canada/helpers.py:971
 #: ckanext/canada/templates/home/quick_links.html:152
 #: ckanext/canada/templates/package/snippets/package_type_label.html:20
 #: ckanext/canada/templates/package/snippets/package_type_label.html:26
-#: ckanext/canada/templates/snippets/cdts/header.html:74
+#: ckanext/canada/templates/snippets/cdts/header.html:75
 #: ckanext/canada/templates/snippets/dataset_facets.html:33
 msgid "Proactive Publication"
 msgstr "Publication proactive"
 
-#: ckanext/canada/helpers.py:995
+#: ckanext/canada/helpers.py:1000
 #: ckanext/canada/templates/snippets/publish_facet.html:25
 msgid "Published"
 msgstr "Publié"
 
-#: ckanext/canada/helpers.py:997
+#: ckanext/canada/helpers.py:1002
 #: ckanext/canada/templates/snippets/publish_facet.html:34
 msgid "Scheduled"
 msgstr "Prévu"
 
-#: ckanext/canada/helpers.py:1037
+#: ckanext/canada/helpers.py:1042
 msgid "Registry Home"
 msgstr "Accueil du registre"
 
-#: ckanext/canada/helpers.py:1042
+#: ckanext/canada/helpers.py:1047
 msgid "Open Government"
 msgstr "Gouvernement ouvert"
 
-#: ckanext/canada/helpers.py:1045
+#: ckanext/canada/helpers.py:1050
 #: ckanext/canada/templates/admin/publish_search.html:19
 #: ckanext/canada/templates/home/quick_links.html:123
 #: ckanext/canada/templates/organization/snippets/organization_search.html:8
 #: ckanext/canada/templates/package/snippets/resources_list.html:36
-#: ckanext/canada/templates/snippets/cdts/header.html:167
+#: ckanext/canada/templates/snippets/cdts/header.html:174
 #: ckanext/canada/templates/snippets/search_form.html:45
 #: ckanext/canada/templates/user/snippets/user_search.html:11
 msgid "Search"
@@ -1150,7 +1150,7 @@ msgstr " d’enregistrements publiés."
 #: ckanext/canada/templates/package/edit.html:8
 #: ckanext/canada/templates/package/resource_edit.html:3
 #: ckanext/canada/templates/package/resource_edit_base.html:7
-#: ckanext/canada/templates/snippets/pd_datatable_depr.html:20
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:31
 #: ckanext/canada/view.py:1195
 msgid "Edit"
 msgstr "Modifier"
@@ -1209,254 +1209,260 @@ msgstr "L’utilisateur %r n’est pas autorisé à modifier les membres de %s"
 msgid "User %r not authorized to view members of %s"
 msgstr "L’utilisateur %r n’est pas autorisé à voir les membres de %s"
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:65
-#: ckanext/canada/templates/snippets/pd_datatable_depr.html:79
+#: ckanext/canada/assets/datatables/pd_datatables.js:68
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:90
 msgid "Select All"
 msgstr "Sélectionner tout"
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:66
+#: ckanext/canada/assets/datatables/pd_datatables.js:69
 msgid "Search:"
 msgstr "Rechercher :"
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:67
+#: ckanext/canada/assets/datatables/pd_datatables.js:70
 msgid "Sorting by:"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:68
+#: ckanext/canada/assets/datatables/pd_datatables.js:71
 msgid "Ascending"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:69
+#: ckanext/canada/assets/datatables/pd_datatables.js:72
 msgid "Descending"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:70
+#: ckanext/canada/assets/datatables/pd_datatables.js:73
 msgid "Any"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:71
+#: ckanext/canada/assets/datatables/pd_datatables.js:74
 msgid "less"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:72
+#: ckanext/canada/assets/datatables/pd_datatables.js:75
 msgid "Row"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:73
+#: ckanext/canada/assets/datatables/pd_datatables.js:76
 msgid "New"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:74
+#: ckanext/canada/assets/datatables/pd_datatables.js:77
 msgid "Updated"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:75
+#: ckanext/canada/assets/datatables/pd_datatables.js:78
 msgid "Jump to page"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:76
+#: ckanext/canada/assets/datatables/pd_datatables.js:79
 msgid "Reset Table"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:77
+#: ckanext/canada/assets/datatables/pd_datatables.js:80
 msgid "Fullscreen"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:78
+#: ckanext/canada/assets/datatables/pd_datatables.js:81
 msgid "Exit Fullscreen"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:79
+#: ckanext/canada/assets/datatables/pd_datatables.js:82
 msgid "Exit Edit Mode"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:80
+#: ckanext/canada/assets/datatables/pd_datatables.js:83
 msgid "Full Table"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:81
+#: ckanext/canada/assets/datatables/pd_datatables.js:84
 msgid "Compact Table"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:82
+#: ckanext/canada/assets/datatables/pd_datatables.js:85
 msgid "Edit Online"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:83
+#: ckanext/canada/assets/datatables/pd_datatables.js:86
 msgid "Add new record in Table"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:84
+#: ckanext/canada/assets/datatables/pd_datatables.js:87
 msgid "Edit<span class=\"pd-datatbales-btn-count\"></span> in Table"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:85
+#: ckanext/canada/assets/datatables/pd_datatables.js:88
 msgid "Record is valid"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:86
+#: ckanext/canada/assets/datatables/pd_datatables.js:89
 msgid "Some fields have validation errors"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:87
+#: ckanext/canada/assets/datatables/pd_datatables.js:90
 msgid "Some fields are required"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:88
+#: ckanext/canada/assets/datatables/pd_datatables.js:91
 msgid "Detailed error summary"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:89
+#: ckanext/canada/assets/datatables/pd_datatables.js:92
 msgid "Field errors"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:90
+#: ckanext/canada/assets/datatables/pd_datatables.js:93
 msgid ""
 "You have unsaved records in the table. Do you want to discard your "
 "changes or continue editing?"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:91
+#: ckanext/canada/assets/datatables/pd_datatables.js:94
 msgid "Validating records"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:92
+#: ckanext/canada/assets/datatables/pd_datatables.js:95
 msgid "Saving records to the system"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:94
+#: ckanext/canada/assets/datatables/pd_datatables.js:97
 msgid "Records saved to the system."
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:95
+#: ckanext/canada/assets/datatables/pd_datatables.js:98
 msgid "Would you like to add more records, or preview them in the table?"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:96
+#: ckanext/canada/assets/datatables/pd_datatables.js:99
 msgid "Add more records"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:97
+#: ckanext/canada/assets/datatables/pd_datatables.js:100
 msgid "Preview records"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:98
+#: ckanext/canada/assets/datatables/pd_datatables.js:101
 msgid ""
 "Your records did not save because one or more of them have errors. Fix "
 "the errors and save again to finalize your records."
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:99
+#: ckanext/canada/assets/datatables/pd_datatables.js:102
 msgid "Could not save the records due to the following error: "
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:100
+#: ckanext/canada/assets/datatables/pd_datatables.js:103
 msgid ""
 "Your records did not save. Try saving again. If the issue persist please "
 "contact support with Support ID: "
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:101
+#: ckanext/canada/assets/datatables/pd_datatables.js:104
 msgid ""
 "Your records did not save. Try saving again. If the issue persist please "
 "contact support."
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:102
+#: ckanext/canada/assets/datatables/pd_datatables.js:105
 msgid "{PRIM_IDS} already used in this Editor Table."
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:103
+#: ckanext/canada/assets/datatables/pd_datatables.js:106
 msgid " record(s)"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:104
+#: ckanext/canada/assets/datatables/pd_datatables.js:107
 msgid "Legend:"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:105
+#: ckanext/canada/assets/datatables/pd_datatables.js:108
 msgid "Valid"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:106
+#: ckanext/canada/assets/datatables/pd_datatables.js:109
 #: ckanext/canada/templates/error_document_template.html:18
 msgid "Error"
 msgstr "Erreur"
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:107
+#: ckanext/canada/assets/datatables/pd_datatables.js:110
 msgid "Required"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:108
+#: ckanext/canada/assets/datatables/pd_datatables.js:111
 msgid "Error: Could not query records. Please try again."
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:109
+#: ckanext/canada/assets/datatables/pd_datatables.js:112
 msgid "Error: Could not generate Excel template. Please try again."
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:110
+#: ckanext/canada/assets/datatables/pd_datatables.js:113
 msgid "Edit<span class=\"pd-datatbales-btn-count\"></span> in Excel"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:111
+#: ckanext/canada/assets/datatables/pd_datatables.js:114
 msgid "Exporting{COUNT} record(s) to an Excel Template"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:112
+#: ckanext/canada/assets/datatables/pd_datatables.js:115
 msgid "Delete<span class=\"pd-datatbales-btn-count\"></span>"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:113
+#: ckanext/canada/assets/datatables/pd_datatables.js:116
 msgid "Save<span class=\"pd-datatbales-btn-count\"></span>"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:116
+#: ckanext/canada/assets/datatables/pd_datatables.js:119
 msgid "No data available in table"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:117
+#: ckanext/canada/assets/datatables/pd_datatables.js:120
 msgid "Showing _START_ to _END_ of _TOTAL_ entries"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:118
+#: ckanext/canada/assets/datatables/pd_datatables.js:121
 msgid "Showing 0 to 0 of 0 entries"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:119
+#: ckanext/canada/assets/datatables/pd_datatables.js:122
 msgid "(filtered from _MAX_ total entries)"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:122
+#: ckanext/canada/assets/datatables/pd_datatables.js:125
 msgid "_MENU_ Show number of entries"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:123
+#: ckanext/canada/assets/datatables/pd_datatables.js:126
 #: ckanext/canada/templates/package/snippets/data_api_button.html:2
 msgid "Loading..."
 msgstr "Chargement..."
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:125
+#: ckanext/canada/assets/datatables/pd_datatables.js:128
 msgid "Full Text Search"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:126
+#: ckanext/canada/assets/datatables/pd_datatables.js:129
 msgid "No matching records found"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:134
+#: ckanext/canada/assets/datatables/pd_datatables.js:137
 msgid "Order by this column"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:135
+#: ckanext/canada/assets/datatables/pd_datatables.js:138
 msgid "Reverse order this column"
 msgstr ""
 
-#: ckanext/canada/assets/datatables/pd_datatables.js:439
-#: ckanext/canada/assets/datatables/pd_datatables.js:487
-#: ckanext/canada/assets/datatables/pd_datatables.js:503
+#: ckanext/canada/assets/datatables/pd_datatables.js:446
+#: ckanext/canada/assets/datatables/pd_datatables.js:494
+#: ckanext/canada/assets/datatables/pd_datatables.js:510
 msgid ": "
 msgstr " : "
+
+#: ckanext/canada/assets/modules/user_opt_in.js:77
+#: ckanext/canada/assets/modules/user_opt_in.js:81
+#: ckanext/canada/assets/modules/user_opt_in.js:85
+msgid "Failed to change user settings"
+msgstr ""
 
 #: ckanext/canada/plugin/public_plugin.py:151
 #: ckanext/canada/templates/scheming/package/snippets/package_form.html:25
@@ -1513,17 +1519,17 @@ msgstr "Juridiction"
 msgid "Suggestion Status"
 msgstr "État de la suggestion"
 
-#: ckanext/canada/plugin/public_plugin.py:257
-#: ckanext/canada/plugin/public_plugin.py:264
+#: ckanext/canada/plugin/public_plugin.py:259
+#: ckanext/canada/plugin/public_plugin.py:266
 msgid "container_title"
 msgstr ""
 
-#: ckanext/canada/plugin/public_plugin.py:331
+#: ckanext/canada/plugin/public_plugin.py:333
 #: ckanext/canada/templates/package/read.html:194
 msgid "Previous"
 msgstr "Précédent"
 
-#: ckanext/canada/plugin/public_plugin.py:332
+#: ckanext/canada/plugin/public_plugin.py:334
 #: ckanext/canada/templates/package/read.html:210
 msgid "Next"
 msgstr "Suivant"
@@ -2860,7 +2866,7 @@ msgid "Load more"
 msgstr "En charger davantage"
 
 #: ckanext/canada/templates/admin/base.html:5
-#: ckanext/canada/templates/snippets/cdts/header.html:215
+#: ckanext/canada/templates/snippets/cdts/header.html:222
 msgid "Admin"
 msgstr "Administrateur"
 
@@ -3095,7 +3101,7 @@ msgstr ""
 
 #: ckanext/canada/templates/home/quick_links.html:71
 #: ckanext/canada/templates/package/new.html:7
-#: ckanext/canada/templates/snippets/cdts/header.html:36
+#: ckanext/canada/templates/snippets/cdts/header.html:38
 msgid "Create an Open Data Record"
 msgstr "Créer un enregistrement de données ouvert"
 
@@ -3119,7 +3125,7 @@ msgstr ""
 " gouvernement."
 
 #: ckanext/canada/templates/home/quick_links.html:96
-#: ckanext/canada/templates/snippets/cdts/header.html:65
+#: ckanext/canada/templates/snippets/cdts/header.html:66
 msgid "Algorithmic Impact Assessment"
 msgstr "Evaluation d'incidence algorithmique"
 
@@ -3130,7 +3136,7 @@ msgstr ""
 "pour votre organisation"
 
 #: ckanext/canada/templates/home/quick_links.html:104
-#: ckanext/canada/templates/snippets/cdts/header.html:69
+#: ckanext/canada/templates/snippets/cdts/header.html:70
 msgid "Institutional Accessibility plans"
 msgstr "Plans sur l'accessibilité des institutions"
 
@@ -3142,13 +3148,13 @@ msgstr ""
 
 #: ckanext/canada/templates/home/quick_links.html:110
 #: ckanext/canada/templates/package/snippets/package_type_label.html:24
-#: ckanext/canada/templates/snippets/cdts/header.html:152
+#: ckanext/canada/templates/snippets/cdts/header.html:159
 #: ckanext/canada/templates/snippets/dataset_facets.html:4
 msgid "Open Dialogue"
 msgstr "Dialogue ouvert"
 
 #: ckanext/canada/templates/home/quick_links.html:117
-#: ckanext/canada/templates/snippets/cdts/header.html:161
+#: ckanext/canada/templates/snippets/cdts/header.html:168
 msgid "Consultations master dataset"
 msgstr "Données de consultations principals"
 
@@ -3187,7 +3193,7 @@ msgid "View the list of members linked to your organization."
 msgstr "Voir la liste des membres liés à votre organisation."
 
 #: ckanext/canada/templates/home/quick_links.html:170
-#: ckanext/canada/templates/snippets/cdts/header.html:123
+#: ckanext/canada/templates/snippets/cdts/header.html:124
 msgid "Reports Tabled in Parliament"
 msgstr "Rapports déposés au Parlement"
 
@@ -3202,7 +3208,7 @@ msgid "Briefing packages"
 msgstr "Documents d’information"
 
 #: ckanext/canada/templates/home/quick_links.html:185
-#: ckanext/canada/templates/snippets/cdts/header.html:135
+#: ckanext/canada/templates/snippets/cdts/header.html:136
 msgid "New or incoming ministers"
 msgstr "Documents d’information pour les nouveaux ministres"
 
@@ -3215,7 +3221,7 @@ msgstr ""
 " contenu ou modifiez-la."
 
 #: ckanext/canada/templates/home/quick_links.html:193
-#: ckanext/canada/templates/snippets/cdts/header.html:139
+#: ckanext/canada/templates/snippets/cdts/header.html:140
 msgid "New or incoming deputy heads"
 msgstr "Documents d’information pour les nouveaux administrateurs généraux"
 
@@ -3228,7 +3234,7 @@ msgstr ""
 " ajoutez-y du contenu ou modifiez-la."
 
 #: ckanext/canada/templates/home/quick_links.html:201
-#: ckanext/canada/templates/snippets/cdts/header.html:143
+#: ckanext/canada/templates/snippets/cdts/header.html:144
 msgid "Parliamentary Committee appearances for ministers"
 msgstr ""
 "Documents d’information à l’intention des ministres pour les comparutions"
@@ -3243,7 +3249,7 @@ msgstr ""
 "devant un comité parlementaire, ajoutez-y du contenu ou modifiez-la."
 
 #: ckanext/canada/templates/home/quick_links.html:209
-#: ckanext/canada/templates/snippets/cdts/header.html:147
+#: ckanext/canada/templates/snippets/cdts/header.html:148
 msgid "Parliamentary Committee appearances for deputy heads"
 msgstr ""
 "Documents d’information à l’intention des administrateurs généraux pour "
@@ -3303,7 +3309,7 @@ msgstr "Gérer"
 #: ckanext/canada/templates/organization/index.html:26
 #: ckanext/canada/templates/organization/members.html:10
 #: ckanext/canada/templates/organization/read_base.html:7
-#: ckanext/canada/templates/snippets/cdts/header.html:171
+#: ckanext/canada/templates/snippets/cdts/header.html:178
 #: ckanext/canada/templates/user/read.html:28
 #: ckanext/canada/templates/user/read_base.html:17
 #: ckanext/canada/templates/user/read_base.html:76
@@ -3963,7 +3969,7 @@ msgid "Explore"
 msgstr "Explorer"
 
 #: ckanext/canada/templates/package/snippets/resource_item.html:79
-#: ckanext/canada/templates/snippets/pd_datatable_depr.html:14
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:17
 msgid "Preview"
 msgstr "Aperçu"
 
@@ -4532,49 +4538,82 @@ msgstr "Demande envoyée au propriétaire des données, en attente de réponse"
 msgid "Resource Formats:"
 msgstr "Formats des ressources :"
 
-#: ckanext/canada/templates/snippets/pd_datatable.html:46
+#: ckanext/canada/templates/snippets/pd_datatable.html:45
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:13
+msgid "feedback"
+msgstr "commentaires"
+
+#: ckanext/canada/templates/snippets/pd_datatable.html:49
 msgid "Interactive Table"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable.html:49
+#: ckanext/canada/templates/snippets/pd_datatable.html:57
+#, python-format
+msgid ""
+"The new table interface will become the default experience. Try the "
+"updated interface and share your %(feedback)s to help shape future "
+"improvements."
+msgstr ""
+"La nouvelle interface sera appliquée par défaut à compter du.  Testez-la "
+"et faites-nous part de vos %(feedback)s afin de nous aider à l’améliorer."
+
+#: ckanext/canada/templates/snippets/pd_datatable.html:58
+msgid "Revert to older table interface"
+msgstr "Retourner à l’ancienne interface des tableaux"
+
+#: ckanext/canada/templates/snippets/pd_datatable.html:61
 msgid "Keyboard controls"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable.html:51
+#: ckanext/canada/templates/snippets/pd_datatable.html:63
 msgid ""
 "Hold <pre>SHIFT</pre> key while clicking on sort controls for multi-"
 "column sorting"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable.html:52
+#: ckanext/canada/templates/snippets/pd_datatable.html:64
 msgid ""
 "Press <pre>ALT + K</pre> keys to enter KeyTable mode, allowing you to "
 "navigate the table with arrow keys"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable.html:54
+#: ckanext/canada/templates/snippets/pd_datatable.html:66
 msgid "Press <pre>SPACE</pre> key to select a row"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable.html:55
+#: ckanext/canada/templates/snippets/pd_datatable.html:67
 msgid "Press <pre>E</pre> key to expand a row (Compact Table mode only)"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable.html:56
+#: ckanext/canada/templates/snippets/pd_datatable.html:68
 msgid "Press <pre>ESC</pre> key to exit KeyTable mode"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable.html:65
-#: ckanext/canada/templates/snippets/pd_datatable.html:76
-#: ckanext/canada/templates/snippets/pd_datatable_depr.html:18
+#: ckanext/canada/templates/snippets/pd_datatable.html:77
+#: ckanext/canada/templates/snippets/pd_datatable.html:88
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:29
 msgid "Select"
 msgstr "Sélectionner"
 
-#: ckanext/canada/templates/snippets/pd_datatable_depr.html:173
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:24
+#, python-format
+msgid ""
+"A new table experience is now available! Try the updated interface and "
+"share your %(feedback)s to help shape future improvements."
+msgstr ""
+"Une toute nouvelle interface est maintenant disponible pour vos tableaux!"
+" Testez-la et faites-nous part de vos %(feedback)s afin de nous aider à "
+"l’améliorer."
+
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:25
+msgid "Enable new table interface"
+msgstr "Activer la nouvelle interface des tableaux"
+
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:184
 msgid "Edit in Excel"
 msgstr "Modifier dans Excel"
 
-#: ckanext/canada/templates/snippets/pd_datatable_depr.html:207
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:218
 msgid "Delete records"
 msgstr "Supprimer des dossiers"
 
@@ -4641,34 +4680,34 @@ msgstr ""
 "Consulter les 60 derniers jours d'activités des métadonnées et les 150 "
 "derniers jours d'activités du DataStore."
 
-#: ckanext/canada/templates/snippets/cdts/header.html:21
-#: ckanext/canada/templates/snippets/cdts/header.html:26
+#: ckanext/canada/templates/snippets/cdts/header.html:23
+#: ckanext/canada/templates/snippets/cdts/header.html:28
 msgid "Home"
 msgstr "Accueil"
 
-#: ckanext/canada/templates/snippets/cdts/header.html:61
+#: ckanext/canada/templates/snippets/cdts/header.html:62
 msgid "Create an Open Information Record"
 msgstr "Créer un enregistrement d'informations ouvertes"
 
-#: ckanext/canada/templates/snippets/cdts/header.html:176
+#: ckanext/canada/templates/snippets/cdts/header.html:183
 msgid "FAQ"
 msgstr "FAQ"
 
-#: ckanext/canada/templates/snippets/cdts/header.html:207
+#: ckanext/canada/templates/snippets/cdts/header.html:214
 #: ckanext/canada/templates/user/dashboard.html:9
 #: ckanext/canada/templates/user/dashboard_datasets.html:19
 msgid "Dashboard"
 msgstr "Tableau de bord"
 
-#: ckanext/canada/templates/snippets/cdts/header.html:223
+#: ckanext/canada/templates/snippets/cdts/header.html:230
 msgid "Get Help"
 msgstr "Obtenez de l’aide"
 
-#: ckanext/canada/templates/snippets/cdts/header.html:244
+#: ckanext/canada/templates/snippets/cdts/header.html:251
 msgid "Signed in as"
 msgstr "Connecté en tant que"
 
-#: ckanext/canada/templates/snippets/cdts/header.html:244
+#: ckanext/canada/templates/snippets/cdts/header.html:251
 msgid "View profile"
 msgstr "Afficher le profil"
 

--- a/ckanext/canada/i18n/fr/LC_MESSAGES/ckanext-canada.po
+++ b/ckanext/canada/i18n/fr/LC_MESSAGES/ckanext-canada.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-09 13:09-0400\n"
+"POT-Creation-Date: 2026-07-10 10:24-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr\n"
@@ -3969,7 +3969,7 @@ msgid "Explore"
 msgstr "Explorer"
 
 #: ckanext/canada/templates/package/snippets/resource_item.html:79
-#: ckanext/canada/templates/snippets/pd_datatable_depr.html:17
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:14
 msgid "Preview"
 msgstr "Aperçu"
 
@@ -4538,24 +4538,19 @@ msgstr "Demande envoyée au propriétaire des données, en attente de réponse"
 msgid "Resource Formats:"
 msgstr "Formats des ressources :"
 
-#: ckanext/canada/templates/snippets/pd_datatable.html:45
-#: ckanext/canada/templates/snippets/pd_datatable_depr.html:13
-msgid "feedback"
-msgstr "commentaires"
-
-#: ckanext/canada/templates/snippets/pd_datatable.html:49
+#: ckanext/canada/templates/snippets/pd_datatable.html:46
 msgid "Interactive Table"
 msgstr ""
 
-#: ckanext/canada/templates/snippets/pd_datatable.html:57
-#, python-format
+#: ckanext/canada/templates/snippets/pd_datatable.html:54
 msgid ""
 "The new table interface will become the default experience. Try the "
-"updated interface and share your %(feedback)s to help shape future "
-"improvements."
+"updated interface and share your <a href='mailto:%(email)s'>feedback</a> "
+"to help shape future improvements."
 msgstr ""
-"La nouvelle interface sera appliquée par défaut à compter du.  Testez-la "
-"et faites-nous part de vos %(feedback)s afin de nous aider à l’améliorer."
+"La nouvelle interface sera appliquée par défaut à compter. Testez-la et "
+"faites-nous part de vos <a href='mailto:%(email)s'>commentaires</a> afin "
+"de nous aider à l’améliorer."
 
 #: ckanext/canada/templates/snippets/pd_datatable.html:58
 msgid "Revert to older table interface"
@@ -4595,14 +4590,16 @@ msgstr ""
 msgid "Select"
 msgstr "Sélectionner"
 
-#: ckanext/canada/templates/snippets/pd_datatable_depr.html:24
+#: ckanext/canada/templates/snippets/pd_datatable_depr.html:21
 #, python-format
 msgid ""
 "A new table experience is now available! Try the updated interface and "
-"share your %(feedback)s to help shape future improvements."
+"share your <a href='mailto:%(email)s'>feedback</a> to help shape future "
+"improvements."
 msgstr ""
 "Une toute nouvelle interface est maintenant disponible pour vos tableaux!"
-" Testez-la et faites-nous part de vos %(feedback)s afin de nous aider à "
+" Testez-la et faites-nous part de vos <a "
+"href='mailto:%(email)s'>commentaires</a> afin de nous aider à "
 "l’améliorer."
 
 #: ckanext/canada/templates/snippets/pd_datatable_depr.html:25

--- a/ckanext/canada/logic.py
+++ b/ckanext/canada/logic.py
@@ -783,7 +783,8 @@ def canada_user_update(up_func: Action,
     schema = {
         'opt_in_features__pd_datatables': [
             ignore_missing_validator,
-            default_validator(False),
+            # type_ignore_reason: incomplete typing
+            default_validator(False),  # type: ignore
             bool_validator,
         ]
     }

--- a/ckanext/canada/logic.py
+++ b/ckanext/canada/logic.py
@@ -764,3 +764,53 @@ def canada_datastore_search(up_func: Action,
                                     'not supported for data with '
                                     'more than {} rows.').format(max_rows_for_fts))
     return up_func(context, data_dict)
+
+
+@chained_action
+def canada_user_update(up_func: Action,
+                       context: Context,
+                       data_dict: DataDict) -> ChainedAction:
+    """
+    Add new fields to the User schema.
+    """
+    bool_validator = get_validator('boolean_validator')
+    default_validator = get_validator('default')
+    ignore_missing_validator = get_validator('ignore_missing')
+    custom_data_dict = {
+        'opt_in_features__pd_datatables': data_dict.get(
+            'opt_in_features__pd_datatables', None)
+    }
+    schema = {
+        'opt_in_features__pd_datatables': [
+            ignore_missing_validator,
+            default_validator(False),
+            bool_validator,
+        ]
+    }
+    data, errors = validate(custom_data_dict, schema, context)
+    if errors:
+        model.Session.rollback()
+        raise ValidationError(errors)
+    if 'opt_in_features__pd_datatables' not in data:
+        return up_func(context, data_dict)
+    if 'plugin_extras' not in data_dict:
+        data_dict['plugin_extras'] = {}
+    data_dict['plugin_extras']['opt_in_features__pd_datatables'] = \
+        data['opt_in_features__pd_datatables']
+    return up_func(context, data_dict)
+
+
+@chained_action
+@side_effect_free
+def canada_user_show(up_func: Action,
+                     context: Context,
+                     data_dict: DataDict) -> ChainedAction:
+    """
+    Return new fields in the User dictionary.
+    """
+    data_dict['include_plugin_extras'] = True
+    user_dict = up_func(context, data_dict)
+    extras = user_dict.pop('plugin_extras', {})
+    user_dict['opt_in_features__pd_datatables'] = extras.get(
+        'opt_in_features__pd_datatables', False) if extras else False
+    return user_dict

--- a/ckanext/canada/logic.py
+++ b/ckanext/canada/logic.py
@@ -7,6 +7,7 @@ from ckanext.activity.model import Activity, activity
 from ckan.logic.schema import (
     default_create_resource_view_schema_filtered,
     default_update_resource_view_schema_changes,
+    default_update_user_schema,
 )
 from contextlib import contextmanager
 
@@ -798,7 +799,15 @@ def canada_user_update(up_func: Action,
         data_dict['plugin_extras'] = {}
     data_dict['plugin_extras']['opt_in_features__pd_datatables'] = \
         data['opt_in_features__pd_datatables']
-    return up_func(context, data_dict)
+    user_update_schema = default_update_user_schema()
+    # remove ignore_not_sysadmin validator from plugin_extras
+    user_update_schema['plugin_extras'] = [get_validator('json_object')]
+    up_context = dict(context, schema=user_update_schema)
+    response = up_func(up_context, data_dict)
+    extras = up_context['user_obj'].plugin_extras
+    response['opt_in_features__pd_datatables'] = extras.get(
+        'opt_in_features__pd_datatables', False)
+    return response
 
 
 @chained_action
@@ -809,9 +818,8 @@ def canada_user_show(up_func: Action,
     """
     Return new fields in the User dictionary.
     """
-    data_dict['include_plugin_extras'] = True
     user_dict = up_func(context, data_dict)
-    extras = user_dict.pop('plugin_extras', {})
+    extras = context['user_obj'].plugin_extras
     user_dict['opt_in_features__pd_datatables'] = extras.get(
-        'opt_in_features__pd_datatables', False) if extras else False
+        'opt_in_features__pd_datatables', False)
     return user_dict

--- a/ckanext/canada/logic.py
+++ b/ckanext/canada/logic.py
@@ -802,9 +802,9 @@ def canada_user_update(up_func: Action,
     user_update_schema = default_update_user_schema()
     # remove ignore_not_sysadmin validator from plugin_extras
     user_update_schema['plugin_extras'] = [get_validator('json_object')]
-    up_context = dict(context, schema=user_update_schema)
+    up_context = cast(Context, dict(context, schema=user_update_schema))
     response = up_func(up_context, data_dict)
-    extras = up_context['user_obj'].plugin_extras
+    extras = up_context['user_obj'].plugin_extras or {}
     response['opt_in_features__pd_datatables'] = extras.get(
         'opt_in_features__pd_datatables', False)
     return response
@@ -819,7 +819,7 @@ def canada_user_show(up_func: Action,
     Return new fields in the User dictionary.
     """
     user_dict = up_func(context, data_dict)
-    extras = context['user_obj'].plugin_extras
+    extras = context['user_obj'].plugin_extras or {}
     user_dict['opt_in_features__pd_datatables'] = extras.get(
         'opt_in_features__pd_datatables', False)
     return user_dict

--- a/ckanext/canada/plugin/public_plugin.py
+++ b/ckanext/canada/plugin/public_plugin.py
@@ -189,6 +189,8 @@ class CanadaPublicPlugin(p.SingletonPlugin, DefaultTranslation):
             'job_list': logic.canada_job_list,
             'registry_jobs_running': logic.registry_jobs_running,
             'datastore_search': logic.canada_datastore_search,
+            'user_update': logic.canada_user_update,
+            'user_show': logic.canada_user_show,
         }
 
     # IAuthFunctions

--- a/ckanext/canada/plugin/theme_plugin.py
+++ b/ckanext/canada/plugin/theme_plugin.py
@@ -18,6 +18,7 @@ class CanadaThemePlugin(p.SingletonPlugin):
         p.toolkit.add_resource('../public/static/js', 'js')
         p.toolkit.add_resource('../assets/internal', 'canada_internal')
         p.toolkit.add_resource('../assets/datatables', 'canada_datatables')
+        p.toolkit.add_resource('../assets/modules', 'canada_modules')
         p.toolkit.add_resource('../assets/public', 'canada_public')
         p.toolkit.add_resource('../assets/invitation-manager', 'invitation_manager')
         config['ckan.favicon'] = helpers.cdts_asset('/assets/favicon.ico')

--- a/ckanext/canada/templates/page.html
+++ b/ckanext/canada/templates/page.html
@@ -148,6 +148,7 @@
   {%- endif -%}
   {{ super() }}
   {% if h.is_registry_domain() %}
+    {% asset 'canada_modules/main_js' %}
     {%- block session_timeout -%}
       {% if g.userobj and h.get_timeout_length() %}
         <script nonce="{{- h.get_inline_script_nonce() -}}">

--- a/ckanext/canada/templates/snippets/pd_datatable.html
+++ b/ckanext/canada/templates/snippets/pd_datatable.html
@@ -41,7 +41,9 @@
 {% if geno.datatables_style %}
   {% do tableStyles.update(geno.datatables_style) %}
 {% endif %}
-{% set feedback_link = '<a href="mailto:' ~ h.support_email_address() ~ '">feedback</a>' %}
+{% set feedback_link %}
+  <a href="mailto:{{ h.support_email_address() }}">{{ _('feedback') }}</a>
+{% endset %}
 
 <section id="dt-preview">
   <h2 id="prtable">{{_("Interactive Table")}}</h2>

--- a/ckanext/canada/templates/snippets/pd_datatable.html
+++ b/ckanext/canada/templates/snippets/pd_datatable.html
@@ -43,7 +43,7 @@
 {% endif %}
 
 <section id="dt-preview">
-  <h2 id="prtable">{{_("Interactive Table")}}</h2>
+  <h2 id="prtable">{{_("Interactive Table (beta version)")}}</h2>
   <div data-module="canada-user-opt-in-feature"
        data-module-csrf_name="{{- g.csrf_field_name -}}"
        data-module-csrf_value="{{- csrf_token() -}}"

--- a/ckanext/canada/templates/snippets/pd_datatable.html
+++ b/ckanext/canada/templates/snippets/pd_datatable.html
@@ -44,6 +44,15 @@
 
 <section id="dt-preview">
   <h2 id="prtable">{{_("Interactive Table")}}</h2>
+  <div data-module="canada-user-opt-in-feature"
+       data-module-csrf_name="{{- g.csrf_field_name -}}"
+       data-module-csrf_value="{{- csrf_token() -}}"
+       data-module-user_id="{{ g.user }}"
+       data-module-feature_key="opt_in_features__pd_datatables"
+       data-module-feature_value=false
+       data-module-page_redirect="#prtable"
+       data-module-label="{{ _('The new table interface will become the default experience on [TBD]. Please familiarize yourself with the updated functionality prior to implementation.') }}"
+       data-module-button_label="{{ _('Revert to older interface') }}"></div>
   <div class="pd-datable-instructions">
     <details>
       <summary>{{ _('Keyboard controls') }}</summary>

--- a/ckanext/canada/templates/snippets/pd_datatable.html
+++ b/ckanext/canada/templates/snippets/pd_datatable.html
@@ -41,6 +41,7 @@
 {% if geno.datatables_style %}
   {% do tableStyles.update(geno.datatables_style) %}
 {% endif %}
+{% set feedback_link = '<a href="mailto:' ~ h.support_email_address() ~ '">feedback</a>' %}
 
 <section id="dt-preview">
   <h2 id="prtable">{{_("Interactive Table")}}</h2>
@@ -51,8 +52,8 @@
        data-module-feature_key="opt_in_features__pd_datatables"
        data-module-feature_value=false
        data-module-page_redirect="#prtable"
-       data-module-label="{{ _('The new table interface will become the default experience on [TBD]. Please familiarize yourself with the updated functionality prior to implementation.') }}"
-       data-module-button_label="{{ _('Revert to older interface') }}"></div>
+       data-module-label="{{ _('The new table interface will become the default experience. Try the updated interface and share your %(feedback)s to help shape future improvements.', feedback=feedback_link) }}"
+       data-module-button_label="{{ _('Revert to older table interface') }}"></div>
   <div class="pd-datable-instructions">
     <details>
       <summary>{{ _('Keyboard controls') }}</summary>

--- a/ckanext/canada/templates/snippets/pd_datatable.html
+++ b/ckanext/canada/templates/snippets/pd_datatable.html
@@ -41,9 +41,6 @@
 {% if geno.datatables_style %}
   {% do tableStyles.update(geno.datatables_style) %}
 {% endif %}
-{% set feedback_link %}
-  <a href="mailto:{{ h.support_email_address() }}">{{ _('feedback') }}</a>
-{% endset %}
 
 <section id="dt-preview">
   <h2 id="prtable">{{_("Interactive Table")}}</h2>
@@ -54,7 +51,10 @@
        data-module-feature_key="opt_in_features__pd_datatables"
        data-module-feature_value=false
        data-module-page_redirect="#prtable"
-       data-module-label="{{ _('The new table interface will become the default experience. Try the updated interface and share your %(feedback)s to help shape future improvements.', feedback=feedback_link) }}"
+       data-module-label="{{ _(
+            "The new table interface will become the default experience. Try the updated interface and share your <a href='mailto:%(email)s'>feedback</a> to help shape future improvements.",
+            email=h.support_email_address()
+        ) }}"
        data-module-button_label="{{ _('Revert to older table interface') }}"></div>
   <div class="pd-datable-instructions">
     <details>

--- a/ckanext/canada/templates/snippets/pd_datatable_depr.html
+++ b/ckanext/canada/templates/snippets/pd_datatable_depr.html
@@ -9,9 +9,6 @@
 {% for _res_name, _fkeys in foreign_keys.items() %}
   {% do fk_links.update({_res_name: h.url_for('recombinant.preview_table', resource_name=_res_name, owner_org=owner_org)}) %}
 {% endfor  %}
-{% set feedback_link %}
-  <a href="mailto:{{ h.support_email_address() }}">{{ _('feedback') }}</a>
-{% endset %}
 
 <section id="dt-preview">
   <h2 id="prtable">{{_("Preview")}}</h2>
@@ -21,7 +18,10 @@
        data-module-user_id="{{ g.user }}"
        data-module-feature_key="opt_in_features__pd_datatables"
        data-module-page_redirect="#prtable"
-       data-module-label="{{ _('A new table experience is now available! Try the updated interface and share your %(feedback)s to help shape future improvements.', feedback=feedback_link) }}"
+       data-module-label="{{ _(
+            "A new table experience is now available! Try the updated interface and share your <a href='mailto:%(email)s'>feedback</a> to help shape future improvements.",
+            email=h.support_email_address()
+        ) }}"
        data-module-button_label="{{ _('Enable new table interface') }}"></div>
   <table id="dtprv" class="table table-striped" data-role="table" data-mode="columntoggle" >
     <thead>

--- a/ckanext/canada/templates/snippets/pd_datatable_depr.html
+++ b/ckanext/canada/templates/snippets/pd_datatable_depr.html
@@ -9,7 +9,9 @@
 {% for _res_name, _fkeys in foreign_keys.items() %}
   {% do fk_links.update({_res_name: h.url_for('recombinant.preview_table', resource_name=_res_name, owner_org=owner_org)}) %}
 {% endfor  %}
-{% set feedback_link = '<a href="mailto:' ~ h.support_email_address() ~ '">feedback</a>' %}
+{% set feedback_link %}
+  <a href="mailto:{{ h.support_email_address() }}">{{ _('feedback') }}</a>
+{% endset %}
 
 <section id="dt-preview">
   <h2 id="prtable">{{_("Preview")}}</h2>

--- a/ckanext/canada/templates/snippets/pd_datatable_depr.html
+++ b/ckanext/canada/templates/snippets/pd_datatable_depr.html
@@ -12,6 +12,14 @@
 
 <section id="dt-preview">
   <h2 id="prtable">{{_("Preview")}}</h2>
+  <div data-module="canada-user-opt-in-feature"
+       data-module-csrf_name="{{- g.csrf_field_name -}}"
+       data-module-csrf_value="{{- csrf_token() -}}"
+       data-module-user_id="{{ g.user }}"
+       data-module-feature_key="opt_in_features__pd_datatables"
+       data-module-page_redirect="#prtable"
+       data-module-label="{{ _('A new table experience is now available! Try the updated interface and share your feedback to help shape future improvements.') }}"
+       data-module-button_label="{{ _('Enable new table interface') }}"></div>
   <table id="dtprv" class="table table-striped" data-role="table" data-mode="columntoggle" >
     <thead>
       <tr class="font-small">

--- a/ckanext/canada/templates/snippets/pd_datatable_depr.html
+++ b/ckanext/canada/templates/snippets/pd_datatable_depr.html
@@ -9,6 +9,7 @@
 {% for _res_name, _fkeys in foreign_keys.items() %}
   {% do fk_links.update({_res_name: h.url_for('recombinant.preview_table', resource_name=_res_name, owner_org=owner_org)}) %}
 {% endfor  %}
+{% set feedback_link = '<a href="mailto:' ~ h.support_email_address() ~ '">feedback</a>' %}
 
 <section id="dt-preview">
   <h2 id="prtable">{{_("Preview")}}</h2>
@@ -18,7 +19,7 @@
        data-module-user_id="{{ g.user }}"
        data-module-feature_key="opt_in_features__pd_datatables"
        data-module-page_redirect="#prtable"
-       data-module-label="{{ _('A new table experience is now available! Try the updated interface and share your feedback to help shape future improvements.') }}"
+       data-module-label="{{ _('A new table experience is now available! Try the updated interface and share your %(feedback)s to help shape future improvements.', feedback=feedback_link) }}"
        data-module-button_label="{{ _('Enable new table interface') }}"></div>
   <table id="dtprv" class="table table-striped" data-role="table" data-mode="columntoggle" >
     <thead>


### PR DESCRIPTION
feat(dev): opt-in js module;

- Added in opt-in feature JS module.
- Added opt-in for new datatables key to user schema.

@wardi I did it with user plugin_extras instead of simple cookie cuz I feel like users might have troubles with cookies. And this way, we can do some other future things with opt-in features fairly easily.