### PR TITLE
Persistant User plugin_extras & Test Coverage

### DIFF
--- a/.github/test-dependencies.json
+++ b/.github/test-dependencies.json
@@ -1,0 +1,24 @@
+{
+  "repositories": {
+    "ckan": {
+      "branches": {
+        "master": "canada-v2.10",
+        "dev": "canada-dev",
+        "staging": "canada-staging",
+        "feature/*": "canada-staging",
+        "fix/*": "canada-staging",
+        "*": "canada-staging"
+      }
+    },
+    "ckanext-xloader": {
+      "branches": {
+        "master": "canada-v2.10",
+        "dev": "canada-staging",
+        "staging": "canada-staging",
+        "feature/*": "canada-staging",
+        "fix/*": "canada-staging",
+        "*": "canada-staging"
+      }
+    }
+  }
+}

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -37,7 +37,7 @@ jobs:
                 if [[ "${reslog}" == "" ]]; then
                     printf "\n${srcName}: Up to date. Skipping..."
                 else
-                    git pull || true;
+                    git pull --ff-only || true;
                     printf "\n${srcName}: Pulled updated code. Re-initializing in python environment..."
                     cd /srv/app;
                     if [[ -f "$dir/requirements.txt" ]]; then
@@ -67,7 +67,7 @@ jobs:
             git checkout -b ${{ github.head_ref || github.ref_name }} origin/${{ github.head_ref || github.ref_name }}
           fi;
           git fetch
-          git pull
+          git pull --ff-only || true
           source /srv/app/venv/bin/activate
           pip install -e .
           pip install -r requirements.txt

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -135,53 +135,120 @@ jobs:
           touch /srv/app/junit/result/test-summary.md
       - name: Check Source Dependency Versions
         run: |
+          cd /srv/app/src/ckanext-canada
+          BRANCH="${{ github.head_ref || github.ref_name }}"
+          git fetch origin
+          if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+            git checkout "$BRANCH"
+          else
+            git checkout -b "$BRANCH" "origin/$BRANCH"
+          fi
+          git fetch
+          git pull --ff-only || true
+          CONFIG="/srv/app/src/ckanext-canada/.github/test-dependencies.json";
+          cd /srv/app;
           source /srv/app/venv/bin/activate
+          CURRENT_BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}";
           for dir in /srv/app/src/*; do
             srcName=$(echo "$dir" | awk -F'/' '{print $NF}');
             if [[ -d "$dir/.git"  ]]; then
-                printf "\n${srcName}: Checking for updates..."
-                cd $dir;
+              DO_PIP_REINSTALL='false';
+              printf "\n${srcName}: Checking for updates..."
+              cd $dir;
+              if jq -e --arg name "$srcName" '.repositories | has($name)' "$CONFIG" > /dev/null; then
+                printf "\n    ${srcName}: Checking configuration from ${CONFIG}..."
+                current_branch=$(
+                  jq -r \
+                    --arg repo "$srcName" \
+                    --arg current "$CURRENT_BRANCH" \
+                    '
+                    .repositories[$repo].branches as $b
+                    | $b[$current]
+                      // (if $current | startswith("feature/") then $b["feature/*"] else null end)
+                      // (if $current | startswith("fix/") then $b["fix/*"] else null end)
+                      // $b["*"]
+                    ' \
+                    "$CONFIG"
+                  );
+                printf "\n    ${srcName}: ${CURRENT_BRANCH} configured to use branch ${current_branch}...";
+                DO_PIP_REINSTALL='true';
+              else
+                printf "\n    ${srcName}: Using default/current branch..."
                 current_branch=$(git rev-parse --abbrev-ref HEAD);
-                if [[ "$srcName" == "ckan" ]]; then
-                    git fetch canada;
-                    reslog=$(git log HEAD..canada/$current_branch --oneline);
+                printf "\n    ${srcName}: using branch ${current_branch}...";
+              fi;
+              if [[ -z "$current_branch" || "$current_branch" == "null" ]]; then
+                current_branch=$(git rev-parse --abbrev-ref HEAD);
+                printf "\n    ${srcName}: unable to determine branch using current branch ${current_branch}..."
+              fi
+              if [[ "$srcName" == "ckan" ]]; then
+                git fetch canada;
+                if git show-ref --verify --quiet "refs/heads/$current_branch"; then
+                  git checkout "$current_branch"
                 else
-                    git fetch origin;
-                    reslog=$(git log HEAD..origin/$current_branch --oneline);
-                fi;
-                if [[ "${reslog}" == "" ]]; then
-                    printf "\n${srcName}: Up to date. Skipping..."
+                  git checkout -B "$current_branch" "canada/$current_branch"
+                fi
+                git fetch
+                git pull --ff-only || true
+                reslog=$(git log HEAD..canada/$current_branch --oneline);
+              else
+                git fetch origin;
+                if git show-ref --verify --quiet "refs/heads/$current_branch"; then
+                  git checkout "$current_branch"
                 else
-                    git pull || true;
-                    printf "\n${srcName}: Pulled updated code. Re-initializing in python environment..."
-                    cd /srv/app;
-                    if [[ -f "$dir/requirements.txt" ]]; then
-                        pip install -r $dir/requirements.txt || true;
-                    fi;
-                    if [[ -f "$dir/dev-requirements.txt" ]]; then
-                        pip install -r $dir/dev-requirements.txt || true;
-                    fi;
-                    if [[ -f "$dir/test-requirements.txt" ]]; then
-                        pip install -r $dir/test-requirements.txt || true;
-                    fi;
-                    if [[ -f "$dir/setup.py" ]]; then
-                        python $dir/setup.py develop || true;
-                    fi;
+                  git checkout -B "$current_branch" "origin/$current_branch"
+                fi
+                git fetch
+                git pull --ff-only || true
+                reslog=$(git log HEAD..origin/$current_branch --oneline);
+              fi;
+              printf "\n    ${srcName}: git info\n";
+              printf "\n";
+              git branch --show-current;
+              printf "\n";
+              git rev-parse HEAD;
+              printf "\n";
+              git log -1 --oneline;
+              printf "\n";
+              printf "\n    ${srcName}: pip info\n";
+              pip show ${srcName};
+              if [[ "${reslog}" == "" && "${DO_PIP_REINSTALL}" == "false" ]]; then
+                  printf "${srcName}: Up to date. Skipping..."
+              else
+                git pull --ff-only || true;
+                printf "\n${srcName}: Pulled updated code. Re-initializing in python environment..."
+                cd /srv/app;
+                if [[ -f "$dir/requirements.txt" ]]; then
+                  pip install -r $dir/requirements.txt || true;
                 fi;
+                if [[ -f "$dir/dev-requirements.txt" ]]; then
+                  pip install -r $dir/dev-requirements.txt || true;
+                fi;
+                if [[ -f "$dir/test-requirements.txt" ]]; then
+                  pip install -r $dir/test-requirements.txt || true;
+                fi;
+                if [[ -f "$dir/setup.py" ]]; then
+                  python $dir/setup.py develop || true;
+                fi;
+              fi;
             else
-                printf "\n${srcName}: Not a source repository. Skipping..."
+              printf "\n${srcName}: Not a source repository. Skipping..."
             fi;
+            printf "\n\n";
           done;
           cd /srv/app;
       - name: Checkout Repository (${{ github.head_ref || github.ref_name }})
         run: |
           cd /srv/app/src/ckanext-canada
+          BRANCH="${{ github.head_ref || github.ref_name }}"
           git fetch origin
-          if [[ "${{ github.head_ref || github.ref_name }}" != "master" ]]; then
-            git checkout -b ${{ github.head_ref || github.ref_name }} origin/${{ github.head_ref || github.ref_name }}
-          fi;
+          if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+            git checkout "$BRANCH"
+          else
+            git checkout -b "$BRANCH" "origin/$BRANCH"
+          fi
           git fetch
-          git pull
+          git pull --ff-only || true
           source /srv/app/venv/bin/activate
           pip install -e .
           pip install -r requirements.txt
@@ -196,10 +263,12 @@ jobs:
       - name: Setup Databases
         run: |
           source /srv/app/venv/bin/activate
-          . /srv/app/src/ckanext-canada/links/ckan/bin/postgres_init/1_create_ckan_db.sh
-          . /srv/app/src/ckanext-canada/links/ckan/bin/postgres_init/2_create_ckan_datastore_db.sh
+          . /srv/app/src/ckan/bin/postgres_init/1_create_ckan_db.sh
+          . /srv/app/src/ckan/bin/postgres_init/2_create_ckan_datastore_db.sh
           ckan -c /srv/app/src/ckanext-canada/test-core.ini db init
           ckan -c /srv/app/src/ckanext-canada/test-core.ini datastore set-permissions | psql -U postgres --set ON_ERROR_STOP=1
+          ckan -c /srv/app/src/ckanext-canada/test-core.ini validation init-db
+          ckan -c /srv/app/src/ckanext-canada/test-core.ini security migrate
           ckan -c /srv/app/src/ckanext-canada/test-core.ini canada update-triggers
           ckan -c /srv/app/src/ckanext-canada/test-core.ini recombinant create-triggers -a
           ckan -c /srv/app/src/ckanext-canada/test-core.ini db upgrade

--- a/changes/1689.bugfix
+++ b/changes/1689.bugfix
@@ -1,0 +1,1 @@
+Fixed an issue with non-persistant custom User settings. Added test coverage for custom User settings.

--- a/ckanext/canada/logic.py
+++ b/ckanext/canada/logic.py
@@ -781,7 +781,9 @@ def canada_user_update(up_func: Action,
     user_obj = model.User.get(id)
     if user_obj is None:
         raise ObjectNotFound('User was not found.')
-    context['user_obj'] = user_obj
+
+    # fresh context copy
+    context = cast(Context, dict(context, user_obj=user_obj))
     extras = context['user_obj'].plugin_extras or {}
 
     # get custom validators for custom fields
@@ -813,8 +815,8 @@ def canada_user_update(up_func: Action,
         data['opt_in_features__pd_datatables'] = extras.get(
             'opt_in_features__pd_datatables', False)
 
-    if 'plugin_extras' not in data_dict:
-        data_dict['plugin_extras'] = {}
+    # always use current("before") extras to prevent arbitrary key/values
+    data_dict['plugin_extras'] = extras
 
     # add our validated values to plugin_extras for core to save
     data_dict['plugin_extras']['opt_in_features__pd_datatables'] = \

--- a/ckanext/canada/logic.py
+++ b/ckanext/canada/logic.py
@@ -4,7 +4,6 @@ from ckan.types import Context, DataDict, Action, ChainedAction, Schema, ErrorDi
 from ckan.logic.validators import isodate, Invalid
 from ckan import model
 from ckanext.activity.model import Activity, activity
-from ckan.logic import get_or_bust
 from ckan.logic.schema import (
     default_create_resource_view_schema_filtered,
     default_update_resource_view_schema_changes,

--- a/ckanext/canada/logic.py
+++ b/ckanext/canada/logic.py
@@ -4,6 +4,7 @@ from ckan.types import Context, DataDict, Action, ChainedAction, Schema, ErrorDi
 from ckan.logic.validators import isodate, Invalid
 from ckan import model
 from ckanext.activity.model import Activity, activity
+from ckan.logic import get_or_bust
 from ckan.logic.schema import (
     default_create_resource_view_schema_filtered,
     default_update_resource_view_schema_changes,
@@ -773,41 +774,64 @@ def canada_user_update(up_func: Action,
                        data_dict: DataDict) -> ChainedAction:
     """
     Add new fields to the User schema.
+
+    - opt_in_features__pd_datatables
     """
+    # get user object as we need existing plugin_extras
+    id = get_or_bust(data_dict, 'id')
+    user_obj = model.User.get(id)
+    if user_obj is None:
+        raise ObjectNotFound('User was not found.')
+    context['user_obj'] = user_obj
+    extras = context['user_obj'].plugin_extras or {}
+
+    # get custom validators for custom fields
     bool_validator = get_validator('boolean_validator')
-    default_validator = get_validator('default')
     ignore_missing_validator = get_validator('ignore_missing')
+
+    # use passed data_dict values, defaulting to existing user settings,
+    # then defaulting to our default values. This is done so the
+    # ignore_missing and ignore_not_sysadmin validators can stop the chain.
     custom_data_dict = {
         'opt_in_features__pd_datatables': data_dict.get(
-            'opt_in_features__pd_datatables', None)
+            'opt_in_features__pd_datatables', extras.get(
+                'opt_in_features__pd_datatables', False))
     }
     schema = {
         'opt_in_features__pd_datatables': [
             ignore_missing_validator,
-            # type_ignore_reason: incomplete typing
-            default_validator(False),  # type: ignore
             bool_validator,
         ]
     }
+    # validate the custom fields
     data, errors = validate(custom_data_dict, schema, context)
     if errors:
         model.Session.rollback()
         raise ValidationError(errors)
+
     if 'opt_in_features__pd_datatables' not in data:
-        return up_func(context, data_dict)
+        # use existing or default value
+        data['opt_in_features__pd_datatables'] = extras.get(
+            'opt_in_features__pd_datatables', False)
+
     if 'plugin_extras' not in data_dict:
         data_dict['plugin_extras'] = {}
+
+    # add our validated values to plugin_extras for core to save
     data_dict['plugin_extras']['opt_in_features__pd_datatables'] = \
         data['opt_in_features__pd_datatables']
-    user_update_schema = default_update_user_schema()
+
+    if 'schema' not in context:
+        context['schema'] = default_update_user_schema()
     # remove ignore_not_sysadmin validator from plugin_extras
-    user_update_schema['plugin_extras'] = [get_validator('json_object')]
-    up_context = cast(Context, dict(context, schema=user_update_schema))
-    response = up_func(up_context, data_dict)
-    extras = up_context['user_obj'].plugin_extras or {}
-    response['opt_in_features__pd_datatables'] = extras.get(
+    context['schema']['plugin_extras'] = [get_validator('json_object')]
+    user_dict = up_func(context, data_dict)
+    extras = context['user_obj'].plugin_extras or {}
+
+    user_dict['opt_in_features__pd_datatables'] = extras.get(
         'opt_in_features__pd_datatables', False)
-    return response
+
+    return user_dict
 
 
 @chained_action
@@ -817,6 +841,8 @@ def canada_user_show(up_func: Action,
                      data_dict: DataDict) -> ChainedAction:
     """
     Return new fields in the User dictionary.
+
+    - opt_in_features__pd_datatables
     """
     user_dict = up_func(context, data_dict)
     extras = context['user_obj'].plugin_extras or {}

--- a/ckanext/canada/tests/test_users.py
+++ b/ckanext/canada/tests/test_users.py
@@ -29,8 +29,10 @@ class TestUserSchema(CanadaTestBase):
         """
         Users cannot change their usernames.
         """
+        username = make_uuid()
+
         user_dict = self.sysadmin_action.user_create(
-            email='example@example.com', name='example', password=make_uuid())
+            email='example+%s@example.com' % username, name=username, password=make_uuid())
 
         with pytest.raises(ValidationError) as ve:
             user_dict = self.sysadmin_action.user_patch(
@@ -52,8 +54,10 @@ class TestUserSchema(CanadaTestBase):
         """
         Custom plugin_extras and Schema should work as expected.
         """
+        username = make_uuid()
+
         user_dict = self.sysadmin_action.user_create(
-            email='example@example.com', name='example', password=make_uuid())
+            email='example+%s@example.com' % username, name=username, password=make_uuid())
 
         assert 'opt_in_features__pd_datatables' not in user_dict
 
@@ -82,3 +86,17 @@ class TestUserSchema(CanadaTestBase):
             id=user_id, fullname='Updated Name')
 
         assert user_dict['opt_in_features__pd_datatables'] is False
+
+        # adding arbitrary key/values is not allowed
+        user_dict = self.normal_action.user_patch(
+            id=user_id, plugin_extras={'this': 'that'})
+
+        assert user_dict['opt_in_features__pd_datatables'] is False
+        assert 'this' not in user_dict
+
+        user_dict = self.sysadmin_action.user_patch(
+            id=user_id, plugin_extras={'this': 'that'})
+
+        assert user_dict['opt_in_features__pd_datatables'] is False
+        assert 'this' not in user_dict
+        assert 'this' not in user_dict['plugin_extras']

--- a/ckanext/canada/tests/test_users.py
+++ b/ckanext/canada/tests/test_users.py
@@ -62,23 +62,23 @@ class TestUserSchema(CanadaTestBase):
         # user_show should fill in defaults
         user_dict = self.sysadmin_action.user_show(id=user_id)
 
-        assert user_dict['opt_in_features__pd_datatables'] == False
+        assert user_dict['opt_in_features__pd_datatables'] is False
 
         user_dict = self.sysadmin_action.user_patch(
             id=user_id,
             opt_in_features__pd_datatables=True)
 
-        assert user_dict['opt_in_features__pd_datatables'] == True
-        assert user_dict['plugin_extras']['opt_in_features__pd_datatables'] == True
+        assert user_dict['opt_in_features__pd_datatables'] is True
+        assert user_dict['plugin_extras']['opt_in_features__pd_datatables'] is True
 
         # own user should be able to update opt_in_features
         user_dict = self.normal_action.user_patch(
             id=user_id, opt_in_features__pd_datatables=False)
 
-        assert user_dict['opt_in_features__pd_datatables'] == False
+        assert user_dict['opt_in_features__pd_datatables'] is False
 
         # excluding custom fields should not change their values
         user_dict = self.normal_action.user_patch(
             id=user_id, fullname='Updated Name')
 
-        assert user_dict['opt_in_features__pd_datatables'] == False
+        assert user_dict['opt_in_features__pd_datatables'] is False

--- a/ckanext/canada/tests/test_users.py
+++ b/ckanext/canada/tests/test_users.py
@@ -1,0 +1,84 @@
+# -*- coding: UTF-8 -*-
+import pytest
+
+from ckanext.canada.tests import CanadaTestBase
+from ckan.tests.factories import Sysadmin
+from ckanext.canada.tests.factories import CanadaUser as User
+
+from ckanapi import LocalCKAN, ValidationError
+from ckan.model.types import make_uuid
+
+
+class TestUserSchema(CanadaTestBase):
+    @classmethod
+    def setup_class(self):
+        """Method is called at class level once the class is instatiated.
+        Setup any state specific to the execution of the given class.
+        """
+        super(TestUserSchema, self).setup_class()
+
+        self.sysadmin_user = Sysadmin()
+        self.normal_user = User()
+
+        self.sysadmin_action = LocalCKAN(
+            username=self.sysadmin_user['name']).action
+        self.normal_action = LocalCKAN(
+            username=self.normal_user['name']).action
+
+    def test_user_name_change(self):
+        """
+        Users cannot change their usernames.
+        """
+        user_dict = self.sysadmin_action.user_create(
+            email='example@example.com', name='example', password=make_uuid())
+
+        with pytest.raises(ValidationError) as ve:
+            user_dict = self.sysadmin_action.user_patch(
+                id=user_dict['id'], name='example_updated')
+        err = ve.value.error_dict
+
+        assert 'name' in err
+        assert err['name'] == ['That login name can not be modified.']
+
+        with pytest.raises(ValidationError) as ve:
+            user_dict = self.normal_action.user_patch(
+                id=self.normal_user['name'], name='example_updated')
+        err = ve.value.error_dict
+
+        assert 'name' in err
+        assert err['name'] == ['That login name can not be modified.']
+
+    def test_user_extras(self):
+        """
+        Custom plugin_extras and Schema should work as expected.
+        """
+        user_dict = self.sysadmin_action.user_create(
+            email='example@example.com', name='example', password=make_uuid())
+
+        assert 'opt_in_features__pd_datatables' not in user_dict
+
+        user_id = self.normal_user['id']
+
+        # user_show should fill in defaults
+        user_dict = self.sysadmin_action.user_show(id=user_id)
+
+        assert user_dict['opt_in_features__pd_datatables'] == False
+
+        user_dict = self.sysadmin_action.user_patch(
+            id=user_id,
+            opt_in_features__pd_datatables=True)
+
+        assert user_dict['opt_in_features__pd_datatables'] == True
+        assert user_dict['plugin_extras']['opt_in_features__pd_datatables'] == True
+
+        # own user should be able to update opt_in_features
+        user_dict = self.normal_action.user_patch(
+            id=user_id, opt_in_features__pd_datatables=False)
+
+        assert user_dict['opt_in_features__pd_datatables'] == False
+
+        # excluding custom fields should not change their values
+        user_dict = self.normal_action.user_patch(
+            id=user_id, fullname='Updated Name')
+
+        assert user_dict['opt_in_features__pd_datatables'] == False

--- a/test-core.ini
+++ b/test-core.ini
@@ -12,7 +12,7 @@ host = 0.0.0.0
 port = 5000
 
 [app:main]
-use = config:links/test-core.ini
+use = config:/srv/app/src/ckan/test-core.ini
 
 # debug & testing false required for Flask Middleware error handling
 debug = false
@@ -25,6 +25,16 @@ who.timeout = -1
 
 wet_theme.url = /theme-gcweb/themes-dist-4.0.9-gcweb
 wet_theme.geo_map_type = dynamic
+
+ckan.locale_default = en
+ckan.locales_offered = en fr
+
+## Database Settings
+# see .github/workflows/pytest.yml:jobs.pytest.services.postgres
+sqlalchemy.url = postgresql://ckan_default:pass@postgres:5432/ckan_test
+ckan.datastore.write_url = postgresql://datastore_write:pass@postgres:5432/datastore_test
+ckan.datastore.read_url = postgresql://datastore_read:pass@postgres:5432/datastore_test
+ckanext.xloader.jobs_db.uri = postgresql://ckan_default:pass@postgres:5432/ckan_test
 
 recombinant.definitions = ckanext.canada:tables/ati.yaml
                           ckanext.canada:tables/briefingt.yaml
@@ -56,12 +66,29 @@ scheming.presets = ckanext.scheming:presets.json
     ckanext.validation:presets.json
 scheming.organization_schemas = ckanext.canada:schemas/organization.yaml
 
-ckan.plugins = canada_theme activity validation canada_forms canada_internal canada_public
-    recombinant datastore canada_datasets scheming_organizations fluent
-    canada_security image_view recline_view
+ckan.plugins = canada_theme
+               activity
+               validation
+               canada_forms
+               canada_internal
+               canada_public
+               recombinant
+               datastore
+               canada_datasets
+               scheming_organizations
+               fluent
+               canada_security
+               image_view
+
+ckan.site_url = http://registry-test.ckan.net
+
+ckan.feeds.authority_name = http://registry-test.ckan.net
+ckan.feeds.date = 2014-01-01
+ckan.feeds.author_name = Open Gov Canada
+ckan.feeds.author_link = http://registry-test.ckan.net
 
 # no default views for tests...
-# ckan.views.default_views = []
+ckan.views.default_views = []
 
 # we have tests for web user registration form
 ckan.auth.create_user_via_web = true
@@ -78,8 +105,6 @@ ckanext.security.nzism_compliant_passwords = False
 ckan.site_logo = /img/logo_64px_wide.png
 ckan.favicon = /images/icons/ckan.ico
 ckan.gravatar_default = identicon
-
-ckan.site_url = http://registry-test.ckan.net
 
 licenses_group_url = file://%(here)s/ckanext/canada/public/static/licenses.json
 ckan.legacy_templates = no


### PR DESCRIPTION
feat(tests): coverage;

- User schema test coverage;
- Fix user schema for custom extra fields.

This code makes more sense when there are more user fields like in the single-instance and staging branches. As fields are omitted across the site in the data_dict

EDIT: just more explanation... so for instance the 'default_publish_visibility' for the combined instance only displays for sysadmin users in the Webform. So if a normal user changes their name, email, or bio, then that field would not get POSTed to the action endpoint and thus would be removed/default validator'd into the plugin_extras. Because we are kind of just piggy-backing off of the plugin_extras core field here, so we don't have to actually make DB Model for our custom user fields. Similarly, the user_opt_in_feature__ fields are only POSTed via the JS Module, so if a user updated their bio in the webform, it would remove/default validator this plugin extra too. So just had to add some extra code in here to fix that. Also, there is a check for if schema is in the context now, as the ckanext-security extension also extends the schema. 