### PR TITLE
Resource Descriptions

### DIFF
--- a/changes/1699.feature
+++ b/changes/1699.feature
@@ -1,0 +1,1 @@
+Resource `description` field has now been added to our Schemas and webforms. Form fields display in a new "Semantic Metadata Fields for Resources" accordion section in the Resource webform.

--- a/ckanext/canada/i18n/ckanext-canada.pot
+++ b/ckanext/canada/i18n/ckanext-canada.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-canada 0.4.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-30 12:36+0000\n"
+"POT-Creation-Date: 2026-08-05 15:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3152,6 +3152,7 @@ msgstr ""
 
 #: ckanext/canada/templates/package/read.html:51
 #: ckanext/canada/templates/package/read.html:116
+#: ckanext/canada/templates/package/resource_read.html:70
 #: ckanext/canada/templates/scheming/display_snippets/fluent_tags.html:8
 #: ckanext/canada/templates/snippets/package_item.html:27
 #: ckanext/canada/templates/snippets/package_item.html:43
@@ -3398,28 +3399,28 @@ msgstr ""
 msgid "Resource data has failed to load to the DataStore."
 msgstr ""
 
-#: ckanext/canada/templates/package/resource_read.html:78
+#: ckanext/canada/templates/package/resource_read.html:87
 msgid "List of downloadable formats"
 msgstr ""
 
-#: ckanext/canada/templates/package/resource_read.html:80
+#: ckanext/canada/templates/package/resource_read.html:89
 #: ckanext/canada/templates/package/snippets/resource_item.html:89
 msgid "Download"
 msgstr ""
 
-#: ckanext/canada/templates/package/resource_read.html:88
+#: ckanext/canada/templates/package/resource_read.html:97
 msgid "CSV type files"
 msgstr ""
 
-#: ckanext/canada/templates/package/resource_read.html:95
+#: ckanext/canada/templates/package/resource_read.html:104
 msgid "TSV type files"
 msgstr ""
 
-#: ckanext/canada/templates/package/resource_read.html:102
+#: ckanext/canada/templates/package/resource_read.html:111
 msgid "JSON type files"
 msgstr ""
 
-#: ckanext/canada/templates/package/resource_read.html:109
+#: ckanext/canada/templates/package/resource_read.html:118
 msgid "XML type files"
 msgstr ""
 
@@ -3946,6 +3947,10 @@ msgid "Metadata Fields for Resources"
 msgstr ""
 
 #: ckanext/canada/templates/scheming/package/snippets/resource_form.html:41
+msgid "Semantic Metadata Fields for Resources"
+msgstr ""
+
+#: ckanext/canada/templates/scheming/package/snippets/resource_form.html:53
 msgid "Metadata Fields for Resource Relationships"
 msgstr ""
 

--- a/ckanext/canada/i18n/en/LC_MESSAGES/ckanext-canada.po
+++ b/ckanext/canada/i18n/en/LC_MESSAGES/ckanext-canada.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  CKAN\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-30 12:36+0000\n"
+"POT-Creation-Date: 2026-08-05 15:44+0000\n"
 "PO-Revision-Date: 2014-01-23 13:04+0000\n"
 "Last-Translator: Sean Hammond <sean.hammond@okfn.org>\n"
 "Language: en\n"
@@ -3208,6 +3208,7 @@ msgstr ""
 
 #: ckanext/canada/templates/package/read.html:51
 #: ckanext/canada/templates/package/read.html:116
+#: ckanext/canada/templates/package/resource_read.html:70
 #: ckanext/canada/templates/scheming/display_snippets/fluent_tags.html:8
 #: ckanext/canada/templates/snippets/package_item.html:27
 #: ckanext/canada/templates/snippets/package_item.html:43
@@ -3456,28 +3457,28 @@ msgstr ""
 msgid "Resource data has failed to load to the DataStore."
 msgstr ""
 
-#: ckanext/canada/templates/package/resource_read.html:78
+#: ckanext/canada/templates/package/resource_read.html:87
 msgid "List of downloadable formats"
 msgstr ""
 
-#: ckanext/canada/templates/package/resource_read.html:80
+#: ckanext/canada/templates/package/resource_read.html:89
 #: ckanext/canada/templates/package/snippets/resource_item.html:89
 msgid "Download"
 msgstr ""
 
-#: ckanext/canada/templates/package/resource_read.html:88
+#: ckanext/canada/templates/package/resource_read.html:97
 msgid "CSV type files"
 msgstr ""
 
-#: ckanext/canada/templates/package/resource_read.html:95
+#: ckanext/canada/templates/package/resource_read.html:104
 msgid "TSV type files"
 msgstr ""
 
-#: ckanext/canada/templates/package/resource_read.html:102
+#: ckanext/canada/templates/package/resource_read.html:111
 msgid "JSON type files"
 msgstr ""
 
-#: ckanext/canada/templates/package/resource_read.html:109
+#: ckanext/canada/templates/package/resource_read.html:118
 msgid "XML type files"
 msgstr ""
 
@@ -4012,6 +4013,10 @@ msgid "Metadata Fields for Resources"
 msgstr ""
 
 #: ckanext/canada/templates/scheming/package/snippets/resource_form.html:41
+msgid "Semantic Metadata Fields for Resources"
+msgstr ""
+
+#: ckanext/canada/templates/scheming/package/snippets/resource_form.html:53
 msgid "Metadata Fields for Resource Relationships"
 msgstr ""
 

--- a/ckanext/canada/i18n/fr/LC_MESSAGES/ckanext-canada.po
+++ b/ckanext/canada/i18n/fr/LC_MESSAGES/ckanext-canada.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-30 12:36+0000\n"
+"POT-Creation-Date: 2026-08-05 15:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr\n"
@@ -2022,8 +2022,8 @@ msgid ""
 "\"Agreement Value\" must be zero or greater for agreements starting on or"
 " after May 1, 2026"
 msgstr ""
-"La « valeur de l'entente » doit être supérieur ou égal à "
-"0 pour les accords qui commencent le 1er mai 2026 ou après"
+"La « valeur de l'entente » doit être supérieur ou égal à 0 pour les "
+"accords qui commencent le 1er mai 2026 ou après"
 
 #. Resource Title for PD Type: grants
 #: ckanext/canada/tables/grants.yaml:1370
@@ -3634,6 +3634,7 @@ msgstr ""
 
 #: ckanext/canada/templates/package/read.html:51
 #: ckanext/canada/templates/package/read.html:116
+#: ckanext/canada/templates/package/resource_read.html:70
 #: ckanext/canada/templates/scheming/display_snippets/fluent_tags.html:8
 #: ckanext/canada/templates/snippets/package_item.html:27
 #: ckanext/canada/templates/snippets/package_item.html:43
@@ -3904,28 +3905,28 @@ msgstr "Voir le rapport"
 msgid "Resource data has failed to load to the DataStore."
 msgstr "Les données de ressource n'ont pas pu être chargées dans le DataStore."
 
-#: ckanext/canada/templates/package/resource_read.html:78
+#: ckanext/canada/templates/package/resource_read.html:87
 msgid "List of downloadable formats"
 msgstr "Liste des formats téléchargeables"
 
-#: ckanext/canada/templates/package/resource_read.html:80
+#: ckanext/canada/templates/package/resource_read.html:89
 #: ckanext/canada/templates/package/snippets/resource_item.html:89
 msgid "Download"
 msgstr "Télécharger"
 
-#: ckanext/canada/templates/package/resource_read.html:88
+#: ckanext/canada/templates/package/resource_read.html:97
 msgid "CSV type files"
 msgstr ""
 
-#: ckanext/canada/templates/package/resource_read.html:95
+#: ckanext/canada/templates/package/resource_read.html:104
 msgid "TSV type files"
 msgstr ""
 
-#: ckanext/canada/templates/package/resource_read.html:102
+#: ckanext/canada/templates/package/resource_read.html:111
 msgid "JSON type files"
 msgstr ""
 
-#: ckanext/canada/templates/package/resource_read.html:109
+#: ckanext/canada/templates/package/resource_read.html:118
 msgid "XML type files"
 msgstr ""
 
@@ -4500,6 +4501,10 @@ msgid "Metadata Fields for Resources"
 msgstr "Champs de métadonnées pour les ressources"
 
 #: ckanext/canada/templates/scheming/package/snippets/resource_form.html:41
+msgid "Semantic Metadata Fields for Resources"
+msgstr "Champs de métadonnées sémantiques pour les ressources"
+
+#: ckanext/canada/templates/scheming/package/snippets/resource_form.html:53
 msgid "Metadata Fields for Resource Relationships"
 msgstr "Champs de métadonnées pour les relations entre ressources"
 

--- a/ckanext/canada/schemas/dataset.pages.yaml
+++ b/ckanext/canada/schemas/dataset.pages.yaml
@@ -484,6 +484,7 @@ resource_fields:
 - preset: canada_resource_format
 - preset: canada_resource_language
 - preset: canada_resource_url
+- preset: canada_resource_description
 - preset: canada_resource_data_quality
 
 # Validation Fields.

--- a/ckanext/canada/schemas/dataset.yaml
+++ b/ckanext/canada/schemas/dataset.yaml
@@ -484,6 +484,7 @@ resource_fields:
 - preset: canada_resource_format
 - preset: canada_resource_language
 - preset: canada_resource_url
+- preset: canada_resource_description
 - preset: canada_resource_data_quality
 
 # Validation Fields.

--- a/ckanext/canada/schemas/doc.yaml
+++ b/ckanext/canada/schemas/doc.yaml
@@ -60,3 +60,4 @@ resource_fields:
 - preset: canada_resource_format
 - preset: canada_resource_language
 - preset: canada_resource_url
+- preset: canada_resource_description

--- a/ckanext/canada/schemas/info.pages.yaml
+++ b/ckanext/canada/schemas/info.pages.yaml
@@ -551,6 +551,7 @@ resource_fields:
 # Field = Location.
 # {The location for online access to the distribution of the resource, if the file resides elsewhere.}
 - preset: canada_resource_url
+- preset: canada_resource_description
 
 # Validation Fields.
 - preset: canada_resource_validation_schema

--- a/ckanext/canada/schemas/info.yaml
+++ b/ckanext/canada/schemas/info.yaml
@@ -551,6 +551,7 @@ resource_fields:
 # Field = Location.
 # {The location for online access to the distribution of the resource, if the file resides elsewhere.}
 - preset: canada_resource_url
+- preset: canada_resource_description
 
 # Validation Fields.
 - preset: canada_resource_validation_schema

--- a/ckanext/canada/schemas/presets.pages.yaml
+++ b/ckanext/canada/schemas/presets.pages.yaml
@@ -2691,6 +2691,41 @@ presets:
       size: 60
       class: form-control
 
+# Field = Description English.
+# {An English description given to the resource}
+# Field = Description French.
+# {A French description given to the resource}
+- preset_name: canada_resource_description
+  values:
+    field_name: description_translated
+    label:
+      en: Description
+      fr: Description
+    fluent_form_label:
+      en:
+        en: "Description (English)"
+        fr: "Description (anglais)"
+      fr:
+        en: "Description (French)"
+        fr: "Description (français)"
+    fluent_help_text:
+      en:
+        en: "An account of the resource, in English. A description may include but is not limited to: an abstract, a table of contents, or a free-text account of the resource."
+        fr: "Description du ressource, en anglais. La description peut comprendre un résumé, une table des matières ou un texte libre."
+      fr:
+        en: "An account of the resource, in French. A description may include but is not limited to: an abstract, a table of contents, or a free-text account of the resource."
+        fr: "Description du ressource, en anglais. La description peut comprendre un résumé, une table des matières ou un texte libre."
+    required: false
+    form_panel: descriptive
+    # copied from fluent_markdown preset
+    form_snippet: fluent_markdown.html
+    display_snippet: fluent_markdown.html
+    error_snippet: fluent_text.html
+    validators: fluent_text
+    output_validators: fluent_core_translated_output
+    form_attrs:
+      class: form-control
+
 # Field = Relationship Type.
 - preset_name: canada_dataset_related_relationship
   values:

--- a/ckanext/canada/schemas/presets.yaml
+++ b/ckanext/canada/schemas/presets.yaml
@@ -2691,6 +2691,41 @@ presets:
       size: 60
       class: form-control
 
+# Field = Description English.
+# {An English description given to the resource}
+# Field = Description French.
+# {A French description given to the resource}
+- preset_name: canada_resource_description
+  values:
+    field_name: description_translated
+    label:
+      en: Description
+      fr: Description
+    fluent_form_label:
+      en:
+        en: "Description (English)"
+        fr: "Description (anglais)"
+      fr:
+        en: "Description (French)"
+        fr: "Description (français)"
+    fluent_help_text:
+      en:
+        en: "An account of the resource, in English. A description may include but is not limited to: an abstract, a table of contents, or a free-text account of the resource."
+        fr: "Description du ressource, en anglais. La description peut comprendre un résumé, une table des matières ou un texte libre."
+      fr:
+        en: "An account of the resource, in French. A description may include but is not limited to: an abstract, a table of contents, or a free-text account of the resource."
+        fr: "Description du ressource, en anglais. La description peut comprendre un résumé, une table des matières ou un texte libre."
+    required: false
+    form_panel: descriptive
+    # copied from fluent_markdown preset
+    form_snippet: fluent_markdown.html
+    display_snippet: fluent_markdown.html
+    error_snippet: fluent_text.html
+    validators: fluent_text
+    output_validators: fluent_core_translated_output
+    form_attrs:
+      class: form-control
+
 # Field = Relationship Type.
 - preset_name: canada_dataset_related_relationship
   values:

--- a/ckanext/canada/templates/package/resource_read.html
+++ b/ckanext/canada/templates/package/resource_read.html
@@ -63,6 +63,15 @@
     {% endif %}
   {% endif %}
   {% block resource_read_title %}{{ super() }}{% endblock %}
+  {% set description, machine_translated = h.get_translated_t(res, 'description') %}
+  {% if description %}
+    <div>
+      {% if machine_translated %}
+        <i class="fa fa-language text-muted mrgn-bttm-md float-right" title="{{ _('This third party metadata element has been translated using an automated translation tool.  To report any discrepancies please contact {support}').format(support=h.support_email_address()) }}"></i>
+      {% endif %}
+      {{- h.render_markdown(description) -}}
+    </div>
+  {% endif %}
   {% block resource_read_url %}
     <p class="mrgn-bttm-lg">&nbsp;</p>
   {% endblock %}

--- a/ckanext/canada/templates/scheming/package/snippets/resource_form.html
+++ b/ckanext/canada/templates/scheming/package/snippets/resource_form.html
@@ -36,6 +36,18 @@
         {%- endfor -%}
       </div>
     </details>
+    <details id="descriptive-resource-meta-group" class="acc-group-des" open="open">
+      <summary class="wb-toggle tgl-tab" data-bs-toggle='{"parent": ".accordion", "group": ".acc-group-des"}'>
+        {{ _("Semantic Metadata Fields for Resources") }}
+      </summary>
+      <div class="tgl-panel">
+        {%- for field in schema.resource_fields -%}
+          {%- if field.form_panel == 'descriptive' -%}
+            {%- snippet 'scheming/snippets/form_field.html', field=field, data=data, errors=errors, entity_type='dataset', object_type=dataset_type -%}
+          {%- endif -%}
+        {%- endfor -%}
+      </div>
+    </details>
     <details id="related-resource-meta-group" class="acc-group-rel" open="open">
       <summary class="wb-toggle tgl-tab" data-bs-toggle='{"parent": ".accordion", "group": ".acc-group-rel"}'>
         {{ _("Metadata Fields for Resource Relationships") }}


### PR DESCRIPTION
feat(schema): resource descriptions;

- Bringing in core field into our schema and webforms.

We do allow markdown descriptions for Resource Views, but would be nice to not require users to add random views and have to render view tabs etc. I think overall this will give users a better way to describe their data. Currently I think everyone actually puts their resource descriptions in the package notes, which is not useful for the Resource index pages.